### PR TITLE
fix(runner): guard against empty expanders list

### DIFF
--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -72,7 +72,11 @@ def run_crawl(
         PartialExpansionError:      Incomplete child list. Caller should
                                     download without persisting to DB.
         ChildListUnavailableError:  Fatal for this run.
+        ValueError:                 Plugin has no expanders configured.
     """
+    if not plugin.expanders:
+        raise ValueError("CrawlPlugin has no expanders configured")
+
     expansion = plugin.expanders[0].expand(top_ref, client)
     parent_record = expansion.record
 

--- a/tests/plugins/test_protocol.py
+++ b/tests/plugins/test_protocol.py
@@ -254,6 +254,18 @@ class TestRunnerHappyPath:
 
 
 class TestRunnerErrors:
+    def test_empty_expanders_raises_value_error(
+        self,
+        top_ref: Ref,
+        http_client: HttpClient,
+        config: RunConfig,
+        child_refs: list[Ref],
+    ) -> None:
+        p = _MockPlugin(child_refs)
+        p.expanders = []
+        with pytest.raises(ValueError, match="no expanders configured"):
+            run_crawl(top_ref, p, http_client, config)
+
     def test_expansion_not_ready_propagates(
         self,
         top_ref: Ref,


### PR DESCRIPTION
## Summary

- Adds an explicit `ValueError` guard in `run_crawl()` before accessing `expanders[0]`
- Without this, a misconfigured plugin raises a bare `IndexError` with no context
- Adds a unit test: `test_empty_expanders_raises_value_error` in `TestRunnerErrors`

Closes #15

## Test plan

- [x] `pytest tests/plugins/test_protocol.py` — 18/18 pass (new test included)
- [x] Full suite — 56/56 pass
- [x] All pre-push hooks pass

## Note

Issue #15 mentions the error message can include the plugin name once `CrawlPlugin.name` is added (issue #16). The message is intentionally generic for now.