### PR TITLE
fix(networking): add HttpClient session lifecycle

### DIFF
--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -39,6 +39,16 @@ class HttpClient:
             self._session.headers["User-Agent"] = self._config.user_agent
         self._session.headers.update(self._config.default_headers)
 
+    def close(self) -> None:
+        """Close the underlying session and release pooled connections."""
+        self._session.close()
+
+    def __enter__(self) -> HttpClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
     def _get_timeout(
         self, override: float | None
     ) -> float | tuple[float, float] | None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,6 +46,25 @@ def _mock_response(
     return response
 
 
+def test_close_closes_session(config):
+    with patch("requests.Session.close") as mock_close:
+        client = HttpClient(config)
+        client.close()
+    mock_close.assert_called_once()
+
+
+def test_context_manager_closes_session_on_exit(config):
+    with patch("requests.Session.close") as mock_close:
+        with HttpClient(config):
+            pass
+    mock_close.assert_called_once()
+
+
+def test_context_manager_returns_client_instance(config):
+    with HttpClient(config) as client:
+        assert isinstance(client, HttpClient)
+
+
 def test_init_sets_user_agent_and_default_headers(client):
     assert client._session.headers["User-Agent"] == "TestAgent/1.0"
     assert client._session.headers["X-Test"] == "yes"


### PR DESCRIPTION
## Summary

- Adds `close()`, `__enter__`, and `__exit__` to `HttpClient`
- The underlying `requests.Session` connection pool is now properly released on exit
- Callers should use `HttpClient` as a context manager to guarantee cleanup:
  ```python
  with HttpClient(config) as client:
      result = run_crawl(ref, plugin, client, run_config)
  ```

Closes #21

## Test plan

- [x] `test_close_closes_session` — `close()` delegates to session
- [x] `test_context_manager_closes_session_on_exit` — `__exit__` calls `close()`
- [x] `test_context_manager_returns_client_instance` — `__enter__` returns `self`
- [x] Full suite — 59/59 pass
- [x] All pre-push hooks (including pyright) pass