### PR TITLE
feat(plugins): add name property to CrawlPlugin protocol

### DIFF
--- a/src/ladon/plugins/protocol.py
+++ b/src/ladon/plugins/protocol.py
@@ -69,10 +69,15 @@ class Sink(Protocol):
 class CrawlPlugin(Protocol):
     """Bundle of all adapters for one crawl domain.
 
-    ``source`` produces top-level refs. ``expanders`` is an ordered list
-    of expansion steps (one per tree level above the leaves). ``sink``
-    consumes the leaf refs produced by the last expander.
+    ``name`` is a short identifier used in log lines and error messages
+    (e.g. ``"christies_online"``, ``"sothebys"``). ``source`` produces
+    top-level refs. ``expanders`` is an ordered list of expansion steps
+    (one per tree level above the leaves). ``sink`` consumes the leaf
+    refs produced by the last expander.
     """
+
+    @property
+    def name(self) -> str: ...
 
     @property
     def source(self) -> Source: ...

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -75,7 +75,9 @@ def run_crawl(
         ValueError:                 Plugin has no expanders configured.
     """
     if not plugin.expanders:
-        raise ValueError("CrawlPlugin has no expanders configured")
+        raise ValueError(
+            f"CrawlPlugin '{plugin.name}' has no expanders configured"
+        )
 
     expansion = plugin.expanders[0].expand(top_ref, client)
     parent_record = expansion.record

--- a/tests/plugins/test_protocol.py
+++ b/tests/plugins/test_protocol.py
@@ -99,6 +99,10 @@ class _MockPlugin:
         self.expanders: list[object] = [_MockExpander(child_refs)]
         self.sink: object = _MockSink()
 
+    @property
+    def name(self) -> str:
+        return "mock_plugin"
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -151,6 +155,9 @@ class TestProtocolStructure:
 
     def test_crawl_plugin_satisfied(self, plugin: _MockPlugin) -> None:
         assert isinstance(plugin, CrawlPlugin)
+
+    def test_crawl_plugin_name(self, plugin: _MockPlugin) -> None:
+        assert plugin.name == "mock_plugin"
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +270,9 @@ class TestRunnerErrors:
     ) -> None:
         p = _MockPlugin(child_refs)
         p.expanders = []
-        with pytest.raises(ValueError, match="no expanders configured"):
+        with pytest.raises(
+            ValueError, match="mock_plugin.*no expanders configured"
+        ):
             run_crawl(top_ref, p, http_client, config)
 
     def test_expansion_not_ready_propagates(


### PR DESCRIPTION
## Summary

- Adds required `name: str` property to the `CrawlPlugin` protocol
- Used as a short identifier in log lines and error messages (e.g. `"sothebys"`, `"christies_online"`)
- The empty-expanders `ValueError` from PR #23 now includes the plugin name:
  `"CrawlPlugin 'X' has no expanders configured"`
- `_MockPlugin` in tests updated to implement `name = "mock_plugin"`

Closes #16

## Note

This was intentionally deferred until now — adding a required property to a `Protocol` after downstream plugin repos exist is a breaking change. No house plugin repos exist yet, so migration cost is zero.

## Test plan

- [x] `test_crawl_plugin_name` — `plugin.name` returns expected value
- [x] `test_empty_expanders_raises_value_error` — error message now includes plugin name
- [x] Full suite — 60/60 pass
- [x] All pre-push hooks pass