### PR TITLE
fix(runner): isolate on_leaf callback exceptions

### DIFF
--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -101,7 +101,11 @@ def run_crawl(
         leaves_parsed += 1
 
         if on_leaf is not None:
-            on_leaf(leaf_record, parent_record)
+            try:
+                on_leaf(leaf_record, parent_record)
+            except Exception as exc:
+                leaves_failed += 1
+                errors.append(f"ref[{i}] on_leaf callback failed: {exc}")
 
     return RunResult(
         record=parent_record,

--- a/tests/plugins/test_protocol.py
+++ b/tests/plugins/test_protocol.py
@@ -398,3 +398,51 @@ class TestRunnerErrors:
         assert on_leaf.call_count == 1
         assert result.leaves_parsed == 1
         assert result.leaves_failed == 1
+
+    def test_on_leaf_exception_is_non_fatal(
+        self,
+        top_ref: Ref,
+        http_client: HttpClient,
+        config: RunConfig,
+        child_refs: list[Ref],
+    ) -> None:
+        """on_leaf failure must not abort the run — remaining leaves continue."""
+
+        def _failing_on_leaf(leaf: object, parent: object) -> None:
+            raise RuntimeError("DB write failed")
+
+        p = _MockPlugin(child_refs)
+        result = run_crawl(
+            top_ref, p, http_client, config, on_leaf=_failing_on_leaf
+        )
+        # All 3 leaves were consumed by the sink; all 3 on_leaf calls failed
+        assert result.leaves_parsed == 3
+        assert result.leaves_failed == 3
+        assert len(result.errors) == 3
+        assert all("on_leaf callback failed" in e for e in result.errors)
+
+    def test_on_leaf_exception_every_other_leaf(
+        self,
+        top_ref: Ref,
+        http_client: HttpClient,
+        config: RunConfig,
+        child_refs: list[Ref],
+    ) -> None:
+        """Alternating on_leaf failure: parsed count stays correct."""
+        call_count = 0
+
+        def _alternating_on_leaf(leaf: object, parent: object) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0:
+                raise RuntimeError("intermittent failure")
+
+        p = _MockPlugin(child_refs)
+        result = run_crawl(
+            top_ref, p, http_client, config, on_leaf=_alternating_on_leaf
+        )
+        # 3 leaves: calls 1, 3 succeed; call 2 fails
+        assert result.leaves_parsed == 3
+        assert result.leaves_failed == 1
+        assert len(result.errors) == 1
+        assert "on_leaf callback failed" in result.errors[0]


### PR DESCRIPTION
## Summary

- Wraps the `on_leaf` call in `try/except` so a DB write failure (or any other callback exception) does not abort the run
- Failed callbacks increment `leaves_failed` and append to `errors` with message `"ref[i] on_leaf callback failed: <exc>"`
- The run continues to the next leaf

Closes #19

## Test plan

- [x] `test_on_leaf_exception_is_non_fatal` — all 3 `on_leaf` calls fail; run completes with `leaves_parsed=3, leaves_failed=3`
- [x] `test_on_leaf_exception_every_other_leaf` — alternating failure; `leaves_parsed=3, leaves_failed=1`
- [x] Full suite — 62/62 pass
- [x] All pre-push hooks pass