### PR TITLE
feat(runner): add structured logging to run_crawl

### DIFF
--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -12,12 +12,15 @@ itself has no DB dependency.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Callable
 
 from ladon.networking.client import HttpClient
 from ladon.plugins.errors import LeafUnavailableError
 from ladon.plugins.protocol import CrawlPlugin
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -79,6 +82,11 @@ def run_crawl(
             f"CrawlPlugin '{plugin.name}' has no expanders configured"
         )
 
+    logger.info(
+        "run_crawl started",
+        extra={"plugin": plugin.name, "ref": str(top_ref)},
+    )
+
     expansion = plugin.expanders[0].expand(top_ref, client)
     parent_record = expansion.record
 
@@ -96,6 +104,14 @@ def run_crawl(
         except LeafUnavailableError as exc:
             leaves_failed += 1
             errors.append(f"ref[{i}]: {exc}")
+            logger.warning(
+                "leaf unavailable",
+                extra={
+                    "plugin": plugin.name,
+                    "ref_index": i,
+                    "error": str(exc),
+                },
+            )
             continue
 
         leaves_parsed += 1
@@ -106,6 +122,23 @@ def run_crawl(
             except Exception as exc:
                 leaves_failed += 1
                 errors.append(f"ref[{i}] on_leaf callback failed: {exc}")
+                logger.warning(
+                    "on_leaf callback failed",
+                    extra={
+                        "plugin": plugin.name,
+                        "ref_index": i,
+                        "error": str(exc),
+                    },
+                )
+
+    logger.info(
+        "run_crawl finished",
+        extra={
+            "plugin": plugin.name,
+            "leaves_parsed": leaves_parsed,
+            "leaves_failed": leaves_failed,
+        },
+    )
 
     return RunResult(
         record=parent_record,

--- a/tests/plugins/test_protocol.py
+++ b/tests/plugins/test_protocol.py
@@ -446,3 +446,113 @@ class TestRunnerErrors:
         assert result.leaves_failed == 1
         assert len(result.errors) == 1
         assert "on_leaf callback failed" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Runner — logging
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerLogging:
+    def test_start_and_finish_logged(
+        self,
+        top_ref: Ref,
+        plugin: _MockPlugin,
+        http_client: HttpClient,
+        config: RunConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="ladon.runner"):
+            run_crawl(top_ref, plugin, http_client, config)
+
+        messages = [r.message for r in caplog.records]
+        assert any("run_crawl started" in m for m in messages)
+        assert any("run_crawl finished" in m for m in messages)
+
+    def test_start_record_has_plugin_and_ref(
+        self,
+        top_ref: Ref,
+        plugin: _MockPlugin,
+        http_client: HttpClient,
+        config: RunConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="ladon.runner"):
+            run_crawl(top_ref, plugin, http_client, config)
+
+        start = next(r for r in caplog.records if "started" in r.message)
+        assert start.plugin == "mock_plugin"  # type: ignore[attr-defined]
+        assert start.ref == str(top_ref)  # type: ignore[attr-defined]
+
+    def test_finish_record_has_counts(
+        self,
+        top_ref: Ref,
+        plugin: _MockPlugin,
+        http_client: HttpClient,
+        config: RunConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="ladon.runner"):
+            run_crawl(top_ref, plugin, http_client, config)
+
+        finish = next(r for r in caplog.records if "finished" in r.message)
+        assert finish.leaves_parsed == 3  # type: ignore[attr-defined]
+        assert finish.leaves_failed == 0  # type: ignore[attr-defined]
+
+    def test_leaf_unavailable_emits_warning(
+        self,
+        top_ref: Ref,
+        http_client: HttpClient,
+        config: RunConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+
+        refs = [Ref(url="https://demo.example.com/leaf/1")]
+
+        class _FailSink:
+            def consume(self, ref: object, client: HttpClient) -> object:
+                raise LeafUnavailableError("gone")
+
+        p = _MockPlugin(refs)
+        p.sink = _FailSink()
+
+        with caplog.at_level(logging.WARNING, logger="ladon.runner"):
+            run_crawl(top_ref, p, http_client, config)
+
+        warn = next(
+            r for r in caplog.records if "leaf unavailable" in r.message
+        )
+        assert warn.levelno == logging.WARNING
+        assert warn.plugin == "mock_plugin"  # type: ignore[attr-defined]
+        assert warn.ref_index == 0  # type: ignore[attr-defined]
+
+    def test_on_leaf_failure_emits_warning(
+        self,
+        top_ref: Ref,
+        plugin: _MockPlugin,
+        http_client: HttpClient,
+        config: RunConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+
+        def _bad_on_leaf(leaf: object, parent: object) -> None:
+            raise RuntimeError("db down")
+
+        with caplog.at_level(logging.WARNING, logger="ladon.runner"):
+            run_crawl(
+                top_ref, plugin, http_client, config, on_leaf=_bad_on_leaf
+            )
+
+        warnings = [
+            r for r in caplog.records if "on_leaf callback failed" in r.message
+        ]
+        assert len(warnings) == 3
+        assert all(w.plugin == "mock_plugin" for w in warnings)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Wires `logging.getLogger(__name__)` into `run_crawl()` with four log points:

| Event | Level | `extra=` fields |
|---|---|---|
| Run started | INFO | `plugin`, `ref` |
| Leaf unavailable | WARNING | `plugin`, `ref_index`, `error` |
| `on_leaf` callback failed | WARNING | `plugin`, `ref_index`, `error` |
| Run finished | INFO | `plugin`, `leaves_parsed`, `leaves_failed` |

All calls use `extra=` for machine-parseable fields, compatible with OpenTelemetry/Loki pipelines. No new runtime dependencies.

Closes #18

## Test plan

- [x] `test_start_and_finish_logged` — both INFO records emitted
- [x] `test_start_record_has_plugin_and_ref` — `extra` fields present on start record
- [x] `test_finish_record_has_counts` — counts on finish record
- [x] `test_leaf_unavailable_emits_warning` — WARNING on `LeafUnavailableError`
- [x] `test_on_leaf_failure_emits_warning` — WARNING on callback exception
- [x] Full suite — 67/67 pass
- [x] All pre-push hooks pass