### PR TITLE
feat(networking): per-domain rate limiting / politeness delay (#20)

### DIFF
--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -7,8 +7,9 @@ robots enforcement are applied by the concrete implementation.
 
 from __future__ import annotations
 
-from time import sleep
+from time import monotonic, sleep
 from typing import Any, Callable, Mapping, TypeVar
+from urllib.parse import urlparse
 
 import requests
 
@@ -35,6 +36,7 @@ class HttpClient:
         """
         self._config = config
         self._session = requests.Session()
+        self._last_request_time: dict[str, float] = {}
         if self._config.user_agent:
             self._session.headers["User-Agent"] = self._config.user_agent
         self._session.headers.update(self._config.default_headers)
@@ -88,6 +90,29 @@ class HttpClient:
         if backoff_base <= 0:
             return
         sleep(backoff_base * (2 ** max(0, attempt - 1)))
+
+    def _enforce_rate_limit(self, url: str) -> None:
+        """Enforce per-host politeness delay before issuing a request.
+
+        If ``min_request_interval_seconds`` is set, sleeps for however long
+        remains since the last request to the same host, then records the
+        current time as the new last-request timestamp for that host.
+
+        No-op when ``min_request_interval_seconds`` is zero (the default).
+        """
+        interval = self._config.min_request_interval_seconds
+        if interval <= 0:
+            return
+        host = urlparse(url).netloc
+        if not host:
+            return  # malformed URL — skip rather than poisoning the empty-key slot
+        last = self._last_request_time.get(host)
+        if last is not None:
+            elapsed = monotonic() - last
+            remaining = interval - elapsed
+            if remaining > 0:
+                sleep(remaining)
+        self._last_request_time[host] = monotonic()
 
     def _build_meta(
         self,
@@ -166,6 +191,7 @@ class HttpClient:
         value_builder: Callable[[requests.Response], ResponseValue],
     ) -> Result[ResponseValue, Exception]:
         """Execute request with retries and normalized metadata."""
+        self._enforce_rate_limit(url)
         attempts = 0
         last_error: requests.exceptions.RequestException | None = None
         for _ in range(self._max_attempts()):

--- a/src/ladon/networking/config.py
+++ b/src/ladon/networking/config.py
@@ -28,12 +28,15 @@ class HttpClientConfig:
     read_timeout_seconds: float | None = None
     backoff_base_seconds: float = 0.0
     timeout_seconds: float | None = None
+    min_request_interval_seconds: float = 0.0
 
     def __post_init__(self) -> None:
         if self.retries < 0:
             raise ValueError("retries must be >= 0")
         if self.backoff_base_seconds < 0:
             raise ValueError("backoff_base_seconds must be >= 0")
+        if self.min_request_interval_seconds < 0:
+            raise ValueError("min_request_interval_seconds must be >= 0")
 
         has_connect_timeout = self.connect_timeout_seconds is not None
         has_read_timeout = self.read_timeout_seconds is not None

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,0 +1,225 @@
+# pyright: reportUnknownParameterType=false, reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false, reportMissingParameterType=false
+# pyright: reportUnknownArgumentType=false
+"""Tests for per-domain rate limiting in HttpClient.
+
+Verifies that ``HttpClientConfig.min_request_interval_seconds`` is respected:
+consecutive requests to the same host sleep for the remaining interval, while
+requests to different hosts are not blocked by each other.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ladon.networking.client import HttpClient
+from ladon.networking.config import HttpClientConfig
+
+
+def _mock_response(
+    *,
+    content: bytes = b"ok",
+    status: int = 200,
+    url: str = "http://example.com",
+):
+    resp = Mock()
+    resp.content = content
+    resp.status_code = status
+    resp.url = url
+    resp.reason = "OK"
+    resp.elapsed.total_seconds.return_value = 0.05
+    resp.headers = {}
+    return resp
+
+
+@pytest.fixture
+def rate_limited_client():
+    config = HttpClientConfig(
+        timeout_seconds=5.0,
+        min_request_interval_seconds=1.0,
+    )
+    return HttpClient(config)
+
+
+# ============================================================
+# Config validation
+# ============================================================
+
+
+class TestRateLimitConfig:
+    def test_default_is_zero(self):
+        config = HttpClientConfig()
+        assert config.min_request_interval_seconds == 0.0
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="min_request_interval_seconds"):
+            HttpClientConfig(min_request_interval_seconds=-0.1)
+
+    def test_zero_is_valid(self):
+        config = HttpClientConfig(min_request_interval_seconds=0.0)
+        assert config.min_request_interval_seconds == 0.0
+
+    def test_positive_is_valid(self):
+        config = HttpClientConfig(min_request_interval_seconds=2.5)
+        assert config.min_request_interval_seconds == 2.5
+
+
+# ============================================================
+# Rate limit enforcement
+# ============================================================
+
+
+class TestRateLimitEnforcement:
+    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking.client.monotonic")
+    @patch("requests.Session.get")
+    def test_first_request_no_sleep(
+        self, mock_get, mock_mono, mock_sleep, rate_limited_client
+    ):
+        """The very first request to a host must not sleep."""
+        mock_get.return_value = _mock_response()
+        mock_mono.return_value = 100.0
+
+        rate_limited_client.get("http://example.com/page")
+
+        mock_sleep.assert_not_called()
+
+    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking.client.monotonic")
+    @patch("requests.Session.get")
+    def test_second_request_sleeps_remaining_interval(
+        self, mock_get, mock_mono, mock_sleep, rate_limited_client
+    ):
+        """Second request within the interval sleeps for the remaining time."""
+        mock_get.return_value = _mock_response()
+        # Request 1: one monotonic call (record timestamp at t=100).
+        # Request 2: two monotonic calls (read elapsed at 100.3, record at 100.3).
+        # Remaining = 1.0 - (100.3 - 100.0) = 0.7s → must sleep(0.7).
+        mock_mono.side_effect = [100.0, 100.3, 100.3]
+
+        rate_limited_client.get("http://example.com/a")
+        rate_limited_client.get("http://example.com/b")
+
+        mock_sleep.assert_called_once()
+        sleep_arg = mock_sleep.call_args[0][0]
+        assert sleep_arg == pytest.approx(0.7, abs=1e-9)
+
+    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking.client.monotonic")
+    @patch("requests.Session.get")
+    def test_request_after_full_interval_no_sleep(
+        self, mock_get, mock_mono, mock_sleep, rate_limited_client
+    ):
+        """No sleep when elapsed time already exceeds the interval."""
+        mock_get.return_value = _mock_response()
+        # Request 1: record at t=100. Request 2: read elapsed at 101.5 (>1.0s), record.
+        mock_mono.side_effect = [100.0, 101.5, 101.5]
+
+        rate_limited_client.get("http://example.com/a")
+        rate_limited_client.get("http://example.com/b")
+
+        mock_sleep.assert_not_called()
+
+    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking.client.monotonic")
+    @patch("requests.Session.get")
+    def test_different_hosts_not_rate_limited_against_each_other(
+        self, mock_get, mock_mono, mock_sleep, rate_limited_client
+    ):
+        """Requests to different hosts must not block each other."""
+        mock_get.return_value = _mock_response()
+        # Both hosts have their own fresh timestamp slot.
+        mock_mono.return_value = 100.0
+
+        rate_limited_client.get("http://alpha.example.com/page")
+        rate_limited_client.get("http://beta.example.com/page")
+
+        mock_sleep.assert_not_called()
+
+    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking.client.monotonic")
+    @patch("requests.Session.get")
+    def test_rate_limit_is_per_host_not_per_url_path(
+        self, mock_get, mock_mono, mock_sleep, rate_limited_client
+    ):
+        """Different paths on the same host share the rate limit slot."""
+        mock_get.return_value = _mock_response()
+        # Request 1: record at t=100 (1 call).
+        # Request 2: read elapsed at t=100.2 → 0.2s elapsed, sleep 0.8s (2 calls).
+        mock_mono.side_effect = [100.0, 100.2, 100.2]
+
+        rate_limited_client.get("http://example.com/lots/1")
+        rate_limited_client.get("http://example.com/lots/2")
+
+        mock_sleep.assert_called_once()
+        sleep_arg = mock_sleep.call_args[0][0]
+        assert sleep_arg == pytest.approx(0.8, abs=1e-9)
+
+    @patch("ladon.networking.client.sleep")
+    @patch("requests.Session.get")
+    def test_zero_interval_never_sleeps(self, mock_get, mock_sleep):
+        """With default interval (0.0), sleep must never be called."""
+        config = HttpClientConfig(timeout_seconds=5.0)
+        client = HttpClient(config)
+        mock_get.return_value = _mock_response()
+
+        client.get("http://example.com/a")
+        client.get("http://example.com/b")
+        client.get("http://example.com/c")
+
+        mock_sleep.assert_not_called()
+
+    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking.client.monotonic")
+    @patch("requests.Session.get")
+    def test_rate_limit_applies_to_consecutive_requests(
+        self, mock_get, mock_mono, mock_sleep, rate_limited_client
+    ):
+        """Consecutive requests to the same host trigger the rate limit."""
+        mock_get.return_value = _mock_response()
+        # Request 1: record at t=100 (1 call).
+        # Request 2: read at t=100.1 (elapsed=0.1), record at t=100.1 (2 calls).
+        mock_mono.side_effect = [100.0, 100.1, 100.1]
+
+        rate_limited_client.get("http://example.com/a")
+        rate_limited_client.get("http://example.com/b")
+
+        assert mock_sleep.call_count == 1
+
+    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking.client.monotonic")
+    @patch("requests.Session.get")
+    @patch("requests.Session.head")
+    @patch("requests.Session.post")
+    def test_rate_limit_applies_to_all_methods(
+        self,
+        mock_post,
+        mock_head,
+        mock_get,
+        mock_mono,
+        mock_sleep,
+        rate_limited_client,
+    ):
+        """Rate limiting is enforced for get, head, post, and download."""
+        mock_response = _mock_response()
+        mock_get.return_value = mock_response
+        mock_head.return_value = mock_response
+        mock_post.return_value = mock_response
+        # 4 requests, each 0.1s apart → 3 sleeps of 0.9s each.
+        # Calls per request: request 1 = 1 monotonic, requests 2-4 = 2 each → 7 total.
+        mock_mono.side_effect = [
+            100.0,  # get: record
+            100.1,
+            100.1,  # head: read + record (elapsed=0.1, sleep=0.9)
+            100.2,
+            100.2,  # post: read + record (elapsed=0.1, sleep=0.9)
+            100.3,
+            100.3,  # download: read + record (elapsed=0.1, sleep=0.9)
+        ]
+
+        rate_limited_client.get("http://example.com/a")
+        rate_limited_client.head("http://example.com/b")
+        rate_limited_client.post("http://example.com/c")
+        rate_limited_client.download("http://example.com/d")
+
+        assert mock_sleep.call_count == 3


### PR DESCRIPTION
## Summary

- Add `min_request_interval_seconds: float = 0.0` to `HttpClientConfig` — default 0 preserves existing behaviour
- Add `HttpClient._enforce_rate_limit(url)` called at the start of every `_request()` invocation
- Per-host tracking via `_last_request_time: dict[str, float]`; host extracted with `urllib.parse.urlparse`
- If elapsed time since last request to same host is less than the interval, sleeps for the remainder
- Requests to different hosts are fully independent (no cross-host blocking)
- Retries within one `_request()` call do not re-trigger the rate limit

## Test plan

- [x] `tests/test_rate_limiting.py` — 11 new tests
  - Config validation (default, negative rejected, zero ok, positive ok)
  - First request to host: no sleep
  - Second request within interval: sleeps correct remaining duration
  - Second request after interval elapsed: no sleep
  - Different hosts: no cross-blocking
  - Same host, different paths: share the rate limit slot
  - Zero interval: sleep never called (3 consecutive requests)
  - All methods go through `_request()` and inherit rate limiting
- [x] Full suite: 114 passed
- [x] Pre-push hooks green (black, isort, ruff, pyright, gitlint)

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)