### PR TITLE
fix(runner): isolate intermediate expander errors per branch (#29)

### DIFF
--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -19,7 +19,12 @@ from dataclasses import dataclass
 from typing import Callable
 
 from ladon.networking.client import HttpClient
-from ladon.plugins.errors import LeafUnavailableError
+from ladon.plugins.errors import (
+    ChildListUnavailableError,
+    ExpansionNotReadyError,
+    LeafUnavailableError,
+    PartialExpansionError,
+)
 from ladon.plugins.protocol import CrawlPlugin
 
 logger = logging.getLogger(__name__)
@@ -41,7 +46,14 @@ class RunConfig:
 
 @dataclass(frozen=True)
 class RunResult:
-    """Outcome of a single run_crawl() call."""
+    """Outcome of a single run_crawl() call.
+
+    ``errors`` accumulates both expander branch failures (Phase 1, format
+    ``"expander branch '...': ..."`` ) and leaf-level failures (Phase 3,
+    format ``"ref[N]: ..."`` ).  A result with ``leaves_failed == 0`` may
+    still contain branch errors — always inspect ``errors`` for a complete
+    picture of what went wrong.
+    """
 
     record: object
     leaves_parsed: int
@@ -71,12 +83,17 @@ def run_crawl(
         RunResult with counts and any per-leaf error messages.
 
     Raises:
-        ExpansionNotReadyError:     Top-level ref is not yet ready.
+        ExpansionNotReadyError:     Raised from any expander. The ref (or
+                                    an intermediate ref) is not yet ready.
                                     Caller should record the event and
-                                    move on.
-        PartialExpansionError:      Incomplete child list. Caller should
-                                    download without persisting to DB.
-        ChildListUnavailableError:  Fatal for this run.
+                                    move on; retry on the next scheduled run.
+        PartialExpansionError:      Raised only from the first expander.
+                                    From non-first expanders the failing
+                                    branch is isolated and recorded in
+                                    RunResult.errors instead.
+        ChildListUnavailableError:  Raised only from the first expander.
+                                    Same isolation rule applies to non-first
+                                    expanders as for PartialExpansionError.
         ValueError:                 Plugin has no expanders configured.
     """
     if not plugin.expanders:
@@ -89,6 +106,8 @@ def run_crawl(
         extra={"plugin": plugin.name, "ref": str(top_ref)},
     )
 
+    errors: list[str] = []
+
     # Phase 1 — traverse all expanders in order.
     #
     # The first expander handles top_ref and yields the top-level record
@@ -97,6 +116,11 @@ def run_crawl(
     # (child_ref, parent_record) pairs so each leaf knows its direct parent.
     #
     # Single-expander behaviour is identical to the previous implementation.
+    #
+    # For non-first expanders, exceptions are isolated per branch:
+    #   - ExpansionNotReadyError  → re-raised (run is globally premature)
+    #   - PartialExpansionError   → branch skipped, error accumulated
+    #   - ChildListUnavailableError → branch skipped, error accumulated
     first_expansion = plugin.expanders[0].expand(top_ref, client)
     top_record: object = first_expansion.record
     pairs: list[tuple[object, object]] = [
@@ -107,7 +131,22 @@ def run_crawl(
     for expander in plugin.expanders[1:]:
         next_pairs: list[tuple[object, object]] = []
         for ref, _ in pairs:
-            expansion = expander.expand(ref, client)
+            try:
+                expansion = expander.expand(ref, client)
+            except ExpansionNotReadyError:
+                raise  # run is globally premature — abort
+            except (PartialExpansionError, ChildListUnavailableError) as exc:
+                errors.append(f"expander branch '{ref}': {exc}")
+                logger.warning(
+                    "expander branch failed",
+                    extra={
+                        "plugin": plugin.name,
+                        "ref": str(ref),
+                        "error": str(exc),
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                continue
             for child_ref in expansion.child_refs:
                 next_pairs.append((child_ref, expansion.record))
         pairs = next_pairs
@@ -119,7 +158,6 @@ def run_crawl(
     # Phase 3 — sink consumes each leaf ref.
     leaves_parsed = 0
     leaves_failed = 0
-    errors: list[str] = []
 
     for i, (leaf_ref, parent_record) in enumerate(pairs):
         try:

--- a/tests/plugins/test_protocol.py
+++ b/tests/plugins/test_protocol.py
@@ -533,6 +533,38 @@ class TestRunnerLogging:
         assert warn.plugin == "mock_plugin"  # type: ignore[attr-defined]
         assert warn.ref_index == 0  # type: ignore[attr-defined]
 
+    def test_expander_branch_failure_emits_warning(
+        self,
+        top_ref: Ref,
+        http_client: HttpClient,
+        config: RunConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+
+        section_a = Ref(url="https://demo.example.com/section/a")
+
+        class _FirstExpander:
+            def expand(self, ref: object, client: HttpClient) -> Expansion:
+                return Expansion(record=_make_record(), child_refs=[section_a])
+
+        class _FailingExpander:
+            def expand(self, ref: object, client: HttpClient) -> Expansion:
+                raise ChildListUnavailableError("API down")
+
+        p = _MockPlugin([])
+        p.expanders = [_FirstExpander(), _FailingExpander()]
+
+        with caplog.at_level(logging.WARNING, logger="ladon.runner"):
+            run_crawl(top_ref, p, http_client, config)
+
+        warn = next(
+            r for r in caplog.records if "expander branch failed" in r.message
+        )
+        assert warn.levelno == logging.WARNING
+        assert warn.plugin == "mock_plugin"  # type: ignore[attr-defined]
+        assert warn.error_type == "ChildListUnavailableError"  # type: ignore[attr-defined]
+
     def test_on_leaf_failure_emits_warning(
         self,
         top_ref: Ref,
@@ -664,17 +696,16 @@ class TestMultiExpander:
         result = run_crawl(top_ref, two_expander_plugin, http_client, cfg)
         assert result.leaves_parsed == 2
 
-    def test_intermediate_expander_error_propagates(
+    def test_intermediate_expansion_not_ready_propagates(
         self,
         top_ref: Ref,
         http_client: HttpClient,
         config: RunConfig,
     ) -> None:
-        """An exception from a non-first expander propagates and aborts the run.
+        """ExpansionNotReadyError from a non-first expander aborts the run.
 
-        See issue #29 — this currently discards leaf refs already collected
-        from other branches. Behaviour is documented here so any future change
-        to per-branch isolation is explicit.
+        The whole run is globally premature — the caller should skip this
+        top_ref entirely and retry on the next scheduled run.
         """
 
         class _FirstExpander:
@@ -684,14 +715,119 @@ class TestMultiExpander:
                     child_refs=[Ref(url="https://demo.example.com/section/a")],
                 )
 
-        class _FailingSecondExpander:
+        class _NotReadySecondExpander:
             def expand(self, ref: object, client: HttpClient) -> Expansion:
-                raise PartialExpansionError("section unavailable")
+                raise ExpansionNotReadyError("section not live yet")
 
         p = _MockPlugin([])
-        p.expanders = [_FirstExpander(), _FailingSecondExpander()]
-        with pytest.raises(PartialExpansionError):
+        p.expanders = [_FirstExpander(), _NotReadySecondExpander()]
+        with pytest.raises(ExpansionNotReadyError):
             run_crawl(top_ref, p, http_client, config)
+
+    def test_intermediate_partial_expansion_is_isolated(
+        self,
+        top_ref: Ref,
+        http_client: HttpClient,
+        config: RunConfig,
+    ) -> None:
+        """PartialExpansionError from a non-first expander is isolated.
+
+        The failing branch is skipped and recorded in errors; other branches
+        and the overall run continue normally. Closes #29.
+        """
+        section_a = Ref(url="https://demo.example.com/section/a")
+        section_b = Ref(url="https://demo.example.com/section/b")
+        item_1 = Ref(url="https://demo.example.com/item/1")
+
+        class _FirstExpander:
+            def expand(self, ref: object, client: HttpClient) -> Expansion:
+                return Expansion(
+                    record=_make_record(),
+                    child_refs=[section_a, section_b],
+                )
+
+        class _SectionExpander:
+            def expand(self, ref: object, client: HttpClient) -> Expansion:
+                r = ref if isinstance(ref, Ref) else Ref(url="")
+                if r.url.endswith("/a"):
+                    raise PartialExpansionError("section_a unavailable")
+                return Expansion(record=_make_record(), child_refs=[item_1])
+
+        p = _MockPlugin([])
+        p.expanders = [_FirstExpander(), _SectionExpander()]
+        result = run_crawl(top_ref, p, http_client, config)
+
+        assert result.leaves_parsed == 1
+        assert result.leaves_failed == 0
+        assert len(result.errors) == 1
+        assert "section_a" in result.errors[0]
+
+    def test_intermediate_child_list_unavailable_is_isolated(
+        self,
+        top_ref: Ref,
+        http_client: HttpClient,
+        config: RunConfig,
+    ) -> None:
+        """ChildListUnavailableError from a non-first expander is isolated.
+
+        The failing branch is skipped and recorded in errors; other branches
+        continue. Closes #29.
+        """
+        section_a = Ref(url="https://demo.example.com/section/a")
+        section_b = Ref(url="https://demo.example.com/section/b")
+        item_1 = Ref(url="https://demo.example.com/item/1")
+
+        class _FirstExpander:
+            def expand(self, ref: object, client: HttpClient) -> Expansion:
+                return Expansion(
+                    record=_make_record(),
+                    child_refs=[section_a, section_b],
+                )
+
+        class _SectionExpander:
+            def expand(self, ref: object, client: HttpClient) -> Expansion:
+                r = ref if isinstance(ref, Ref) else Ref(url="")
+                if r.url.endswith("/b"):
+                    raise ChildListUnavailableError("API down")
+                return Expansion(record=_make_record(), child_refs=[item_1])
+
+        p = _MockPlugin([])
+        p.expanders = [_FirstExpander(), _SectionExpander()]
+        result = run_crawl(top_ref, p, http_client, config)
+
+        assert result.leaves_parsed == 1
+        assert result.leaves_failed == 0
+        assert len(result.errors) == 1
+        assert "section/b" in result.errors[0]
+
+    def test_all_branches_fail_returns_empty_result(
+        self,
+        top_ref: Ref,
+        http_client: HttpClient,
+        config: RunConfig,
+    ) -> None:
+        """If every branch of a non-first expander fails, result has no leaves."""
+        section_a = Ref(url="https://demo.example.com/section/a")
+        section_b = Ref(url="https://demo.example.com/section/b")
+
+        class _FirstExpander:
+            def expand(self, ref: object, client: HttpClient) -> Expansion:
+                return Expansion(
+                    record=_make_record(),
+                    child_refs=[section_a, section_b],
+                )
+
+        class _AlwaysFailExpander:
+            def expand(self, ref: object, client: HttpClient) -> Expansion:
+                raise ChildListUnavailableError("API down")
+
+        p = _MockPlugin([])
+        p.expanders = [_FirstExpander(), _AlwaysFailExpander()]
+        result = run_crawl(top_ref, p, http_client, config)
+
+        assert result.leaves_parsed == 0
+        assert result.leaves_failed == 0
+        assert len(result.errors) == 2  # one per failed branch
 
     def test_zero_leaves_when_first_expander_returns_empty(
         self,


### PR DESCRIPTION
## Summary

Fixes the data-loss bug where a `PartialExpansionError` or `ChildListUnavailableError` from a non-first expander would abort the entire run, silently discarding leaf refs already collected from sibling branches.

**New per-branch isolation logic** in the multi-expander traversal loop:

| Exception | Before | After |
|---|---|---|
| `ExpansionNotReadyError` | propagated (abort) | **unchanged** — run is globally premature |
| `PartialExpansionError` | propagated (abort) | **isolated** — branch skipped, error accumulated in `RunResult.errors` |
| `ChildListUnavailableError` | propagated (abort) | **isolated** — same as above |

A structured `"expander branch failed"` WARNING is logged for each isolated failure with `plugin`, `ref`, `error`, and `error_type` fields.

First-expander exceptions are unchanged — they propagate as before.

## Tests

- `test_intermediate_expander_error_propagates` split into:
  - `test_intermediate_expansion_not_ready_propagates` — `ExpansionNotReadyError` still raises
  - `test_intermediate_partial_expansion_is_isolated` — `PartialExpansionError` now isolated, good branch still yields leaves
- `test_intermediate_child_list_unavailable_is_isolated` — new
- `test_all_branches_fail_returns_empty_result` — all branches fail → empty `RunResult` with 2 errors, no exception
- `test_expander_branch_failure_emits_warning` — log record verified

119 tests passing. Pre-push hooks green.

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)