### PR TITLE
refactor(runner): remove dead RunConfig fields skip_assets and output_dir

### DIFF
--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -34,14 +34,10 @@ logger = logging.getLogger(__name__)
 class RunConfig:
     """Configuration for a single runner invocation.
 
-    ``leaf_limit`` caps the number of leaves parsed; 0 means no limit.
-    ``skip_assets`` suppresses asset downloads (useful for fast canary
-    runs). ``output_dir`` must be set when assets are enabled.
+    ``leaf_limit`` caps the number of leaves processed; 0 means no limit.
     """
 
     leaf_limit: int = 0
-    skip_assets: bool = False
-    output_dir: str | None = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

- Removes `skip_assets: bool = False` and `output_dir: str | None = None` from `RunConfig`
- Neither field is read anywhere in the runner or passed to any plugin — a plugin author who sets `skip_assets=True` gets no benefit and no error (silent contract violation)
- `RunConfig` docstring updated to remove references to the removed fields
- Storage configuration will be reintroduced via ADR-004 (Storage injected at plugin construction) once the design is settled

## Test plan

- [ ] All 119 existing tests pass (no `RunConfig` test constructs the removed fields)
- [ ] `pyright --strict` clean
- [ ] `ruff` + `isort` clean

Refs: staff+ review 2026-03-15, plan item A1 (`hesperides: 01-Projects/Development/ladon_p1_fixes_plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)