### PR TITLE
fix(networking): enforce default timeout_seconds=30.0 in HttpClientConfig

### DIFF
--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -53,7 +53,7 @@ class HttpClient:
 
     def _get_timeout(
         self, override: float | None
-    ) -> float | tuple[float, float] | None:
+    ) -> float | tuple[float, float]:
         """Resolve timeout preference."""
         if override is not None:
             if override <= 0:

--- a/src/ladon/networking/config.py
+++ b/src/ladon/networking/config.py
@@ -27,7 +27,7 @@ class HttpClientConfig:
     connect_timeout_seconds: float | None = None
     read_timeout_seconds: float | None = None
     backoff_base_seconds: float = 0.0
-    timeout_seconds: float | None = None
+    timeout_seconds: float = 30.0
     min_request_interval_seconds: float = 0.0
 
     def __post_init__(self) -> None:
@@ -45,8 +45,8 @@ class HttpClientConfig:
                 "connect_timeout_seconds and read_timeout_seconds "
                 "must be set together"
             )
-        if self.timeout_seconds is not None and self.timeout_seconds <= 0:
-            raise ValueError("timeout_seconds must be > 0 when provided")
+        if self.timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be > 0")
         if (
             self.connect_timeout_seconds is not None
             and self.connect_timeout_seconds <= 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -124,7 +124,6 @@ def test_get_rejects_non_positive_timeout_override(client):
 @patch("requests.Session.get")
 def test_get_uses_connect_read_timeout_tuple(mock_get):
     config = HttpClientConfig(
-        timeout_seconds=None,
         connect_timeout_seconds=1.0,
         read_timeout_seconds=3.0,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ def test_config_defaults_are_stable():
     assert config.connect_timeout_seconds is None
     assert config.read_timeout_seconds is None
     assert config.backoff_base_seconds == 0.0
-    assert config.timeout_seconds is None
+    assert config.timeout_seconds == 30.0
 
 
 def test_config_default_headers_are_independent():


### PR DESCRIPTION
## Summary

- `timeout_seconds` defaulted to `None`, which passed `timeout=None` to `requests` — indefinite hangs for unattended nightly crawls
- Default changed to `30.0` seconds
- `__post_init__` validation simplified (None guard removed — value is always `float`)
- `test_config_defaults_are_stable`: assertion updated to `30.0`
- `test_get_uses_connect_read_timeout_tuple`: `timeout_seconds=None` override removed; connect/read pair still takes priority in `_get_timeout`, test behaviour unchanged

Per-request overrides via `connect_timeout_seconds` / `read_timeout_seconds` remain optional and continue to take priority over `timeout_seconds` when both are set.

## Test plan

- [ ] All 119 tests pass
- [ ] `pyright --strict` clean
- [ ] `ruff` + `isort` clean

Refs: staff+ review 2026-03-15, plan item A3 (`hesperides: 01-Projects/Development/ladon_p1_fixes_plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)