### PR TITLE
fix(ci): remove --no-build flag from mkdocs gh-deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,12 +30,6 @@ jobs:
       - name: Build docs (strict)
         run: mkdocs build --strict
 
-      - name: Upload built site
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
-        with:
-          name: docs-site
-          path: site/
-
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
@@ -57,16 +51,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[docs]"
 
-      - name: Download built site
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
-        with:
-          name: docs-site
-          path: site/
-
       - name: Configure git identity
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force --no-build
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary

- `mkdocs gh-deploy` does not support `--no-build` — the flag was incorrectly suggested during review and caused the deploy job to fail with exit code 2
- Removes the artifact upload/download roundtrip (no longer needed without `--no-build`)
- The `deploy` job now runs `mkdocs gh-deploy --force` directly, which builds and deploys in one step
- The `build` job still runs `mkdocs build --strict` first; the `deploy` job is gated on it via `needs: build`

## Root cause

`--no-build` does not exist in mkdocs. Verified against the error from run [23321504151](https://github.com/MoonyFringers/ladon/actions/runs/23321504151):
```
Error: No such option: --no-build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)