### PR TITLE
docs(cla): add CLA, ADR-010, and contribution guidelines update

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,121 @@
+# Ladon Individual Contributor License Agreement
+
+*Based on the Apache Software Foundation Individual Contributor License Agreement v2.1.*
+
+Thank you for your interest in contributing to Ladon ("the Project"), maintained by
+Alessio Pascucci ("the Maintainer"). This Contributor License Agreement ("CLA")
+clarifies the terms under which you, the person named below, may make contributions
+to the Project.
+
+This license is for your protection as a contributor as well as the protection of
+the Maintainer. It does not change your rights to use your own contributions for
+any other purpose.
+
+Please read this document carefully before signing.
+
+---
+
+## 1. Definitions
+
+**"You"** means the individual who is making a contribution to the Project.
+
+**"Contribution"** means any original work of authorship, including any modifications
+or additions to an existing work, that you intentionally submit to the Project for
+inclusion in, or documentation of, any of the products managed or maintained by the
+Project. "Submit" means any form of electronic, verbal, or written communication sent
+to the Maintainer or its representatives, including but not limited to communication
+on electronic mailing lists, source code control systems, and issue tracking systems.
+
+---
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this CLA, you hereby grant to the Maintainer
+and to recipients of software distributed by the Maintainer a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce,
+prepare derivative works of, publicly display, publicly perform, sublicense, and
+distribute your Contributions and such derivative works under any terms the Maintainer
+chooses, including terms that differ from the license under which the Project is
+currently distributed.
+
+**You retain copyright over your Contributions.** This CLA grants a license; it does
+not transfer ownership.
+
+---
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this CLA, you hereby grant to the Maintainer
+and to recipients of software distributed by the Maintainer a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated below) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise transfer
+the Project, where such license applies only to those patent claims licensable by you
+that are necessarily infringed by your Contribution(s) alone or by combination of your
+Contribution(s) with the Project to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against you or any other entity (including
+a cross-claim or counterclaim in a lawsuit) alleging that your Contribution or the
+Project constitutes direct or contributory patent infringement, then any patent
+licenses granted to that entity under this CLA shall terminate as of the date such
+litigation is filed.
+
+---
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses. If your employer has rights
+   to intellectual property that you create (including your Contributions), you
+   represent that you have received permission to make Contributions on behalf of that
+   employer, or that your employer has waived such rights for your Contributions to
+   the Project.
+
+2. Each of your Contributions is your original creation (see Section 5 for submissions
+   of work that is not your original creation).
+
+3. Your Contributions do not include any third-party code, patents, or other
+   intellectual property that you do not have the right to license in the manner
+   described in this CLA.
+
+4. You are not aware of any pending or threatened claims, suits, actions, or
+   proceedings related to your Contribution.
+
+---
+
+## 5. Third-Party Contributions
+
+Should you wish to submit work that is not your original creation, you may submit it
+to the Project separately from any Contribution, identifying the complete details of
+its source and of any license or other restriction (including, but not limited to,
+related patents, trademarks, and license agreements) of which you are personally aware,
+and conspicuously marking the work as "Submitted on behalf of a third-party:
+[named here]".
+
+---
+
+## 6. No Warranty
+
+Your Contributions are provided "as is". You provide no warranties of any kind, either
+express or implied, including without limitation any warranties of title,
+non-infringement, merchantability, or fitness for a particular purpose.
+
+---
+
+## 7. Notification of Changes
+
+You agree to notify the Maintainer of any facts or circumstances of which you become
+aware that would make any of your representations in Section 4 inaccurate in any
+respect.
+
+---
+
+## How to Sign
+
+Signing is automatic via GitHub. When you open a pull request, the **cla-assistant**
+bot will post a comment with a link. Click it, authenticate with your GitHub account,
+and the CLA is signed. The record is permanent and applies to all future contributions
+from that account — you will not be asked again.
+
+If you have questions about this CLA, open an issue or email the maintainer before
+submitting your contribution.

--- a/CONTRIBUTION_GUIDELINES.md
+++ b/CONTRIBUTION_GUIDELINES.md
@@ -155,6 +155,23 @@ below.
 2. **Respond to feedback**: Address comments and suggestions
    from reviewers promptly.
 
+## Contributor License Agreement (CLA)
+
+Before your first pull request can be merged, you must sign the
+[Contributor License Agreement](CLA.md).
+
+**Why?** Ladon is AGPL-licensed with a commercial dual-licensing path. The CLA grants
+the maintainer the right to sublicense your contribution under commercial terms while
+you retain full copyright over your work.
+
+**How?** When you open your first PR, the **cla-assistant** bot will post a comment
+with a one-click signing link. Authenticate with your GitHub account — the whole
+process takes about 30 seconds. Once signed, the CLA covers all your future
+contributions automatically.
+
+Read the full [CLA text](CLA.md) before signing if you want to understand exactly
+what you are agreeing to.
+
 ## Code of Conduct
 
 Please adhere to the [Code of Conduct](CODE_OF_CONDUCT.md) to
@@ -171,9 +188,9 @@ ensure a welcoming environment for all contributors.
 
 ## Licensing
 
-By contributing to this project, you agree that your
-contributions will be licensed under the project's
-[LICENSE](LICENSE).
+Ladon is licensed under [AGPL-3.0-or-later](LICENSE). By signing the
+[CLA](CLA.md), you retain copyright over your contributions and grant the
+maintainer the additional rights described therein.
 
 Thank you for contributing! Together, we can make this project
 even better. If you have any questions, feel free to reach out.

--- a/docs/decisions/adr-010-contributor-license-agreement.md
+++ b/docs/decisions/adr-010-contributor-license-agreement.md
@@ -1,0 +1,133 @@
+---
+status: accepted
+date: 2026-03-26
+decision-makers:
+  - Ladon maintainers
+---
+
+# ADR-010 — Contributor License Agreement
+
+## Context and Problem Statement
+
+Ladon is licensed under AGPL-3.0-or-later. The commercial roadmap (documented in the
+internal hesperides vault) includes a dual-licensing phase in which companies that
+cannot comply with AGPL may purchase a commercial license. This requires the maintainer
+to hold sublicensing rights over **all code in the repository** — including contributions
+from external contributors.
+
+Under copyright law, a contributor retains full copyright over their contribution by
+default. The AGPL grant allows redistribution under AGPL terms only. Without an
+additional agreement, the maintainer cannot legally offer that contribution under a
+commercial license. A single contributor who has not signed a CLA becomes a permanent
+blocker on any commercial license that covers their code.
+
+The question is: **what agreement must a contributor sign, and when, in order to preserve
+the maintainer's ability to dual-license the codebase?**
+
+## Decision Drivers
+
+- Dual licensing (Phase 1 of the commercial roadmap) requires the maintainer to
+  sublicense contributions beyond the AGPL terms.
+- The CLA must be in place **before** the first external PR is accepted — retroactive
+  CLAs are not legally reliable.
+- Contributor friction must be minimal — a CLA process that takes more than 60 seconds
+  kills community participation.
+- The CLA must be automatable — manual tracking does not scale past the first few
+  contributors.
+- The CLA text must be standard and recognisable — an unusual CLA raises red flags for
+  contributors and their employers.
+
+## Considered Options
+
+- **Option A: No CLA — rely on AGPL grant only.**
+  Simplest for contributors. Permanently forecloses dual licensing. Incompatible with
+  the commercial roadmap.
+
+- **Option B: Full copyright assignment.**
+  Contributor assigns copyright entirely to the maintainer. Legally cleanest for dual
+  licensing but high friction — many contributors (especially those employed by companies)
+  cannot assign copyright without employer approval. Overreaches for this project's needs.
+
+- **Option C: Apache-style Individual CLA (sublicense grant only).**
+  Contributor retains copyright, grants the maintainer a perpetual, irrevocable,
+  worldwide, royalty-free license to sublicense their contribution under any terms.
+  Industry standard (used by Apache, Google, Canonical). Balances legal completeness
+  with contributor fairness. Chosen.
+
+- **Option D: Developer Certificate of Origin (DCO) only.**
+  Contributor certifies they have the right to submit the code under the project's
+  license (via `Signed-off-by` in commits). Does not grant sublicensing rights.
+  Insufficient for dual licensing.
+
+## Decision Outcome
+
+**Option C: Apache-style Individual CLA enforced via `cla-assistant`.**
+
+Contributors sign a CLA that grants the maintainer sublicensing rights while retaining
+their copyright. The CLA is enforced automatically on every PR via the `cla-assistant`
+GitHub App — no manual tracking required.
+
+### Why `cla-assistant`?
+
+- Free for open-source projects.
+- GitHub OAuth sign-in — no account creation, no PDF, 30-second workflow.
+- Permanent record stored at `cla-assistant.io`.
+- Repeat contributors are automatically cleared on subsequent PRs.
+- Widely recognised by contributors; not a surprise.
+
+### What the CLA covers
+
+The CLA in `CLA.md` grants the maintainer:
+
+1. **Copyright license** — perpetual, worldwide, royalty-free, irrevocable right to
+   reproduce, prepare derivative works, publicly display, sublicense, and distribute
+   the contribution and its derivatives under any terms.
+2. **Patent license** — perpetual, worldwide, royalty-free, irrevocable (except for
+   litigation) patent license for any patents the contributor holds that are necessarily
+   infringed by their contribution.
+3. **Representation** — the contributor confirms they have the legal right to grant
+   the above licenses (either as an individual or as authorised by their employer).
+
+The contributor **retains copyright**. The CLA is a license grant, not an assignment.
+
+### Entity
+
+The CLA is granted to **Alessio Pascucci (GitHub: feed3r)**, current sole maintainer,
+acting as the legal holder of the dual-licensing right. If a legal entity is formed in
+the future, the CLA text must be updated to name that entity, and `cla-assistant`
+reconfigured accordingly. Contributions signed before that point remain valid — the
+individual grant covers future sublicensing.
+
+### Corporate contributors
+
+The Individual CLA covers contributors acting in a personal capacity. Contributors who
+wish to contribute on behalf of an employer (where the employer owns the copyright to
+work created in employment) should contact the maintainer directly before opening a PR.
+A Corporate CLA can be issued at that point. This is deferred: the likely early
+contributor population is individual developers.
+
+## Consequences
+
+**Good:**
+
+- Dual licensing (Phase 1 commercial roadmap) is legally possible for all merged code.
+- Contributor workflow is low-friction and automated.
+- The CLA text is standard and recognisable — no red flags for contributors or their
+  employers.
+- Permanent, auditable record of all signed CLAs.
+
+**Trade-offs:**
+
+- The CLA bot adds one step before a first-time contributor's PR can be merged.
+  This is unavoidable if dual licensing is a goal.
+- Contributors who object to CLAs on principle will not contribute. This is a known
+  cost of the dual-licensing model and is accepted.
+- The `cla-assistant.io` service is a third-party dependency for the signing record.
+  If the service shuts down, records should be exported and self-hosted. A backup
+  export should be taken annually.
+
+## Related
+
+- `CLA.md` — the full CLA text contributors sign
+- `CONTRIBUTION_GUIDELINES.md` — contributor-facing instructions including CLA step
+- Internal hesperides: `ladon_commercial_roadmap.md` — dual-licensing commercial plan

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -16,6 +16,7 @@ chosen over the alternatives.
 | [ADR-007](adr-007-circuit-breaker.md) | Per-Host Circuit Breaker | Accepted |
 | [ADR-008](adr-008-robots-txt.md) | robots.txt Enforcement | Accepted |
 | ADR-009 | Observability (metrics, structured logs) | Proposed — Phase 3 |
+| [ADR-010](adr-010-contributor-license-agreement.md) | Contributor License Agreement | Accepted |
 
 ## Format
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,3 +70,4 @@ nav:
     - ADR-004 SES Protocol Design: decisions/adr-004-ses-protocol-design.md
     - ADR-007 Circuit Breaker: decisions/adr-007-circuit-breaker.md
     - ADR-008 robots.txt: decisions/adr-008-robots-txt.md
+    - ADR-010 Contributor License Agreement: decisions/adr-010-contributor-license-agreement.md


### PR DESCRIPTION
## Summary

- **`CLA.md`**: Apache-style Individual CLA. Contributors retain copyright; they grant the maintainer a perpetual, sublicensable copyright and patent license. This is the legal prerequisite for the dual-licensing commercial roadmap (Phase 1).
- **`ADR-010`**: records the governance decision — why a CLA is required, the four options considered (no CLA, full assignment, Apache-style grant, DCO-only), and why `cla-assistant` with an Apache-style grant was chosen.
- **`CONTRIBUTION_GUIDELINES.md`**: new CLA section explaining the why and the 30-second signing workflow; stale Licensing section updated.
- **`docs/decisions/index.md` + `mkdocs.yml`**: ADR-010 wired into the index table and docs nav.

## What this does NOT include

CLA enforcement via `cla-assistant` requires configuring the GitHub App on the repository settings. That step is done after this PR is merged — the bot needs the `CLA.md` file to be on `main` before it can be pointed at it.

## Test plan

- [x] `mkdocs build --strict` passes with no warnings
- [x] ADR-010 renders in the Decisions section
- [x] All internal links in ADR-010 resolve (`CLA.md`, `CONTRIBUTION_GUIDELINES.md`, `ladon_commercial_roadmap.md` noted as internal)
- [ ] After merge: configure `cla-assistant` GitHub App pointing at `CLA.md` on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)