### PR TITLE
docs(adr-006): fix RunRecord snippet imports and document isinstance limitation

### DIFF
--- a/docs/decisions/adr-006-persistence-layer.md
+++ b/docs/decisions/adr-006-persistence-layer.md
@@ -119,6 +119,10 @@ domain-specific fields.
 ### The `RunRecord` dataclass
 
 ```python
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
 @dataclass
 class RunRecord:
     run_id: str
@@ -212,7 +216,10 @@ if isinstance(repository, RunAudit):
 
 The `isinstance(repository, RunAudit)` check uses Python structural subtyping
 at runtime — adapters implementing both protocols need not declare it
-explicitly.
+explicitly. Note: Python's runtime checkable protocol check verifies only
+that the required method *names* are present, not their signatures. A class
+with a mismatched `record_run` signature would pass `isinstance` at runtime
+but fail under a static type-checker (pyright, mypy).
 
 ### Why no `DatabaseBackend` abstraction
 


### PR DESCRIPTION
## Summary

- Add missing `from dataclasses import dataclass, field`, `from datetime import datetime`, and `from typing import Literal` imports to the `RunRecord` code snippet so it matches `record.py` and is copy-paste correct
- Document that `@runtime_checkable` `isinstance` checks only verify method *name* presence, not signatures — and that static type-checkers (pyright, mypy) catch the gap

## Test plan

- [ ] `mkdocs build --strict` passes
- [ ] Spot-check: `RunRecord` snippet imports match `src/ladon/persistence/record.py` exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)