### PR TITLE
chore: add py313 to black target-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ build-backend = "setuptools.build_meta"
 # ----------------------------------------
 [tool.black]
 line-length = 80
-target-version = ['py311', 'py312']
+target-version = ['py311', 'py312', 'py313']
 extend-exclude = '''
 # A regex preceded with ^/ will apply only to files and directories
 # in the root of the project.


### PR DESCRIPTION
Black's `target-version` listed `py311` and `py312` but was missing `py313`, even though the project supports Python 3.13 (classifier and `requires-python = ">=3.11"` both cover it). Aligns the formatter config with the declared support matrix.