### PR TITLE
chore(cla): write signatures to cla-signatures branch

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path-to-signatures: ".github/cla_signatures.json"
           path-to-document: "https://github.com/MoonyFringers/ladon/blob/main/CLA.md"
-          branch: "main"
+          branch: "cla-signatures"
           # Bots that should be exempted from the CLA requirement.
           allowlist: >
             dependabot[bot],


### PR DESCRIPTION
`main` is now a protected branch requiring PRs + status checks. The CLA bot cannot push `cla_signatures.json` directly to `main`.

Fix: point `branch` to the dedicated `cla-signatures` branch (already created from `main`, containing the existing signatures). The bot reads and writes from that branch exclusively — branch protection on `main` is unaffected.