### PR TITLE
feat(#93): AsyncSource, AsyncExpander, AsyncSink, AsyncCrawlPlugin protocols

### DIFF
--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -18,6 +18,10 @@ from .networking.types import Result
 from .persistence import NullRepository, Repository, RunAudit, RunRecord
 from .plugins import (
     AssetDownloadError,
+    AsyncCrawlPlugin,
+    AsyncExpander,
+    AsyncSink,
+    AsyncSource,
     ChildListUnavailableError,
     CrawlPlugin,
     Expander,
@@ -51,11 +55,16 @@ __all__ = [
     "run_crawl",
     "RunConfig",
     "RunResult",
-    # Plugin protocols
+    # Sync plugin protocols
     "CrawlPlugin",
     "Source",
     "Expander",
     "Sink",
+    # Async plugin protocols
+    "AsyncCrawlPlugin",
+    "AsyncSource",
+    "AsyncExpander",
+    "AsyncSink",
     # Plugin models
     "Ref",
     "Expansion",

--- a/src/ladon/plugins/__init__.py
+++ b/src/ladon/plugins/__init__.py
@@ -6,6 +6,12 @@ defined as typing.Protocol classes so that third-party implementations
 need not import from this package.
 """
 
+from .async_protocol import (
+    AsyncCrawlPlugin,
+    AsyncExpander,
+    AsyncSink,
+    AsyncSource,
+)
 from .errors import (
     AssetDownloadError,
     ChildListUnavailableError,
@@ -18,11 +24,16 @@ from .models import Expansion, Ref
 from .protocol import CrawlPlugin, Expander, Sink, Source
 
 __all__ = [
-    # Protocols
+    # Sync protocols
     "Source",
     "Expander",
     "Sink",
     "CrawlPlugin",
+    # Async protocols
+    "AsyncSource",
+    "AsyncExpander",
+    "AsyncSink",
+    "AsyncCrawlPlugin",
     # Models
     "Ref",
     "Expansion",

--- a/src/ladon/plugins/async_protocol.py
+++ b/src/ladon/plugins/async_protocol.py
@@ -1,3 +1,7 @@
+# AsyncHttpClient is forward-referenced under TYPE_CHECKING below; its module
+# (networking/async_client.py) does not exist yet, so pyright sees Unknown for
+# the import and all method parameters typed with it. Remove both suppressions
+# once async_client.py is created.
 # pyright: reportUnknownVariableType=false, reportUnknownParameterType=false
 """typing.Protocol definitions for async Ladon crawl plugins.
 

--- a/src/ladon/plugins/async_protocol.py
+++ b/src/ladon/plugins/async_protocol.py
@@ -1,0 +1,90 @@
+# pyright: reportUnknownVariableType=false, reportUnknownParameterType=false
+"""typing.Protocol definitions for async Ladon crawl plugins.
+
+Async adapters implement these protocols by structural subtyping — no
+inheritance from this module is required.
+
+All async adapters receive a configured AsyncHttpClient instance. They
+must not construct their own HTTP sessions or import ``httpx`` directly.
+
+The three-layer pipeline is:
+
+    AsyncSource  →  [AsyncExpander, ...]  →  AsyncSink
+
+``AsyncSource`` discovers top-level refs. Each ``AsyncExpander`` awaits
+a ref and returns an ``Expansion``. ``AsyncSink`` awaits a leaf ref and
+returns a final record. ``AsyncCrawlPlugin`` bundles all three.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from .models import Expansion
+
+if TYPE_CHECKING:
+    from ..networking.async_client import AsyncHttpClient
+
+
+@runtime_checkable
+class AsyncSource(Protocol):
+    """Discover top-level refs from an external source, asynchronously."""
+
+    async def discover(self, client: AsyncHttpClient) -> Sequence[object]:
+        """Return all discoverable top-level references."""
+        ...
+
+
+@runtime_checkable
+class AsyncExpander(Protocol):
+    """Expand one ref into a record plus child refs, asynchronously."""
+
+    async def expand(self, ref: object, client: AsyncHttpClient) -> Expansion:
+        """Fetch ref, return its record and the child refs to process next.
+
+        Raises:
+            ExpansionNotReadyError: ref is not yet ready to be expanded.
+            PartialExpansionError: child list is incomplete.
+            ChildListUnavailableError: child list could not be retrieved.
+        """
+        ...
+
+
+@runtime_checkable
+class AsyncSink(Protocol):
+    """Consume a leaf ref and return its final record, asynchronously."""
+
+    async def consume(self, ref: object, client: AsyncHttpClient) -> object:
+        """Fetch and parse one leaf ref, returning a complete record.
+
+        Context for the leaf flows through ``ref.raw`` — no parent-record
+        parameter is needed here.
+
+        Raises:
+            LeafUnavailableError: ref could not be fetched or parsed.
+        """
+        ...
+
+
+@runtime_checkable
+class AsyncCrawlPlugin(Protocol):
+    """Bundle of all async adapters for one crawl domain.
+
+    ``name`` is a short identifier used in log lines and error messages.
+    ``source`` discovers top-level refs. ``expanders`` is an ordered list
+    of async expansion steps. ``sink`` consumes the leaf refs produced by
+    the last expander.
+    """
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def source(self) -> AsyncSource: ...
+
+    @property
+    def expanders(self) -> Sequence[AsyncExpander]: ...
+
+    @property
+    def sink(self) -> AsyncSink: ...

--- a/tests/plugins/test_async_protocol.py
+++ b/tests/plugins/test_async_protocol.py
@@ -1,0 +1,193 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+# pyright: reportUnknownArgumentType=false, reportArgumentType=false
+# pyright: reportUnknownParameterType=false, reportMissingParameterType=false
+"""Structural conformance tests for async crawl plugin protocols.
+
+Uses plain Python classes with no inheritance from ladon.plugins.
+All isinstance checks are synchronous — pytest-asyncio is not required.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from ladon.plugins.async_protocol import (
+    AsyncCrawlPlugin,
+    AsyncExpander,
+    AsyncSink,
+    AsyncSource,
+)
+from ladon.plugins.models import Expansion, Ref
+
+# ---------------------------------------------------------------------------
+# Minimal mock implementations — satisfy each protocol by structure only
+# ---------------------------------------------------------------------------
+
+
+class _MockAsyncSource:
+    async def discover(self, client: object) -> Sequence[Ref]:
+        return [Ref(url="https://example.com/top/1")]
+
+
+class _MockAsyncExpander:
+    async def expand(self, ref: object, client: object) -> Expansion:
+        return Expansion(record=object(), child_refs=[])
+
+
+class _MockAsyncSink:
+    async def consume(self, ref: object, client: object) -> object:
+        return object()
+
+
+class _MockAsyncPlugin:
+    @property
+    def name(self) -> str:
+        return "mock_async_plugin"
+
+    @property
+    def source(self) -> _MockAsyncSource:
+        return _MockAsyncSource()
+
+    @property
+    def expanders(self) -> list[_MockAsyncExpander]:
+        return [_MockAsyncExpander()]
+
+    @property
+    def sink(self) -> _MockAsyncSink:
+        return _MockAsyncSink()
+
+
+# ---------------------------------------------------------------------------
+# Classes that are missing the required methods — must NOT satisfy protocols
+# ---------------------------------------------------------------------------
+
+
+class _NotASource:
+    """Has no 'discover' method."""
+
+
+class _SyncSource:
+    """Has 'discover' but it is synchronous — not a coroutine function."""
+
+    def discover(self, client: object) -> list[object]:
+        return []
+
+
+class _NotAnExpander:
+    """Has no 'expand' method."""
+
+
+class _NotASink:
+    """Has no 'consume' method."""
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance — positive cases
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncSourceProtocol:
+    def test_mock_satisfies_async_source(self) -> None:
+        assert isinstance(_MockAsyncSource(), AsyncSource)
+
+    def test_mock_async_plugin_source_satisfies_async_source(self) -> None:
+        plugin = _MockAsyncPlugin()
+        assert isinstance(plugin.source, AsyncSource)
+
+
+class TestAsyncExpanderProtocol:
+    def test_mock_satisfies_async_expander(self) -> None:
+        assert isinstance(_MockAsyncExpander(), AsyncExpander)
+
+    def test_mock_async_plugin_expander_satisfies_async_expander(self) -> None:
+        plugin = _MockAsyncPlugin()
+        assert isinstance(plugin.expanders[0], AsyncExpander)
+
+
+class TestAsyncSinkProtocol:
+    def test_mock_satisfies_async_sink(self) -> None:
+        assert isinstance(_MockAsyncSink(), AsyncSink)
+
+    def test_mock_async_plugin_sink_satisfies_async_sink(self) -> None:
+        plugin = _MockAsyncPlugin()
+        assert isinstance(plugin.sink, AsyncSink)
+
+
+class TestAsyncCrawlPluginProtocol:
+    def test_mock_satisfies_async_crawl_plugin(self) -> None:
+        assert isinstance(_MockAsyncPlugin(), AsyncCrawlPlugin)
+
+    def test_name_property(self) -> None:
+        plugin = _MockAsyncPlugin()
+        assert plugin.name == "mock_async_plugin"
+
+    def test_source_property_type(self) -> None:
+        plugin = _MockAsyncPlugin()
+        assert isinstance(plugin.source, AsyncSource)
+
+    def test_expanders_property_is_sequence(self) -> None:
+        plugin = _MockAsyncPlugin()
+        assert len(plugin.expanders) == 1
+
+    def test_sink_property_type(self) -> None:
+        plugin = _MockAsyncPlugin()
+        assert isinstance(plugin.sink, AsyncSink)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance — negative cases
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncSourceNegative:
+    def test_missing_discover_not_async_source(self) -> None:
+        assert not isinstance(_NotASource(), AsyncSource)
+
+    def test_sync_discover_not_async_source(self) -> None:
+        # runtime_checkable only checks method existence, not coroutine nature.
+        # _SyncSource HAS 'discover', so isinstance returns True at runtime.
+        # This is a known limitation of runtime_checkable Protocol checks.
+        # Pyright catches the distinction at type-check time.
+        assert isinstance(_SyncSource(), AsyncSource)
+
+
+class TestAsyncExpanderNegative:
+    def test_missing_expand_not_async_expander(self) -> None:
+        assert not isinstance(_NotAnExpander(), AsyncExpander)
+
+
+class TestAsyncSinkNegative:
+    def test_missing_consume_not_async_sink(self) -> None:
+        assert not isinstance(_NotASink(), AsyncSink)
+
+
+class TestAsyncCrawlPluginNegative:
+    def test_plain_object_not_async_crawl_plugin(self) -> None:
+        assert not isinstance(object(), AsyncCrawlPlugin)
+
+
+# ---------------------------------------------------------------------------
+# Top-level export reachability
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelExports:
+    def test_async_source_importable_from_ladon(self) -> None:
+        from ladon import AsyncSource as _AS
+
+        assert _AS is AsyncSource
+
+    def test_async_expander_importable_from_ladon(self) -> None:
+        from ladon import AsyncExpander as _AE
+
+        assert _AE is AsyncExpander
+
+    def test_async_sink_importable_from_ladon(self) -> None:
+        from ladon import AsyncSink as _ASink
+
+        assert _ASink is AsyncSink
+
+    def test_async_crawl_plugin_importable_from_ladon(self) -> None:
+        from ladon import AsyncCrawlPlugin as _ACP
+
+        assert _ACP is AsyncCrawlPlugin

--- a/tests/plugins/test_async_protocol.py
+++ b/tests/plugins/test_async_protocol.py
@@ -6,7 +6,7 @@ All isinstance checks are synchronous — pytest-asyncio is not required.
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from ladon.plugins.async_protocol import (
     AsyncCrawlPlugin,

--- a/tests/plugins/test_async_protocol.py
+++ b/tests/plugins/test_async_protocol.py
@@ -1,6 +1,3 @@
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
-# pyright: reportUnknownArgumentType=false, reportArgumentType=false
-# pyright: reportUnknownParameterType=false, reportMissingParameterType=false
 """Structural conformance tests for async crawl plugin protocols.
 
 Uses plain Python classes with no inheritance from ladon.plugins.
@@ -81,6 +78,38 @@ class _NotASink:
     """Has no 'consume' method."""
 
 
+class _PluginMissingExpanders:
+    """Has name/source/sink but no expanders property."""
+
+    @property
+    def name(self) -> str:
+        return "no_expanders"
+
+    @property
+    def source(self) -> _MockAsyncSource:
+        return _MockAsyncSource()
+
+    @property
+    def sink(self) -> _MockAsyncSink:
+        return _MockAsyncSink()
+
+
+class _PluginMissingSink:
+    """Has name/source/expanders but no sink property."""
+
+    @property
+    def name(self) -> str:
+        return "no_sink"
+
+    @property
+    def source(self) -> _MockAsyncSource:
+        return _MockAsyncSource()
+
+    @property
+    def expanders(self) -> list[_MockAsyncExpander]:
+        return [_MockAsyncExpander()]
+
+
 # ---------------------------------------------------------------------------
 # Protocol conformance — positive cases
 # ---------------------------------------------------------------------------
@@ -143,11 +172,11 @@ class TestAsyncSourceNegative:
     def test_missing_discover_not_async_source(self) -> None:
         assert not isinstance(_NotASource(), AsyncSource)
 
-    def test_sync_discover_not_async_source(self) -> None:
-        # runtime_checkable only checks method existence, not coroutine nature.
-        # _SyncSource HAS 'discover', so isinstance returns True at runtime.
-        # This is a known limitation of runtime_checkable Protocol checks.
-        # Pyright catches the distinction at type-check time.
+    def test_sync_discover_passes_isinstance_runtime_limitation(self) -> None:
+        # runtime_checkable only checks that the method name exists, not that
+        # it is a coroutine function. A plain sync def satisfies the check at
+        # runtime even though it is semantically wrong. Pyright catches this
+        # at type-check time; the runtime cannot.
         assert isinstance(_SyncSource(), AsyncSource)
 
 
@@ -164,6 +193,12 @@ class TestAsyncSinkNegative:
 class TestAsyncCrawlPluginNegative:
     def test_plain_object_not_async_crawl_plugin(self) -> None:
         assert not isinstance(object(), AsyncCrawlPlugin)
+
+    def test_missing_expanders_not_async_crawl_plugin(self) -> None:
+        assert not isinstance(_PluginMissingExpanders(), AsyncCrawlPlugin)
+
+    def test_missing_sink_not_async_crawl_plugin(self) -> None:
+        assert not isinstance(_PluginMissingSink(), AsyncCrawlPlugin)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds four `@runtime_checkable` Protocol classes in `src/ladon/plugins/async_protocol.py` mirroring the sync stack (`Source`, `Expander`, `Sink`, `CrawlPlugin`)
- `AsyncHttpClient` referenced via `TYPE_CHECKING` guard — avoids circular import with `networking/async_client.py` (added in #94); pyright suppression scoped to the protocol file with an explanatory comment for the forward-ref situation
- All four exported from `ladon.plugins` and `ladon` top-level package

## Test plan

- [x] 22 structural conformance tests in `tests/plugins/test_async_protocol.py` — all sync, no `pytest-asyncio` needed
- [x] Positive cases: each mock class satisfies its protocol via `isinstance()`
- [x] Negative cases: classes missing required methods/properties fail the protocol check (including partial `AsyncCrawlPlugin` — missing `expanders`, missing `sink`)
- [x] Documents `runtime_checkable` limitation: sync methods pass `isinstance` at runtime; pyright catches the distinction at type-check time
- [x] Top-level export reachability: `from ladon import AsyncSource` etc.
- [x] Full suite: 366 passed (344 pre-branch + 22 new)
- [x] Pyright strict: 0 errors
- [x] Ruff + black + isort: clean

Closes #93. Depends on: none. Blocks: #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)