### PR TITLE
docs: v0.2.0 release docs — README, CHANGELOG, doc site, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] — 2026-04-25
+
 ### Added
 
 - **Async crawling via `async_run_crawl()`** — asyncio-native counterpart to
@@ -20,6 +24,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   leaves continue); `ExpansionNotReadyError` remains globally fatal.
   `RunConfig` gains `async_concurrency: int = 10`; `AsyncHttpClient` and
   `async_run_crawl` are exported from the top-level `ladon` namespace.
+
+- **`AsyncHttpClient`** — full async HTTP client backed by `httpx`.  Mirrors
+  all policies of `HttpClient` (retries, exponential backoff, full-jitter,
+  429/503 Retry-After, circuit breaker, proxy rotation, HTTP auth,
+  `default_params`, `default_headers`).  `respect_robots_txt=True` raises
+  `NotImplementedError` at construction time (deferred to a later release).
+  Exported from `ladon.networking` and the top-level `ladon` namespace.
+
+- **Async plugin protocols** — `AsyncSource`, `AsyncExpander`, `AsyncSink`,
+  and `AsyncCrawlPlugin` structural protocols (PEP 544, all
+  `@runtime_checkable`).  All four are exported from `ladon.plugins` and the
+  top-level `ladon` namespace.  The sync protocol hierarchy is untouched.
 
 ---
 
@@ -102,6 +118,7 @@ First public release.
   current counters are correct but the model will be simplified
 - Python 3.11, 3.12, and 3.13 supported; 3.10 and below are not
 
-[Unreleased]: https://github.com/MoonyFringers/ladon/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/MoonyFringers/ladon/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/MoonyFringers/ladon/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/MoonyFringers/ladon/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/MoonyFringers/ladon/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -101,13 +101,55 @@ directly from Python — see
 [`ladon-hackernews` — Use as a library](https://github.com/MoonyFringers/ladon-hackernews#use-as-a-library)
 for a full example.
 
+## Async crawling
+
+`async_run_crawl()` is the asyncio-native counterpart to `run_crawl()`.
+Phase 1 (expander traversal) runs sequentially; Phase 3 issues leaf fetches
+concurrently behind `asyncio.Semaphore(config.async_concurrency)` (default 10):
+
+```python
+import asyncio
+from ladon import AsyncHttpClient, async_run_crawl
+from ladon.networking.config import HttpClientConfig
+from ladon.runner import RunConfig
+
+async def main() -> None:
+    config = HttpClientConfig(retries=2, timeout_seconds=10)
+    async with AsyncHttpClient(config) as client:
+        result = await async_run_crawl(
+            top_ref=my_ref,
+            plugin=my_async_plugin,
+            client=client,
+            config=RunConfig(async_concurrency=20),
+            on_leaf=my_async_persist,
+        )
+        print(f"consumed {result.leaves_consumed}, failed {result.leaves_failed}")
+
+asyncio.run(main())
+```
+
+`AsyncHttpClient` mirrors all policies of `HttpClient` (retries, backoff,
+Retry-After, circuit breaker, proxy rotation, auth) using `httpx` as the
+backend. Adapters implement `AsyncCrawlPlugin`, `AsyncSource`, `AsyncExpander`,
+and `AsyncSink` — the same structural-protocol pattern as the sync stack.
+
 ## Status
 
-`v0.0.1` — alpha. The SES protocol and HTTP layer are stable. One reference
-adapter (`ladon-hackernews`) is available as open source and tested against
-the real HN API.
+`v0.2.0` — async crawling milestone. `AsyncHttpClient`, `AsyncCrawlPlugin`,
+and `async_run_crawl()` are stable and fully tested. The sync API is unchanged.
 
-What is in v0.0.1:
+What is in v0.2.0:
+- **Async crawling** — `async_run_crawl()` + `AsyncHttpClient` (httpx backend)
+- **Async plugin protocols** — `AsyncSource`, `AsyncExpander`, `AsyncSink`, `AsyncCrawlPlugin`
+- `RunConfig.async_concurrency` — bounded leaf-fetch concurrency (default 10)
+
+What was in v0.1.0:
+- HTTP 429/503 Retry-After respect and full-jitter backoff
+- Static and rotating proxy support (`ProxyPool`, `RoundRobinProxyPool`)
+- HTTP authentication — Basic, Digest, any `requests.auth.AuthBase`
+- Default query parameters via `HttpClientConfig(default_params=...)`
+
+What was in v0.0.1:
 - SES protocol (Source / Expander / Sink) with structural typing
 - `run_crawl()` runner with leaf isolation and `RunResult` summary
 - `HttpClient` with retries, back-off, rate limiting, circuit breaker, robots.txt
@@ -115,10 +157,9 @@ What is in v0.0.1:
 - `Repository` and `RunAudit` persistence protocols with `NullRepository`
 - `ladon run` / `ladon info` CLI
 
-What is coming in v0.1.0 (in progress):
-- HTTP 429/503 Retry-After respect, full-jitter backoff, static and rotating proxy support ✓
-- HTTP authentication — Basic, Digest, OAuth client credentials (issue [#86](https://github.com/MoonyFringers/ladon/issues/86))
-- RunResult counter semantics redesign (issue [#62](https://github.com/MoonyFringers/ladon/issues/62))
+What is coming:
+- `ladon-mimir` — async Wikipedia adapter for LLM fine-tuning (issue [#96](https://github.com/MoonyFringers/ladon/issues/96))
+- Async robots.txt enforcement in `AsyncHttpClient`
 - Structured logging baseline (ADR-009)
 
 ## Contributing

--- a/docs/api/networking.md
+++ b/docs/api/networking.md
@@ -1,8 +1,8 @@
 # Networking API
 
-The networking layer provides a single `HttpClient` that all Ladon crawlers
-must use.  Centralising HTTP ensures consistent politeness, retry, and
-resilience policies across every plugin.
+The networking layer provides `HttpClient` (sync) and `AsyncHttpClient`
+(async) — both backed by the same `HttpClientConfig` and sharing the same
+politeness, retry, and resilience policies.
 
 ## HttpClientConfig
 
@@ -11,6 +11,20 @@ resilience policies across every plugin.
 ## HttpClient
 
 ::: ladon.networking.client.HttpClient
+
+## AsyncHttpClient
+
+`AsyncHttpClient` is the async counterpart to `HttpClient`.  It uses
+`httpx` as its backend and implements the same retry, backoff, circuit
+breaker, proxy rotation, and auth policies.  Use it with
+`async_run_crawl()` and `AsyncCrawlPlugin`.
+
+!!! note "`respect_robots_txt` is not yet supported"
+    Passing `respect_robots_txt=True` to `HttpClientConfig` raises
+    `NotImplementedError` at `AsyncHttpClient` construction time.
+    The default (`False`) is safe for all current use cases.
+
+::: ladon.networking.async_client.AsyncHttpClient
 
 ## Result type
 

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -3,11 +3,21 @@
 Plugins are the site-specific half of Ladon.  A plugin bundles a `Source`
 (discovers top-level refs), one or more `Expanders` (fan out through the
 URL tree), and a `Sink` (fetches each leaf and returns a record).  All
-three are structural protocols — no inheritance from Ladon is required.
+protocols are structural (PEP 544) — no inheritance from Ladon is required.
 
-## Protocols
+Ladon ships two parallel protocol hierarchies: sync and async.
+
+## Sync protocols
 
 ::: ladon.plugins.protocol
+
+## Async protocols
+
+The async protocols mirror the sync ones exactly but use `async def`
+methods and accept `AsyncHttpClient` instead of `HttpClient`.  Use them
+with `async_run_crawl()`.
+
+::: ladon.plugins.async_protocol
 
 ## Data models
 

--- a/docs/api/runner.md
+++ b/docs/api/runner.md
@@ -3,9 +3,17 @@
 The runner drives the crawl loop: it expands refs through the plugin's
 expander chain and passes each leaf to the sink.
 
+Ladon ships two runners: a synchronous `run_crawl()` and an async
+`async_run_crawl()`.  Both use the same `RunConfig` and return the same
+`RunResult`.
+
 ## run_crawl
 
 ::: ladon.runner.run_crawl
+
+## async_run_crawl
+
+::: ladon.async_runner.async_run_crawl
 
 ## RunConfig
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,16 +2,12 @@
 
 ## Installation
 
-Ladon is not yet published on PyPI — a release will follow once example
-adapters are available. Install from source:
-
 ```bash
-git clone https://github.com/moonyfringers/ladon.git
-cd ladon
-pip install -e .
+pip install ladon-crawl
 ```
 
-Ladon requires Python 3.12+.  The only runtime dependency is `requests`.
+Ladon requires Python 3.11+.  Runtime dependencies: `requests` (sync
+client) and `httpx` (async client).
 
 ## First request
 
@@ -123,8 +119,41 @@ the config is immutable after construction.
   `HttpClient` session — at most one fetch per origin (one per
   `scheme + hostname` pair).
 
+## Async crawling
+
+For high-throughput crawls use `async_run_crawl()` with `AsyncHttpClient`:
+
+```python
+import asyncio
+from ladon import AsyncHttpClient, async_run_crawl
+from ladon.networking.config import HttpClientConfig
+from ladon.runner import RunConfig
+
+config = HttpClientConfig(retries=2, timeout_seconds=10)
+
+async def main() -> None:
+    async with AsyncHttpClient(config) as client:
+        result = await async_run_crawl(
+            top_ref=my_ref,
+            plugin=my_async_plugin,
+            client=client,
+            config=RunConfig(async_concurrency=20),
+            on_leaf=my_async_persist,
+        )
+        print(f"consumed {result.leaves_consumed}, failed {result.leaves_failed}")
+
+asyncio.run(main())
+```
+
+Phase 1 (expander traversal) runs sequentially; Phase 3 (sink) issues leaf
+fetches concurrently behind `asyncio.Semaphore(async_concurrency)`.  Each
+slot covers the full `sink.consume()` + `on_leaf` pair so slow callbacks
+do not cause unbounded parallelism.
+
+`on_leaf` must be an `async def` function when used with `async_run_crawl`.
+
 ## Next steps
 
 - [Authoring Plugins](guides/authoring-plugins.md) — build a site adapter
-- [API Reference → Networking](api/networking.md) — `HttpClient` and config
-- [API Reference → Runner](api/runner.md) — `run_crawl` and result types
+- [API Reference → Networking](api/networking.md) — `HttpClient`, `AsyncHttpClient`, and config
+- [API Reference → Runner](api/runner.md) — `run_crawl`, `async_run_crawl`, and result types

--- a/docs/guides/authoring-plugins.md
+++ b/docs/guides/authoring-plugins.md
@@ -135,6 +135,60 @@ The CLI uses default `RunConfig` settings (no leaf limit, no `on_leaf`
 callback).  For production use write a Python script that calls `run_crawl`
 directly.
 
+## Async plugins
+
+For high-concurrency crawls implement `AsyncCrawlPlugin` and call
+`async_run_crawl()` instead.  The async protocols mirror the sync ones with
+`async def` methods and `AsyncHttpClient` as the client parameter.
+
+```python
+from ladon.plugins.async_protocol import AsyncCrawlPlugin, AsyncExpander, AsyncSink, AsyncSource
+from ladon.networking.async_client import AsyncHttpClient
+
+class AsyncAuctionPlugin:
+    def __init__(self) -> None:
+        self.name = "async_auction_example"
+        self.source = AsyncCatalogueSource()
+        self.expanders = [AsyncCategoryExpander(), AsyncAuctionExpander()]
+        self.sink = AsyncLotSink()
+
+
+class AsyncLotSink:
+    async def consume(self, ref: object, client: AsyncHttpClient) -> object:
+        result = await client.get(str(ref))
+        if not result.ok:
+            from ladon.plugins.errors import LeafUnavailableError
+            raise LeafUnavailableError(f"fetch failed: {result.error}")
+        return parse_lot(result.value)
+```
+
+Run it:
+
+```python
+import asyncio
+from ladon import AsyncHttpClient, async_run_crawl
+from ladon.networking.config import HttpClientConfig
+from ladon.runner import RunConfig
+
+async def main() -> None:
+    config = HttpClientConfig(retries=2, min_request_interval_seconds=0.5)
+    async with AsyncHttpClient(config) as client:
+        result = await async_run_crawl(
+            top_ref="https://example-auction.com/catalogue/2026",
+            plugin=AsyncAuctionPlugin(),
+            client=client,
+            config=RunConfig(leaf_limit=100, async_concurrency=20),
+            on_leaf=my_async_persist,
+        )
+        print(f"fetched {result.leaves_consumed}, failed {result.leaves_failed}")
+
+asyncio.run(main())
+```
+
+`async_run_crawl` accepts the same `RunConfig` as `run_crawl`.  The
+`async_concurrency` field controls how many leaf fetches run simultaneously
+(default 10).  The sync runner ignores it.
+
 ## Error taxonomy
 
 All errors are in `ladon.plugins.errors` and `ladon.networking.errors`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,8 @@ plumbing.
 | robots.txt | RFC 9309 enforcement with fail-open and Crawl-delay propagation |
 | Plugin protocol | Typed `Expander` / `Sink` / `CrawlPlugin` interface |
 | Result type | `Ok` / `Err` without exceptions crossing API boundaries |
+| Async crawling | `async_run_crawl()` with `asyncio.Semaphore` concurrency control |
+| Async client | `AsyncHttpClient` — full httpx-backed mirror of `HttpClient` |
 
 ## Quick start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ladon-crawl"
-version = "0.1.0"
+version = "0.2.0"
 description = "A structured, resumable web crawling framework for AI-ready datasets."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version to `0.2.0`
- Cut `[0.2.0]` CHANGELOG entry with full entries for `async_run_crawl`, `AsyncHttpClient`, and async protocols
- README: add async crawling section with code example; replace stale v0.0.1 Status section with cumulative v0.0.1/v0.1.0/v0.2.0 history
- `docs/index.md`: two new rows in feature table
- `docs/api/runner.md`: `async_run_crawl` reference block
- `docs/api/networking.md`: `AsyncHttpClient` reference + robots.txt note
- `docs/api/plugins.md`: async protocols section
- `docs/getting-started.md`: Python 3.11+, `pip install`, new async crawling section
- `docs/guides/authoring-plugins.md`: full async plugin authoring section with example

## Test plan

- [ ] Verify doc site renders correctly after merge (MkDocs build)
- [ ] Confirm CHANGELOG comparison links point to correct tags once v0.2.0 is tagged