### PR TITLE
build: add curl-cffi optional dependency group (issue #107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`cffi` optional dependency group** — `pip install ladon-crawl[cffi]` installs
+  `curl-cffi>=0.11,<1`, enabling the `CurlHttpClient` and `AsyncCurlHttpClient`
+  backends for Cloudflare-protected targets (issue #107).
+
+- **`CurlHttpClient` / `AsyncCurlHttpClient`** — sync and async HTTP clients
+  backed by curl-cffi.  Mirror all policies of `HttpClient` / `AsyncHttpClient`
+  (retries, exponential backoff, circuit breaker, proxy rotation, rate limiting)
+  but use TLS fingerprint impersonation (JA3/JA4) to bypass Cloudflare L1+L2
+  challenges without browser automation.  Both are exported from `ladon.networking`
+  and the top-level `ladon` namespace.
+
+- **`HttpClientConfig(backend=, impersonate=)`** — two new fields select the
+  HTTP backend without changing call sites.  `backend="curl-cffi"` (requires
+  `impersonate`) returns a `CurlHttpClient` / `AsyncCurlHttpClient` from the
+  factory helpers.  Default is `backend="requests"` (unchanged behaviour).
+
+- **`make_http_client()` / `make_async_http_client()`** — factory helpers that
+  instantiate the correct sync or async client based on `config.backend`.
+  Exported from `ladon.networking` and the top-level `ladon` namespace.
+
 ---
 
 ## [0.2.0] — 2026-04-25

--- a/README.md
+++ b/README.md
@@ -101,6 +101,40 @@ directly from Python — see
 [`ladon-hackernews` — Use as a library](https://github.com/MoonyFringers/ladon-hackernews#use-as-a-library)
 for a full example.
 
+## Cloudflare-protected targets
+
+Standard HTTP clients fail against Cloudflare because their TLS fingerprint
+is identifiable as non-browser traffic.  Ladon's optional curl-cffi backend
+impersonates a real browser's TLS `ClientHello` to bypass L1 and L2 challenges
+without a browser process.
+
+```bash
+pip install ladon-crawl[cffi]   # adds curl-cffi (binary wheel, ~10 MB)
+```
+
+```python
+from ladon.networking import make_http_client
+from ladon.networking.config import HttpClientConfig
+
+config = HttpClientConfig(
+    backend="curl-cffi",
+    impersonate="chrome136",
+    timeout_seconds=20.0,
+    retries=2,
+)
+with make_http_client(config) as client:
+    result = client.get("https://protected-target.example/")
+```
+
+`make_http_client()` and `make_async_http_client()` dispatch on
+`config.backend` — change one field to switch backends with no call-site
+changes.  All policies (retries, circuit breaker, proxy rotation, rate
+limiting) are identical to the standard backends.
+
+See the [Cloudflare bypass guide](docs/guides/cloudflare-bypass.md) for the
+full layer-by-layer breakdown, impersonate target list, and L3 (IP reputation)
+considerations.
+
 ## Async crawling
 
 `async_run_crawl()` is the asyncio-native counterpart to `run_crawl()`.
@@ -156,6 +190,11 @@ What was in v0.0.1:
 - `Storage` protocol with `LocalFileStorage`
 - `Repository` and `RunAudit` persistence protocols with `NullRepository`
 - `ladon run` / `ladon info` CLI
+
+What is in progress (unreleased):
+- **Cloudflare bypass** — `CurlHttpClient` / `AsyncCurlHttpClient` via
+  curl-cffi, `HttpClientConfig(backend="curl-cffi", impersonate="chrome136")`,
+  `make_http_client()` / `make_async_http_client()` factories (issue [#107](https://github.com/MoonyFringers/ladon/issues/107))
 
 What is coming:
 - `ladon-mimir` — async Wikipedia adapter for LLM fine-tuning (issue [#96](https://github.com/MoonyFringers/ladon/issues/96))

--- a/docs/decisions/adr-011-curl-cffi-cloudflare-bypass.md
+++ b/docs/decisions/adr-011-curl-cffi-cloudflare-bypass.md
@@ -1,0 +1,118 @@
+---
+status: accepted
+date: 2026-05-16
+decision-makers: [Maintainers]
+informed: [Contributors]
+refs: [ADR-001, Issue #107]
+---
+
+# ADR-011 — curl-cffi as the Cloudflare-Bypass HTTP Backend
+
+## Context and Problem Statement
+
+Ladon's primary motivating use case includes crawling comics databases and
+similar sites that are protected by Cloudflare.  The existing `HttpClient`
+(requests) and `AsyncHttpClient` (httpx) backends fail against Cloudflare L2
+(TLS fingerprint challenge) because their TLS `ClientHello` is identifiable
+as non-browser traffic.  The `ladon-dylan-dog` adapter targets `comics.org`,
+which is behind Cloudflare and blocks both standard backends.
+
+We need a third backend that can bypass Cloudflare L1+L2 without requiring
+browser automation (Playwright, Selenium), which would be a heavyweight and
+operationally complex dependency.
+
+## Decision Drivers
+
+* Must bypass Cloudflare L1 (JS challenge) and L2 (TLS fingerprint / JA3 hash).
+* Must not require a system-level browser installation or subprocess.
+* Must mirror the full policy surface of `HttpClient` (retries, circuit breaker,
+  proxy rotation, rate limiting, auth) — adapters should not need special-casing.
+* Must be an optional dependency — users who don't crawl Cloudflare-protected
+  targets should not pay the binary wheel cost (~10 MB).
+* Must be compatible with Ladon's strict-mode Pyright type checking.
+
+## Considered Options
+
+* **A — curl-cffi (chosen)**
+* **B — DrissionPage**
+* **C — cloudscraper**
+* **D — Playwright / Selenium**
+
+## Decision Outcome
+
+**Chosen: Option A — curl-cffi.**
+
+curl-cffi is a Python binding over libcurl with BoringSSL (the same TLS
+library used by Chrome).  It can impersonate the exact TLS `ClientHello` of
+43 browser targets (chrome99–chrome136, firefox, safari, tor) including
+ALPN, cipher suites, and extension order — the fields that make up the JA3/JA4
+hash.  The result is a response identical to what a real browser would receive,
+with no JavaScript execution or DOM required.
+
+### Implementation
+
+* New `ladon/networking/curl_client.py` (`CurlHttpClient`) and
+  `ladon/networking/async_curl_client.py` (`AsyncCurlHttpClient`).
+* Both files mirror `client.py` / `async_client.py` exactly — same public
+  interface, same policy pipeline, different underlying session class.
+* `HttpClientConfig` gains `backend: Literal["requests", "curl-cffi"]` and
+  `impersonate: str | None` fields.  `make_http_client()` and
+  `make_async_http_client()` factories dispatch on `config.backend`.
+* curl-cffi is placed behind the `[cffi]` optional extra group so it is
+  never installed as a transitive dependency.
+* Import guard at module top: if curl-cffi is not installed, importing the
+  module succeeds but instantiating the class raises `ImportError` with an
+  actionable message.  This keeps `from ladon.networking import *` safe in
+  all environments.
+
+### Consequences
+
+* **Good**: L1+L2 Cloudflare bypass without a browser process or system
+  dependency — a single binary wheel.
+* **Good**: Full policy parity with existing backends — adapters require zero
+  changes to use the curl backend.
+* **Good**: Optional dependency — zero impact on users who don't need it.
+* **Good**: `impersonate` validated at construction time against `BrowserType`
+  — no runtime surprise on first network call.
+* **Neutral**: L3 (IP reputation / ASN blocking) is not addressed and is
+  explicitly out of scope.  Residential proxies remain required for datacenter
+  IPs against aggressive Cloudflare configurations.
+* **Neutral**: `respect_robots_txt=True` raises `NotImplementedError` on
+  `AsyncCurlHttpClient` — async robots.txt enforcement is deferred.
+  `CurlHttpClient` (sync) supports robots.txt via the standard `RobotsCache`.
+* **Bad**: Binary wheel (~10 MB) with bundled BoringSSL.  Acceptable for an
+  optional extra; not acceptable as a default dependency.
+* **Bad**: `curl_cffi` is untyped; `type: ignore[import-untyped]` annotations
+  required at import sites.  Mitigated by keeping all curl-cffi interaction
+  confined to the two backend files.
+
+## Rejected options
+
+**B — DrissionPage:** Bundles a Chromium browser and requires system-level
+dependencies.  A 200 MB install for a problem that curl-cffi solves with 10 MB.
+Operationally impractical for server deployments.
+
+**C — cloudscraper:** A requests-based library that solves L1 (JS challenge)
+by re-implementing the JavaScript solver in Python.  Does not address L2 (TLS
+fingerprint) — Cloudflare's Turnstile and newer IUAM challenges are not
+solvable without a real TLS fingerprint.  Also unmaintained (last release 2022).
+
+**D — Playwright / Selenium:** Full browser automation.  Definitively solves
+L1+L2+L3 (human-like behaviour) but requires a running browser process, a
+display server or `--headless` mode, and significant operational overhead.
+The right tool for interactive challenges; overkill for what is fundamentally
+a TLS fingerprinting problem.
+
+## Confirmation
+
+The decision is confirmed by:
+
+* `tests/test_curl_client.py` and `tests/test_async_curl_client.py` — 191 unit
+  tests covering the full policy surface (retries, circuit breaker, 429/503,
+  proxy pool, `ImpersonateError` mapping, robots.txt, rate limiting, backoff
+  jitter, Retry-After HTTP-date, proxy pool rotation, context metadata).
+* `tests/test_factory.py` — factory dispatch and backend selection.
+* `scripts/smoke_test_gcd.py` — live smoke test against `www.comics.org`.
+  Confirmed: TLS fingerprint impersonation works (HTTP connections succeed,
+  real Cloudflare responses received).  L3 IP reputation blocking is the
+  remaining obstacle on datacenter IPs, as expected.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -17,6 +17,7 @@ chosen over the alternatives.
 | [ADR-008](adr-008-robots-txt.md) | robots.txt Enforcement | Accepted |
 | ADR-009 | Observability (metrics, structured logs) | Proposed — Phase 3 |
 | [ADR-010](adr-010-dual-license-model.md) | Dual-License Model (AGPL-3.0-only + Commercial) | Accepted |
+| [ADR-011](adr-011-curl-cffi-cloudflare-bypass.md) | curl-cffi as the Cloudflare-Bypass HTTP Backend | Accepted |
 
 ## Format
 

--- a/docs/guides/cloudflare-bypass.md
+++ b/docs/guides/cloudflare-bypass.md
@@ -1,0 +1,161 @@
+# Cloudflare-Protected Targets
+
+Some targets are protected by Cloudflare's bot-detection stack.  Standard
+HTTP clients fail because their TLS handshake identifies them as non-browser
+traffic.  Ladon's optional `curl-cffi` backend bypasses this by impersonating
+a real browser's TLS fingerprint (JA3/JA4).
+
+## Cloudflare protection layers
+
+| Layer | What it checks | Bypassed by curl-cffi? |
+|---|---|---|
+| **L1 — JS challenge** | Whether the client can execute JavaScript | Yes — TLS fingerprint bypasses the pre-check |
+| **L2 — TLS fingerprint** | JA3/JA4 hash of the TLS `ClientHello` | Yes — BoringSSL fingerprint matches the target browser |
+| **L3 — IP reputation** | ASN, data-centre ranges, historical abuse score | No — requires a residential or clean-IP proxy |
+
+L3 is independent of the HTTP client.  If the crawl machine's IP is in a
+blocked ASN range, combine `CurlHttpClient` with `HttpClientConfig(proxy_pool=...)`
+pointing to residential proxies.
+
+## Installation
+
+The curl-cffi backend is an optional extra.  It is not installed by default.
+
+```bash
+pip install ladon-crawl[cffi]
+```
+
+This adds `curl-cffi>=0.11,<1` — a binary wheel that bundles libcurl and
+BoringSSL.  No system-level `curl` installation is required.
+
+## Choosing an impersonate target
+
+The `impersonate` argument selects the TLS fingerprint.  Pass any value from
+`curl_cffi.requests.BrowserType`:
+
+```bash
+python -c "from curl_cffi.requests import BrowserType; print([b.value for b in BrowserType])"
+```
+
+As of curl-cffi 0.15, 43 targets are available: `chrome99` through `chrome136`,
+`firefox133` through `firefox147`, `safari15_3` through `safari184`, `tor145`,
+and several iOS/Android variants.
+
+A safe default for most Cloudflare-protected targets is `chrome136`.
+
+## Usage
+
+### Factory helper (recommended)
+
+```python
+from ladon.networking import make_http_client
+from ladon.networking.config import HttpClientConfig
+
+config = HttpClientConfig(
+    backend="curl-cffi",
+    impersonate="chrome136",
+    timeout_seconds=20.0,
+    retries=2,
+    min_request_interval_seconds=2.0,
+)
+
+with make_http_client(config) as client:
+    result = client.get("https://protected-target.example/")
+    if result.ok:
+        print(result.value[:200])
+    else:
+        print("failed:", result.error)
+```
+
+`make_http_client()` and `make_async_http_client()` inspect `config.backend`
+and return a `CurlHttpClient` or `AsyncCurlHttpClient` automatically.  Swap
+the backend by changing one field — no call-site changes required.
+
+### Direct instantiation
+
+```python
+from ladon.networking.curl_client import CurlHttpClient
+from ladon.networking.config import HttpClientConfig
+
+config = HttpClientConfig(timeout_seconds=20.0, retries=2)
+with CurlHttpClient(config, impersonate="chrome136") as client:
+    result = client.get("https://protected-target.example/")
+```
+
+### Async
+
+```python
+from ladon.networking import make_async_http_client
+from ladon.networking.config import HttpClientConfig
+
+config = HttpClientConfig(
+    backend="curl-cffi",
+    impersonate="chrome136",
+    timeout_seconds=20.0,
+)
+
+async with make_async_http_client(config) as client:
+    result = await client.get("https://protected-target.example/")
+```
+
+## Policy parity
+
+`CurlHttpClient` and `AsyncCurlHttpClient` support all the same
+`HttpClientConfig` policies as the standard backends:
+
+| Policy | Config field |
+|---|---|
+| Retries + exponential backoff | `retries`, `backoff_base_seconds`, `backoff_jitter` |
+| Per-domain rate limiting | `min_request_interval_seconds` |
+| 429/503 Retry-After respect | `retry_on_status`, `max_retry_after_seconds` |
+| Circuit breaker | `circuit_breaker_failure_threshold` |
+| Static proxy | `proxies` |
+| Rotating proxy pool | `proxy_pool` |
+| HTTP authentication | `auth` |
+| Default headers / params | `default_headers`, `default_params` |
+| TLS verification | `verify_tls` |
+| Connect / read timeouts | `connect_timeout_seconds`, `read_timeout_seconds` |
+
+The one limitation: `respect_robots_txt=True` raises `NotImplementedError` on
+both curl clients.  Async robots.txt enforcement is deferred to a future release.
+
+## Error handling
+
+Errors map to the same `ladon.networking.errors` hierarchy as the standard
+backends:
+
+| curl-cffi exception | Ladon error |
+|---|---|
+| `Timeout`, `ConnectTimeout`, `ReadTimeout` | `RequestTimeoutError` |
+| `ConnectionError`, `SSLError` | `TransientNetworkError` |
+| Any other `RequestException` | `HttpClientError` |
+| `ImpersonateError` | `HttpClientError` |
+
+`SSLError` is a subclass of `ConnectionError` and will be retried on
+safe methods.  Certificate failures are not transient — they will exhaust
+the retry budget and then raise `TransientNetworkError`.
+
+## `ImpersonateError` and invalid targets
+
+Passing an unrecognised value to `impersonate` raises `ValueError` immediately
+at construction time, before any network call:
+
+```python
+# Raises ValueError at construction — no request is sent
+CurlHttpClient(config, impersonate="notabrowser")
+```
+
+If curl-cffi raises `ImpersonateError` at request time (the fingerprint was
+valid but could not be applied), it maps to `HttpClientError`.
+
+## Validation errors
+
+Passing `backend="curl-cffi"` without `impersonate` raises `ValueError` at
+`HttpClientConfig` construction time:
+
+```python
+# Raises ValueError immediately
+HttpClientConfig(backend="curl-cffi")
+# Correct
+HttpClientConfig(backend="curl-cffi", impersonate="chrome136")
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
 ladon = "ladon.cli:main"
 
 [project.optional-dependencies]
+cffi = [
+    "curl-cffi>=0.11,<1",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
@@ -43,6 +46,7 @@ dev = [
     "black",
     "ruff",
     "isort",
+    "curl-cffi>=0.11,<1",
 ]
 docs = [
     "mkdocs-material>=9.5",

--- a/scripts/smoke_test_gcd.py
+++ b/scripts/smoke_test_gcd.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Smoke test: verify CurlHttpClient bypasses Cloudflare on comics.org.
+
+Not part of the automated test suite — requires a live internet connection.
+
+Usage:
+    python scripts/smoke_test_gcd.py
+
+Acceptance criterion: HTTP 200 with real GCD HTML (not a Cloudflare challenge
+page).  Checks for the string "Grand Comics Database" in the response body.
+
+Tries a small set of impersonate targets in order; stops on first success.
+"""
+
+from __future__ import annotations
+
+import sys
+
+TARGETS = ["chrome136", "chrome131", "firefox147", "safari184"]
+URL = "https://www.comics.org/series/"
+CLOUDFLARE_MARKER = b"Just a moment"
+SUCCESS_MARKER = b"Grand Comics Database"
+
+
+def run() -> int:
+    from ladon.networking import make_http_client
+    from ladon.networking.config import HttpClientConfig
+
+    print(f"Target: {URL}")
+    print()
+
+    for impersonate in TARGETS:
+        config = HttpClientConfig(
+            backend="curl-cffi",
+            impersonate=impersonate,
+            timeout_seconds=20.0,
+            retries=1,
+            min_request_interval_seconds=2.0,
+        )
+        print(f"  [{impersonate}]", end=" ", flush=True)
+        with make_http_client(config) as client:
+            result = client.get(URL)
+
+        if not result.ok:
+            print(f"FAIL — {result.error}")
+            continue
+
+        body = result.value or b""
+        status = result.meta.get("status_code")
+        elapsed = result.meta.get("elapsed_s", "?")
+        size = len(body)
+
+        if CLOUDFLARE_MARKER in body:
+            print(
+                f"BLOCKED — HTTP {status}, {size} bytes — Cloudflare challenge page"
+            )
+            continue
+
+        if SUCCESS_MARKER in body:
+            print(f"OK — HTTP {status}, {size} bytes, {elapsed:.2f}s")
+            print()
+            print("  Cloudflare L1+L2 bypassed successfully.")
+            return 0
+
+        print(f"UNKNOWN — HTTP {status}, {size} bytes — unexpected body")
+
+    print()
+    print("All impersonate targets returned a Cloudflare challenge page.")
+    print()
+    print("Diagnosis:")
+    print(
+        "  TLS fingerprint impersonation is working (HTTP connection succeeded)."
+    )
+    print("  Cloudflare L3 (IP reputation) is blocking this machine's IP.")
+    print("  This is expected on datacenter/VPS IPs — use a residential IP to")
+    print("  confirm full L1+L2 bypass.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -3,9 +3,12 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .async_runner import async_run_crawl
+from .networking import make_async_http_client, make_http_client
 from .networking.async_client import AsyncHttpClient
+from .networking.async_curl_client import AsyncCurlHttpClient
 from .networking.client import HttpClient
 from .networking.config import HttpClientConfig
+from .networking.curl_client import CurlHttpClient
 from .networking.errors import (
     CircuitOpenError,
     HttpClientError,
@@ -81,6 +84,10 @@ __all__ = [
     # Networking
     "HttpClient",
     "AsyncHttpClient",
+    "CurlHttpClient",
+    "AsyncCurlHttpClient",
+    "make_http_client",
+    "make_async_http_client",
     "HttpClientConfig",
     "Result",
     "HttpClientError",

--- a/src/ladon/networking/__init__.py
+++ b/src/ladon/networking/__init__.py
@@ -1,9 +1,13 @@
 """Networking package for Ladon."""
 
+from __future__ import annotations
+
 from .async_client import AsyncHttpClient
+from .async_curl_client import AsyncCurlHttpClient
 from .circuit_breaker import CircuitState
 from .client import HttpClient
 from .config import HttpClientConfig
+from .curl_client import CurlHttpClient
 from .errors import (
     CircuitOpenError,
     HttpClientError,
@@ -15,13 +19,61 @@ from .errors import (
 from .proxy_pool import ProxyPool, RoundRobinProxyPool, validate_proxy
 from .types import Result
 
+
+def make_http_client(
+    config: HttpClientConfig,
+) -> HttpClient | CurlHttpClient:
+    """Instantiate a sync HTTP client from *config*.
+
+    Returns a :class:`CurlHttpClient` when ``config.backend == "curl-cffi"``,
+    otherwise returns a :class:`HttpClient`.  The ``impersonate`` field is
+    passed through automatically — see :class:`HttpClientConfig` for details.
+
+    Raises:
+        ImportError: When ``backend="curl-cffi"`` and ``curl-cffi`` is not
+            installed (``pip install ladon-crawl[cffi]``).
+    """
+    if config.backend == "curl-cffi":
+        # config.impersonate is str | None, but __post_init__ guarantees it is
+        # not None when backend="curl-cffi" — Pyright cannot see that invariant.
+        return CurlHttpClient(
+            config, impersonate=config.impersonate  # type: ignore[arg-type]
+        )
+    return HttpClient(config)
+
+
+def make_async_http_client(
+    config: HttpClientConfig,
+) -> AsyncHttpClient | AsyncCurlHttpClient:
+    """Instantiate an async HTTP client from *config*.
+
+    Returns an :class:`AsyncCurlHttpClient` when ``config.backend == "curl-cffi"``,
+    otherwise returns an :class:`AsyncHttpClient`.
+
+    Raises:
+        ImportError: When ``backend="curl-cffi"`` and ``curl-cffi`` is not
+            installed (``pip install ladon-crawl[cffi]``).
+    """
+    if config.backend == "curl-cffi":
+        # config.impersonate is str | None, but __post_init__ guarantees it is
+        # not None when backend="curl-cffi" — Pyright cannot see that invariant.
+        return AsyncCurlHttpClient(
+            config, impersonate=config.impersonate  # type: ignore[arg-type]
+        )
+    return AsyncHttpClient(config)
+
+
 __all__ = [
+    "AsyncCurlHttpClient",
     "AsyncHttpClient",
     "CircuitOpenError",
     "CircuitState",
+    "CurlHttpClient",
     "HttpClient",
     "HttpClientError",
     "HttpClientConfig",
+    "make_async_http_client",
+    "make_http_client",
     "ProxyPool",
     "RoundRobinProxyPool",
     "validate_proxy",

--- a/src/ladon/networking/async_client.py
+++ b/src/ladon/networking/async_client.py
@@ -108,7 +108,7 @@ class AsyncHttpClient:
     async def __aenter__(self) -> AsyncHttpClient:
         return self
 
-    async def __aexit__(self, *args: object) -> None:
+    async def __aexit__(self, *_: object) -> None:
         await self.aclose()
 
     # ------------------------------------------------------------------

--- a/src/ladon/networking/async_curl_client.py
+++ b/src/ladon/networking/async_curl_client.py
@@ -1,0 +1,648 @@
+"""Asynchronous HTTP client backed by curl-cffi (Cloudflare bypass).
+
+Mirrors ``AsyncHttpClient`` exactly but uses ``curl_cffi.requests.AsyncSession``
+instead of ``httpx.AsyncClient``, enabling TLS fingerprint impersonation
+(JA3/JA4) to bypass Cloudflare L1+L2 challenges without browser automation.
+
+Requires the optional ``cffi`` extra::
+
+    pip install ladon-crawl[cffi]
+
+If curl-cffi is not installed, importing this module succeeds but
+instantiating ``AsyncCurlHttpClient`` raises ``ImportError`` with an
+actionable message.
+
+Blast radius: if curl-cffi changes its async API, only this file is affected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from random import uniform
+from time import monotonic
+from typing import Any, Callable, Coroutine, Mapping, TypeVar
+from urllib.parse import urlparse
+
+try:
+    from curl_cffi import (
+        requests as _cffi,  # type: ignore[import-untyped, import-not-found]
+    )
+    from curl_cffi.requests import (
+        BrowserType as _BrowserType,  # type: ignore[import-untyped, import-not-found]
+    )
+    from curl_cffi.requests import (
+        exceptions as _cffi_exc,  # type: ignore[import-untyped, import-not-found]
+    )
+
+    _curl_cffi_available: bool = True
+    _valid_impersonate: frozenset[str] = frozenset(
+        b.value for b in _BrowserType  # type: ignore[union-attr]
+    )
+except ImportError:
+    _cffi: Any = None
+    _cffi_exc: Any = None
+    _curl_cffi_available = False
+    _valid_impersonate = frozenset()
+
+from .circuit_breaker import CircuitBreaker, CircuitState
+from .config import HttpClientConfig
+from .errors import (
+    CircuitOpenError,
+    HttpClientError,
+    RateLimitedError,
+    RequestTimeoutError,
+    TransientNetworkError,
+)
+from .types import Err, Ok, Result
+
+ResponseValue = TypeVar("ResponseValue")
+
+_AsyncRequestFn = Callable[[], Coroutine[Any, Any, Any]]
+
+_IMPORT_ERROR_MSG = (
+    "curl-cffi is required for AsyncCurlHttpClient.\n"
+    "Install it with:  pip install ladon-crawl[cffi]"
+)
+
+
+class AsyncCurlHttpClient:
+    """Async HTTP client with TLS fingerprint impersonation via curl-cffi.
+
+    Drop-in async replacement for ``AsyncHttpClient`` for targets protected
+    by Cloudflare L1 (JS challenge) or L2 (TLS fingerprint / JA3 hash).
+    All policy (retries, rate limiting, circuit breaking) is identical to
+    ``AsyncHttpClient``.
+
+    Robots.txt enforcement is not supported (same limitation as
+    ``AsyncHttpClient``). Passing ``respect_robots_txt=True`` raises
+    ``NotImplementedError`` at construction time.
+
+    Concurrent safety
+    -----------------
+    Safe for concurrent use within a single asyncio event loop. Do not share
+    an instance across threads.
+
+    Args:
+        config: Standard ``HttpClientConfig``.
+        impersonate: Browser fingerprint to impersonate.
+            Examples: ``"chrome136"``, ``"firefox147"``, ``"safari184"``.
+            Run ``python -c "from curl_cffi.requests import BrowserType;
+            print([b.value for b in BrowserType])"`` for the full list.
+    """
+
+    def __init__(self, config: HttpClientConfig, *, impersonate: str) -> None:
+        if not _curl_cffi_available:
+            raise ImportError(_IMPORT_ERROR_MSG)
+        if config.respect_robots_txt:
+            raise NotImplementedError(
+                "respect_robots_txt is not supported by AsyncCurlHttpClient; "
+                "async robots enforcement is deferred to a future release"
+            )
+        if impersonate not in _valid_impersonate:
+            raise ValueError(
+                f"Unknown impersonate target {impersonate!r}. "
+                f'Run `python -c "from curl_cffi.requests import BrowserType; '
+                f'print([b.value for b in BrowserType])"` for valid values.'
+            )
+        if config.auth is not None and not isinstance(config.auth, tuple):
+            raise ValueError(
+                "curl-cffi only supports HTTP Basic Auth; "
+                "AuthBase subclasses (HTTPDigestAuth, custom HMAC/OAuth) are "
+                "not supported. Use default_headers={'Authorization': '...'} "
+                "for Bearer tokens or other header-based schemes."
+            )
+        self._config = config
+        self._impersonate = impersonate
+        self._session: Any = _cffi.AsyncSession(impersonate=impersonate)
+        self._last_request_time: dict[str, float] = {}
+        self._circuit_breakers: dict[str, CircuitBreaker] = {}
+        self._crawl_delay_overrides: dict[str, float] = {}
+        if self._config.user_agent:
+            self._session.headers["User-Agent"] = self._config.user_agent
+        self._session.headers.update(self._config.default_headers)
+        if self._config.proxies is not None:
+            self._session.proxies.update(self._config.proxies)
+        if self._config.auth is not None:
+            self._session.auth = self._config.auth
+
+    @property
+    def impersonate(self) -> str:
+        """The browser fingerprint this client is configured to impersonate."""
+        return self._impersonate
+
+    async def aclose(self) -> None:
+        """Close the underlying session and release pooled connections."""
+        await self._session.close()
+
+    async def __aenter__(self) -> AsyncCurlHttpClient:
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.aclose()
+
+    def _get_timeout(
+        self, override: float | None
+    ) -> float | tuple[float, float]:
+        if override is not None:
+            if override <= 0:
+                raise ValueError("timeout override must be > 0 when provided")
+            return override
+        if (
+            self._config.connect_timeout_seconds is not None
+            and self._config.read_timeout_seconds is not None
+        ):
+            return (
+                self._config.connect_timeout_seconds,
+                self._config.read_timeout_seconds,
+            )
+        return self._config.timeout_seconds
+
+    def _max_attempts(self) -> int:
+        return 1 + max(0, self._config.retries)
+
+    def _is_retryable_exception(self, method: str, error: Any) -> bool:
+        if method.upper() not in {"GET", "HEAD"}:
+            return False
+        # SSLError subclasses ConnectionError and will be retried here; cert
+        # failures are not transient but exhausting retries is the safe default.
+        return isinstance(error, (_cffi_exc.Timeout, _cffi_exc.ConnectionError))
+
+    async def _sleep_between_attempts(self, attempt: int) -> None:
+        backoff_base = self._config.backoff_base_seconds
+        if backoff_base <= 0:
+            return
+        cap = backoff_base * (2 ** max(0, attempt - 1))
+        await asyncio.sleep(
+            uniform(0.0, cap) if self._config.backoff_jitter else cap
+        )
+
+    @staticmethod
+    def _parse_retry_after(response: Any) -> float | None:
+        header = response.headers.get("Retry-After")
+        if header is None:
+            return None
+        try:
+            return max(0.0, float(header))
+        except ValueError:
+            pass
+        try:
+            dt: datetime = parsedate_to_datetime(str(header))
+            delta: float = (dt - datetime.now(tz=timezone.utc)).total_seconds()
+            return max(0.0, delta)
+        except Exception:
+            return None
+
+    async def _sleep_for_retry_after(
+        self, retry_after: float | None, attempt: int
+    ) -> None:
+        if retry_after is not None:
+            capped = min(retry_after, self._config.max_retry_after_seconds)
+            await asyncio.sleep(
+                max(capped, self._config.min_request_interval_seconds)
+            )
+        else:
+            await self._sleep_between_attempts(attempt)
+
+    def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
+        self._session.proxies.clear()
+        if proxy is not None:
+            self._session.proxies.update(proxy)
+
+    def _merge_params(
+        self, params: Mapping[str, str] | None
+    ) -> Mapping[str, str] | None:
+        dp = self._config.default_params
+        if dp is None:
+            return params
+        merged = {**dp, **(params or {})}
+        return merged if merged else None
+
+    async def _enforce_rate_limit(self, url: str) -> None:
+        host = urlparse(url).netloc
+        if not host:
+            return
+        interval = max(
+            self._config.min_request_interval_seconds,
+            self._crawl_delay_overrides.get(host, 0.0),
+        )
+        if interval <= 0:
+            return
+        last = self._last_request_time.get(host)
+        if last is not None:
+            elapsed = monotonic() - last
+            remaining = interval - elapsed
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+
+    def _build_meta(
+        self,
+        method: str,
+        request_url: str,
+        response: Any | None,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: float | tuple[float, float] | None,
+        final_error: str | None = None,
+    ) -> dict[str, Any]:
+        meta: dict[str, Any] = {}
+        meta["method"] = method
+        meta["url"] = request_url
+        meta["attempts"] = attempts
+        meta["timeout_s"] = timeout
+        if context:
+            context_dict = dict(context)
+            meta["context"] = context_dict
+            for key, value in context_dict.items():
+                meta.setdefault(key, value)
+        if response is not None:
+            meta["status_code"] = response.status_code
+            meta["url"] = response.url
+            meta["reason"] = response.reason
+            try:
+                meta["elapsed_s"] = response.elapsed.total_seconds()
+            except AttributeError:
+                pass
+        if final_error is not None:
+            meta["final_error"] = final_error
+        return meta
+
+    def _handle_request_exception(
+        self,
+        method: str,
+        request_url: str,
+        e: Any,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: float | tuple[float, float] | None,
+    ) -> Result[Any, Exception]:
+        response = getattr(e, "response", None)
+        meta = self._build_meta(
+            method,
+            request_url,
+            response,
+            context,
+            attempts,
+            timeout,
+            final_error=type(e).__name__,
+        )
+        if isinstance(e, _cffi_exc.Timeout):
+            return Err(RequestTimeoutError(str(e)), meta=meta)
+        if isinstance(e, _cffi_exc.ConnectionError):
+            return Err(TransientNetworkError(str(e)), meta=meta)
+        return Err(HttpClientError(str(e)), meta=meta)
+
+    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
+        threshold = self._config.circuit_breaker_failure_threshold
+        if threshold is None:
+            return None
+        host = urlparse(url).netloc
+        if not host:
+            return None
+        if host not in self._circuit_breakers:
+            self._circuit_breakers[host] = CircuitBreaker(
+                threshold=threshold,
+                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
+            )
+        return self._circuit_breakers[host]
+
+    def circuit_state(self, url: str) -> CircuitState | None:
+        """Return the current circuit-breaker state for *url*'s host, or None."""
+        cb = self._circuit_breakers.get(urlparse(url).netloc)
+        return cb.state if cb is not None else None
+
+    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
+        """Override the per-host crawl delay for *host*.
+
+        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
+        when the override is larger.  Intended for callers that parse a site's
+        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
+        """
+        self._crawl_delay_overrides[host] = delay_seconds
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        context: Mapping[str, Any] | None,
+        timeout: float | tuple[float, float],
+        request_fn: _AsyncRequestFn,
+        value_builder: Callable[[Any], ResponseValue],
+    ) -> Result[ResponseValue, Exception]:
+        cb = self._get_circuit_breaker(url)
+        if cb is not None and not cb.allow_request():
+            meta = self._build_meta(
+                method=method,
+                request_url=url,
+                response=None,
+                context=context,
+                attempts=0,
+                timeout=timeout,
+                final_error="CircuitOpenError",
+            )
+            return Err(CircuitOpenError(urlparse(url).netloc), meta=meta)
+
+        await self._enforce_rate_limit(url)
+        host = urlparse(url).netloc
+        is_safe_method = method.upper() in {"GET", "HEAD"}
+        pool = self._config.proxy_pool
+        attempts = 0
+        last_error: Any = None
+        last_blocked_response: Any = None
+        last_blocked_retry_after: float | None = None
+        current_proxy: Mapping[str, str] | None = None
+        if pool is not None:
+            current_proxy = pool.next_proxy()
+            self._apply_proxy(current_proxy)
+
+        for _ in range(self._max_attempts()):
+            attempts += 1
+            try:
+                response = await request_fn()
+                if (
+                    response.status_code in self._config.retry_on_status
+                    and is_safe_method
+                ):
+                    last_blocked_retry_after = self._parse_retry_after(response)
+                    last_blocked_response = response
+                    last_error = None
+                    if attempts < self._max_attempts():
+                        if pool is not None:
+                            pool.mark_failure(current_proxy)
+                            current_proxy = pool.next_proxy()
+                            self._apply_proxy(current_proxy)
+                        await self._sleep_for_retry_after(
+                            last_blocked_retry_after, attempts
+                        )
+                        continue
+                    break
+                if cb is not None:
+                    cb.record_success()
+                return Ok(
+                    value_builder(response),
+                    meta=self._build_meta(
+                        method=method,
+                        request_url=url,
+                        response=response,
+                        context=context,
+                        attempts=attempts,
+                        timeout=timeout,
+                    ),
+                )
+            except _cffi_exc.RequestException as exc:
+                last_error = exc
+                last_blocked_response = None
+                last_blocked_retry_after = None
+                if (
+                    attempts >= self._max_attempts()
+                    or not self._is_retryable_exception(method, exc)
+                ):
+                    break
+                if pool is not None:
+                    pool.mark_failure(current_proxy)
+                    current_proxy = pool.next_proxy()
+                    self._apply_proxy(current_proxy)
+                await self._sleep_between_attempts(attempts)
+            except Exception as exc:  # pragma: no cover - defensive fallback
+                if cb is not None:
+                    cb.record_failure()
+                return Err(
+                    HttpClientError(str(exc)),
+                    meta=self._build_meta(
+                        method=method,
+                        request_url=url,
+                        response=None,
+                        context=context,
+                        attempts=attempts,
+                        timeout=timeout,
+                        final_error=type(exc).__name__,
+                    ),
+                )
+            finally:
+                if host:
+                    self._last_request_time[host] = monotonic()
+
+        if last_blocked_response is not None:
+            if cb is not None:
+                cb.record_failure()
+            if pool is not None:
+                pool.mark_failure(current_proxy)
+            return Err(
+                RateLimitedError(
+                    last_blocked_response.status_code,
+                    last_blocked_retry_after,
+                ),
+                meta=self._build_meta(
+                    method=method,
+                    request_url=url,
+                    response=last_blocked_response,
+                    context=context,
+                    attempts=attempts,
+                    timeout=timeout,
+                    final_error="RateLimitedError",
+                ),
+            )
+
+        assert last_error is not None
+        if cb is not None:
+            cb.record_failure()
+        if pool is not None:
+            pool.mark_failure(current_proxy)
+        return self._handle_request_exception(
+            method=method,
+            request_url=url,
+            e=last_error,
+            context=context,
+            attempts=attempts,
+            timeout=timeout,
+        )
+
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[bytes, Exception]:
+        """Perform an async HTTP GET request.
+
+        Args:
+            url: Absolute URL to request.
+            headers: Optional per-request headers merged with defaults.
+            params: Optional query parameters.
+            timeout: Override timeout in seconds for this request.
+            allow_redirects: Whether redirects should be followed.
+            context: Optional caller context for logging/tracing.
+
+        Returns:
+            Result containing response bytes on success, or an error on failure.
+        """
+        resolved_timeout = self._get_timeout(timeout)
+        merged_params = self._merge_params(params)
+
+        async def _fn() -> Any:
+            return await self._session.get(
+                url,
+                headers=headers,
+                params=merged_params,
+                timeout=resolved_timeout,
+                allow_redirects=allow_redirects,
+                verify=self._config.verify_tls,
+            )
+
+        return await self._request(
+            method="GET",
+            url=url,
+            context=context,
+            timeout=resolved_timeout,
+            request_fn=_fn,
+            value_builder=lambda r: r.content,
+        )
+
+    async def head(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[Mapping[str, Any], Exception]:
+        """Perform an async HTTP HEAD request.
+
+        Args:
+            url: Absolute URL to request.
+            headers: Optional per-request headers merged with defaults.
+            params: Optional query parameters.
+            timeout: Override timeout in seconds for this request.
+            allow_redirects: Whether redirects should be followed.
+            context: Optional caller context for logging/tracing.
+
+        Returns:
+            Result containing response headers on success, or an error on failure.
+        """
+        resolved_timeout = self._get_timeout(timeout)
+        merged_params = self._merge_params(params)
+
+        async def _fn() -> Any:
+            return await self._session.head(
+                url,
+                headers=headers,
+                params=merged_params,
+                timeout=resolved_timeout,
+                allow_redirects=allow_redirects,
+                verify=self._config.verify_tls,
+            )
+
+        return await self._request(
+            method="HEAD",
+            url=url,
+            context=context,
+            timeout=resolved_timeout,
+            request_fn=_fn,
+            value_builder=lambda r: dict(r.headers),
+        )
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        data: Any | None = None,
+        json: Any | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[bytes, Exception]:
+        """Perform an async HTTP POST request.
+
+        Args:
+            url: Absolute URL to request.
+            headers: Optional per-request headers merged with defaults.
+            params: Optional query parameters.
+            data: Optional form/body payload.
+            json: Optional JSON payload (mutually exclusive with data).
+            timeout: Override timeout in seconds for this request.
+            allow_redirects: Whether redirects should be followed.
+            context: Optional caller context for logging/tracing.
+
+        Returns:
+            Result containing response bytes on success, or an error on failure.
+        """
+        resolved_timeout = self._get_timeout(timeout)
+        merged_params = self._merge_params(params)
+
+        async def _fn() -> Any:
+            return await self._session.post(
+                url,
+                headers=headers,
+                params=merged_params,
+                data=data,
+                json=json,
+                timeout=resolved_timeout,
+                allow_redirects=allow_redirects,
+                verify=self._config.verify_tls,
+            )
+
+        return await self._request(
+            method="POST",
+            url=url,
+            context=context,
+            timeout=resolved_timeout,
+            request_fn=_fn,
+            value_builder=lambda r: r.content,
+        )
+
+    async def download(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[Any, Exception]:
+        """Perform an async download (GET, returns the full curl-cffi response).
+
+        Args:
+            url: Absolute URL to request.
+            headers: Optional per-request headers merged with defaults.
+            params: Optional query parameters.
+            timeout: Override timeout in seconds for this request.
+            allow_redirects: Whether redirects should be followed.
+            context: Optional caller context for logging/tracing.
+
+        Returns:
+            Result containing a curl-cffi response object with ``iter_content``
+            and ``iter_lines`` for streaming, or an error on failure.
+        """
+        resolved_timeout = self._get_timeout(timeout)
+        merged_params = self._merge_params(params)
+
+        async def _fn() -> Any:
+            return await self._session.get(
+                url,
+                headers=headers,
+                params=merged_params,
+                timeout=resolved_timeout,
+                allow_redirects=allow_redirects,
+                stream=True,
+                verify=self._config.verify_tls,
+            )
+
+        return await self._request(
+            method="GET",
+            url=url,
+            context=context,
+            timeout=resolved_timeout,
+            request_fn=_fn,
+            value_builder=lambda r: r,
+        )

--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -84,7 +84,7 @@ class HttpClient:
     def __enter__(self) -> HttpClient:
         return self
 
-    def __exit__(self, *args: object) -> None:
+    def __exit__(self, *_: object) -> None:
         self.close()
 
     def _get_timeout(
@@ -251,6 +251,8 @@ class HttpClient:
             remaining = interval - elapsed
             if remaining > 0:
                 sleep(remaining)
+        # Writes here (start-to-start semantics). The three other clients write
+        # in the _request finally block (end-to-start). Will be aligned in #109.
         self._last_request_time[host] = monotonic()
 
     def _build_meta(
@@ -350,6 +352,15 @@ class HttpClient:
         if cb is None:
             return None
         return cb.state
+
+    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
+        """Override the per-host crawl delay for *host*.
+
+        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
+        when the override is larger.  Intended for callers that parse a site's
+        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
+        """
+        self._crawl_delay_overrides[host] = delay_seconds
 
     def _request(
         self,

--- a/src/ladon/networking/config.py
+++ b/src/ladon/networking/config.py
@@ -1,10 +1,9 @@
 """Configuration models for the HttpClient interface."""
 
-from __future__ import annotations
-
+import warnings
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Literal, Mapping
 
 from requests.auth import AuthBase
 
@@ -18,6 +17,26 @@ def _default_headers() -> Mapping[str, str]:
     """Return immutable empty default headers mapping."""
 
     return MappingProxyType({})
+
+
+_cffi_valid_impersonate: frozenset[str] | None = None
+
+
+def _get_cffi_valid_impersonate() -> frozenset[str] | None:
+    global _cffi_valid_impersonate
+    if _cffi_valid_impersonate is None:
+        try:
+            from curl_cffi.requests import (
+                BrowserType as _BrowserType,  # type: ignore[import-untyped, import-not-found]
+            )
+
+            _cffi_valid_impersonate = frozenset(
+                b.value  # type: ignore[union-attr]
+                for b in _BrowserType  # type: ignore[union-attr]
+            )
+        except ImportError:
+            pass
+    return _cffi_valid_impersonate
 
 
 @dataclass(frozen=True)
@@ -46,19 +65,48 @@ class HttpClientConfig:
 
     Authentication patterns
     -----------------------
-    +---------------------------------+--------------------------------------------------+
-    | Mechanism                       | Config                                           |
-    +=================================+==================================================+
-    | HTTP Basic Auth                 | ``auth=("user", "pass")``                        |
-    +---------------------------------+--------------------------------------------------+
-    | HTTP Digest Auth                | ``auth=HTTPDigestAuth("user", "pass")``          |
-    +---------------------------------+--------------------------------------------------+
-    | Bearer token / API key (header) | ``default_headers={"Authorization": "Bearer …"}``|
-    +---------------------------------+--------------------------------------------------+
-    | API key in query string         | ``default_params={"api_key": "…"}``              |
-    +---------------------------------+--------------------------------------------------+
-    | HMAC signing / OAuth tokens     | Custom ``requests.auth.AuthBase`` via ``auth``   |
-    +---------------------------------+--------------------------------------------------+
+    +---------------------------------+--------------------------------------------------+--------------------+
+    | Mechanism                       | Config                                           | Backends           |
+    +=================================+==================================================+====================+
+    | HTTP Basic Auth                 | ``auth=("user", "pass")``                        | all                |
+    +---------------------------------+--------------------------------------------------+--------------------+
+    | HTTP Digest Auth                | ``auth=HTTPDigestAuth("user", "pass")``          | requests only      |
+    +---------------------------------+--------------------------------------------------+--------------------+
+    | Bearer token / API key (header) | ``default_headers={"Authorization": "Bearer …"}``| all                |
+    +---------------------------------+--------------------------------------------------+--------------------+
+    | API key in query string         | ``default_params={"api_key": "…"}``              | all                |
+    +---------------------------------+--------------------------------------------------+--------------------+
+    | HMAC signing / OAuth tokens     | Custom ``requests.auth.AuthBase`` via ``auth``   | requests only      |
+    +---------------------------------+--------------------------------------------------+--------------------+
+
+    ``curl-cffi`` only supports Basic Auth (``auth`` as a tuple).  Passing an
+    ``AuthBase`` subclass with ``backend="curl-cffi"`` raises ``ValueError``
+    at client construction time.
+
+    Backend selection
+    -----------------
+    The default backend (``"requests"``) is sufficient for most targets.
+    Use ``"curl-cffi"`` for Cloudflare-protected sites — it impersonates a
+    real browser's TLS ``ClientHello`` (JA3/JA4), bypassing L1 (JS challenge)
+    and L2 (TLS fingerprint) without a browser process:
+
+    .. code-block:: python
+
+        HttpClientConfig(backend="curl-cffi", impersonate="chrome136")
+
+    ``impersonate`` is required when ``backend="curl-cffi"``; construction
+    raises ``ValueError`` otherwise.  Valid values are the members of
+    ``curl_cffi.requests.BrowserType`` (e.g. ``"chrome136"``,
+    ``"firefox147"``, ``"safari184"``).  Requires
+    ``pip install ladon-crawl[cffi]``.
+
+    When curl-cffi is installed, ``HttpClientConfig`` checks ``impersonate``
+    against ``BrowserType`` at construction time.  An unrecognised value
+    emits a ``UserWarning`` but does **not** raise — forward-compatible
+    strings (fingerprints added in a newer curl-cffi release) should not
+    be blocked.  When curl-cffi is not installed the check is skipped; an
+    invalid value will raise ``ValueError`` at client construction time
+    (``CurlHttpClient`` / ``AsyncCurlHttpClient`` or the factory helpers).
     """
 
     user_agent: str | None = None
@@ -93,7 +141,7 @@ class HttpClientConfig:
     # Proxy rotation strategy.  Mutually exclusive with proxies.
     # HttpClient calls next_proxy() before each request attempt and
     # mark_failure() when a transport error or rate-limit response occurs.
-    proxy_pool: ProxyPool | None = None
+    proxy_pool: "ProxyPool | None" = None
     # HTTP authentication passed verbatim to requests.Session.auth.
     # Use a (username, password) tuple for Basic Auth, or an AuthBase subclass
     # (HTTPDigestAuth, custom HMAC/OAuth token injectors) for other schemes.
@@ -103,6 +151,10 @@ class HttpClientConfig:
     # override contract as default_headers: per-request params take precedence
     # on key collision.  Useful for API keys passed as query string parameters.
     default_params: Mapping[str, str] | None = None
+    # HTTP backend — "requests" (default) or "curl-cffi".  See class docstring.
+    backend: Literal["requests", "curl-cffi"] = "requests"
+    # Browser fingerprint for curl-cffi impersonation.  See class docstring.
+    impersonate: str | None = None
 
     def __post_init__(self) -> None:
         if self.retries < 0:
@@ -166,6 +218,27 @@ class HttpClientConfig:
                 "proxies",
                 MappingProxyType(dict(self.proxies)),
             )
+        if self.backend not in {"requests", "curl-cffi"}:
+            raise ValueError(
+                f"backend must be 'requests' or 'curl-cffi', got {self.backend!r}"
+            )
+        if self.backend == "curl-cffi" and self.impersonate is None:
+            raise ValueError(
+                "impersonate is required when backend='curl-cffi'; "
+                "e.g. HttpClientConfig(backend='curl-cffi', impersonate='chrome136')"
+            )
+        if self.backend == "curl-cffi" and self.impersonate is not None:
+            valid = _get_cffi_valid_impersonate()
+            if valid is not None and self.impersonate not in valid:
+                warnings.warn(
+                    f"Unknown impersonate target {self.impersonate!r}; "
+                    "it will be rejected at client construction time. "
+                    'Run `python -c "from curl_cffi.requests import '
+                    'BrowserType; print([b.value for b in BrowserType])"`'
+                    " for valid values.",
+                    UserWarning,
+                    stacklevel=3,
+                )
         if isinstance(self.auth, tuple) and len(self.auth) != 2:
             raise ValueError("auth tuple must be (username, password)")
         if self.default_params is not None:

--- a/src/ladon/networking/curl_client.py
+++ b/src/ladon/networking/curl_client.py
@@ -1,0 +1,674 @@
+"""Synchronous HTTP client backed by curl-cffi (Cloudflare bypass).
+
+Mirrors ``HttpClient`` exactly but uses ``curl_cffi.requests.Session``
+instead of ``requests.Session``, allowing TLS fingerprint impersonation
+(JA3/JA4) to bypass Cloudflare L1+L2 challenges without browser automation.
+
+Requires the optional ``cffi`` extra::
+
+    pip install ladon-crawl[cffi]
+
+If curl-cffi is not installed, importing this module succeeds but
+instantiating ``CurlHttpClient`` raises ``ImportError`` with an
+actionable message.
+
+Blast radius: if curl-cffi changes its API, only this file is affected.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from random import uniform
+from time import monotonic, sleep
+from typing import Any, Callable, Mapping, TypeVar
+from urllib.parse import urlparse
+
+try:
+    from curl_cffi import (
+        requests as _cffi,  # type: ignore[import-untyped, import-not-found]
+    )
+    from curl_cffi.requests import (
+        BrowserType as _BrowserType,  # type: ignore[import-untyped, import-not-found]
+    )
+    from curl_cffi.requests import (
+        exceptions as _cffi_exc,  # type: ignore[import-untyped, import-not-found]
+    )
+
+    _curl_cffi_available: bool = True
+    _valid_impersonate: frozenset[str] = frozenset(
+        b.value for b in _BrowserType  # type: ignore[union-attr]
+    )
+except ImportError:
+    _cffi: Any = None
+    _cffi_exc: Any = None
+    _curl_cffi_available = False
+    _valid_impersonate = frozenset()
+
+from .circuit_breaker import CircuitBreaker, CircuitState
+from .config import HttpClientConfig
+from .errors import (
+    CircuitOpenError,
+    HttpClientError,
+    RateLimitedError,
+    RequestTimeoutError,
+    RobotsBlockedError,
+    TransientNetworkError,
+)
+from .robots import RobotsCache
+from .types import Err, Ok, Result
+
+ResponseValue = TypeVar("ResponseValue")
+
+_IMPORT_ERROR_MSG = (
+    "curl-cffi is required for CurlHttpClient.\n"
+    "Install it with:  pip install ladon-crawl[cffi]"
+)
+
+
+class CurlHttpClient:
+    """Sync HTTP client with TLS fingerprint impersonation via curl-cffi.
+
+    Drop-in replacement for ``HttpClient`` for targets protected by
+    Cloudflare L1 (JS challenge) or L2 (TLS fingerprint / JA3 hash).
+    All policy (retries, rate limiting, circuit breaking, robots.txt) is
+    identical to ``HttpClient``.
+
+    Thread safety
+    -------------
+    Not thread-safe — same contract as ``HttpClient``.
+
+    Args:
+        config: Standard ``HttpClientConfig``.
+        impersonate: Browser fingerprint to impersonate.
+            Examples: ``"chrome136"``, ``"firefox147"``, ``"safari184"``.
+            Run ``python -c "from curl_cffi.requests import BrowserType;
+            print([b.value for b in BrowserType])"`` for the full list.
+    """
+
+    def __init__(self, config: HttpClientConfig, *, impersonate: str) -> None:
+        if not _curl_cffi_available:
+            raise ImportError(_IMPORT_ERROR_MSG)
+        if impersonate not in _valid_impersonate:
+            raise ValueError(
+                f"Unknown impersonate target {impersonate!r}. "
+                f'Run `python -c "from curl_cffi.requests import BrowserType; '
+                f'print([b.value for b in BrowserType])"` for valid values.'
+            )
+        if config.auth is not None and not isinstance(config.auth, tuple):
+            raise ValueError(
+                "curl-cffi only supports HTTP Basic Auth; "
+                "AuthBase subclasses (HTTPDigestAuth, custom HMAC/OAuth) are "
+                "not supported. Use default_headers={'Authorization': '...'} "
+                "for Bearer tokens or other header-based schemes."
+            )
+        self._config = config
+        self._impersonate = impersonate
+        self._session: Any = _cffi.Session(impersonate=impersonate)
+        self._last_request_time: dict[str, float] = {}
+        self._circuit_breakers: dict[str, CircuitBreaker] = {}
+        if self._config.user_agent:
+            self._session.headers["User-Agent"] = self._config.user_agent
+        self._session.headers.update(self._config.default_headers)
+        if self._config.proxies is not None:
+            self._session.proxies.update(self._config.proxies)
+        if self._config.auth is not None:
+            self._session.auth = self._config.auth
+        self._robots_cache: RobotsCache | None = (
+            RobotsCache(
+                self._session,
+                self._config.user_agent or "*",
+                fetch_timeout=self._config.timeout_seconds,
+                verify_tls=self._config.verify_tls,
+            )
+            if self._config.respect_robots_txt
+            else None
+        )
+        self._crawl_delay_overrides: dict[str, float] = {}
+
+    @property
+    def impersonate(self) -> str:
+        """The browser fingerprint this client is configured to impersonate."""
+        return self._impersonate
+
+    def close(self) -> None:
+        """Close the underlying session and release pooled connections."""
+        self._session.close()
+
+    def __enter__(self) -> CurlHttpClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def _get_timeout(
+        self, override: float | None
+    ) -> float | tuple[float, float]:
+        if override is not None:
+            if override <= 0:
+                raise ValueError("timeout override must be > 0 when provided")
+            return override
+        if (
+            self._config.connect_timeout_seconds is not None
+            and self._config.read_timeout_seconds is not None
+        ):
+            return (
+                self._config.connect_timeout_seconds,
+                self._config.read_timeout_seconds,
+            )
+        return self._config.timeout_seconds
+
+    def _max_attempts(self) -> int:
+        return 1 + max(0, self._config.retries)
+
+    def _is_retryable_exception(self, method: str, error: Any) -> bool:
+        if method.upper() not in {"GET", "HEAD"}:
+            return False
+        # SSLError subclasses ConnectionError and will be retried here; cert
+        # failures are not transient but exhausting retries is the safe default.
+        return isinstance(
+            error,
+            (_cffi_exc.Timeout, _cffi_exc.ConnectionError),
+        )
+
+    def _sleep_between_attempts(self, attempt: int) -> None:
+        backoff_base = self._config.backoff_base_seconds
+        if backoff_base <= 0:
+            return
+        cap = backoff_base * (2 ** max(0, attempt - 1))
+        sleep(uniform(0.0, cap) if self._config.backoff_jitter else cap)
+
+    @staticmethod
+    def _parse_retry_after(response: Any) -> float | None:
+        header = response.headers.get("Retry-After")
+        if header is None:
+            return None
+        try:
+            return max(0.0, float(header))
+        except ValueError:
+            pass
+        try:
+            dt: datetime = parsedate_to_datetime(str(header))
+            delta: float = (dt - datetime.now(tz=timezone.utc)).total_seconds()
+            return max(0.0, delta)
+        except Exception:
+            return None
+
+    def _sleep_for_retry_after(
+        self, retry_after: float | None, attempt: int
+    ) -> None:
+        if retry_after is not None:
+            capped = min(retry_after, self._config.max_retry_after_seconds)
+            sleep(max(capped, self._config.min_request_interval_seconds))
+        else:
+            self._sleep_between_attempts(attempt)
+
+    def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
+        self._session.proxies.clear()
+        if proxy is not None:
+            self._session.proxies.update(proxy)
+
+    def _merge_params(
+        self, params: Mapping[str, str] | None
+    ) -> Mapping[str, str] | None:
+        dp = self._config.default_params
+        if dp is None:
+            return params
+        merged = {**dp, **(params or {})}
+        return merged if merged else None
+
+    def _enforce_robots(self, url: str) -> None:
+        if self._robots_cache is None:
+            return
+        if not self._robots_cache.is_allowed(url):
+            raise RobotsBlockedError(f"robots.txt disallows: {url}")
+        delay = self._robots_cache.crawl_delay(url)
+        if delay is not None:
+            host = urlparse(url).netloc
+            current = self._config.min_request_interval_seconds
+            if delay > current:
+                self._crawl_delay_overrides[host] = delay
+
+    def _enforce_rate_limit(self, url: str) -> None:
+        host = urlparse(url).netloc
+        if not host:
+            return
+        interval = max(
+            self._config.min_request_interval_seconds,
+            self._crawl_delay_overrides.get(host, 0.0),
+        )
+        if interval <= 0:
+            return
+        last = self._last_request_time.get(host)
+        if last is not None:
+            elapsed = monotonic() - last
+            remaining = interval - elapsed
+            if remaining > 0:
+                sleep(remaining)
+
+    def _build_meta(
+        self,
+        method: str,
+        request_url: str,
+        response: Any | None,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: float | tuple[float, float] | None,
+        final_error: str | None = None,
+    ) -> dict[str, Any]:
+        meta: dict[str, Any] = {}
+        meta["method"] = method
+        meta["url"] = request_url
+        meta["attempts"] = attempts
+        meta["timeout_s"] = timeout
+        if context:
+            context_dict = dict(context)
+            meta["context"] = context_dict
+            for key, value in context_dict.items():
+                meta.setdefault(key, value)
+
+        if response is not None:
+            meta["status_code"] = response.status_code
+            meta["url"] = response.url
+            meta["reason"] = response.reason
+            try:
+                meta["elapsed_s"] = response.elapsed.total_seconds()
+            except AttributeError:
+                pass
+        if final_error is not None:
+            meta["final_error"] = final_error
+
+        return meta
+
+    def _handle_request_exception(
+        self,
+        method: str,
+        request_url: str,
+        e: Any,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: float | tuple[float, float] | None,
+    ) -> Result[Any, Exception]:
+        response = getattr(e, "response", None)
+        meta = self._build_meta(
+            method,
+            request_url,
+            response,
+            context,
+            attempts,
+            timeout,
+            final_error=type(e).__name__,
+        )
+
+        if isinstance(e, _cffi_exc.Timeout):
+            return Err(RequestTimeoutError(str(e)), meta=meta)
+
+        if isinstance(e, _cffi_exc.ConnectionError):
+            return Err(TransientNetworkError(str(e)), meta=meta)
+
+        return Err(HttpClientError(str(e)), meta=meta)
+
+    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
+        threshold = self._config.circuit_breaker_failure_threshold
+        if threshold is None:
+            return None
+        host = urlparse(url).netloc
+        if not host:
+            return None
+        if host not in self._circuit_breakers:
+            self._circuit_breakers[host] = CircuitBreaker(
+                threshold=threshold,
+                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
+            )
+        return self._circuit_breakers[host]
+
+    def circuit_state(self, url: str) -> CircuitState | None:
+        """Return the current circuit-breaker state for *url*'s host.
+
+        Returns ``None`` when circuit breaking is disabled or no request has
+        been made to the host yet.
+        """
+        cb = self._circuit_breakers.get(urlparse(url).netloc)
+        if cb is None:
+            return None
+        return cb.state
+
+    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
+        """Override the per-host crawl delay for *host*.
+
+        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
+        when the override is larger.  Intended for callers that parse a site's
+        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
+        """
+        self._crawl_delay_overrides[host] = delay_seconds
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        context: Mapping[str, Any] | None,
+        timeout: float | tuple[float, float],
+        request_fn: Callable[[], Any],
+        value_builder: Callable[[Any], ResponseValue],
+    ) -> Result[ResponseValue, Exception]:
+        cb = self._get_circuit_breaker(url)
+        if cb is not None and not cb.allow_request():
+            meta = self._build_meta(
+                method=method,
+                request_url=url,
+                response=None,
+                context=context,
+                attempts=0,
+                timeout=timeout,
+                final_error="CircuitOpenError",
+            )
+            return Err(CircuitOpenError(urlparse(url).netloc), meta=meta)
+
+        try:
+            self._enforce_robots(url)
+        except RobotsBlockedError as exc:
+            meta = self._build_meta(
+                method=method,
+                request_url=url,
+                response=None,
+                context=context,
+                attempts=0,
+                timeout=timeout,
+                final_error="RobotsBlockedError",
+            )
+            return Err(exc, meta=meta)
+
+        self._enforce_rate_limit(url)
+        host = urlparse(url).netloc
+        is_safe_method = method.upper() in {"GET", "HEAD"}
+        pool = self._config.proxy_pool
+        attempts = 0
+        last_error: Any = None
+        last_blocked_response: Any = None
+        last_blocked_retry_after: float | None = None
+        current_proxy: Mapping[str, str] | None = None
+        if pool is not None:
+            current_proxy = pool.next_proxy()
+            self._apply_proxy(current_proxy)
+        for _ in range(self._max_attempts()):
+            attempts += 1
+            try:
+                response = request_fn()
+                if (
+                    response.status_code in self._config.retry_on_status
+                    and is_safe_method
+                ):
+                    last_blocked_retry_after = self._parse_retry_after(response)
+                    last_blocked_response = response
+                    last_error = None
+                    if attempts < self._max_attempts():
+                        if pool is not None:
+                            pool.mark_failure(current_proxy)
+                            current_proxy = pool.next_proxy()
+                            self._apply_proxy(current_proxy)
+                        self._sleep_for_retry_after(
+                            last_blocked_retry_after, attempts
+                        )
+                        continue
+                    break
+                if cb is not None:
+                    cb.record_success()
+                return Ok(
+                    value_builder(response),
+                    meta=self._build_meta(
+                        method=method,
+                        request_url=url,
+                        response=response,
+                        context=context,
+                        attempts=attempts,
+                        timeout=timeout,
+                    ),
+                )
+            except _cffi_exc.RequestException as exc:
+                last_error = exc
+                last_blocked_response = None
+                last_blocked_retry_after = None
+                if (
+                    attempts >= self._max_attempts()
+                    or not self._is_retryable_exception(method, exc)
+                ):
+                    break
+                if pool is not None:
+                    pool.mark_failure(current_proxy)
+                    current_proxy = pool.next_proxy()
+                    self._apply_proxy(current_proxy)
+                self._sleep_between_attempts(attempts)
+            except Exception as exc:  # pragma: no cover - defensive fallback
+                if cb is not None:
+                    cb.record_failure()
+                return Err(
+                    HttpClientError(str(exc)),
+                    meta=self._build_meta(
+                        method=method,
+                        request_url=url,
+                        response=None,
+                        context=context,
+                        attempts=attempts,
+                        timeout=timeout,
+                        final_error=type(exc).__name__,
+                    ),
+                )
+            finally:
+                if host:
+                    self._last_request_time[host] = monotonic()
+
+        if last_blocked_response is not None:
+            if cb is not None:
+                cb.record_failure()
+            if pool is not None:
+                pool.mark_failure(current_proxy)
+            return Err(
+                RateLimitedError(
+                    last_blocked_response.status_code, last_blocked_retry_after
+                ),
+                meta=self._build_meta(
+                    method=method,
+                    request_url=url,
+                    response=last_blocked_response,
+                    context=context,
+                    attempts=attempts,
+                    timeout=timeout,
+                    final_error="RateLimitedError",
+                ),
+            )
+
+        assert last_error is not None
+        if cb is not None:
+            cb.record_failure()
+        if pool is not None:
+            pool.mark_failure(current_proxy)
+        return self._handle_request_exception(
+            method=method,
+            request_url=url,
+            e=last_error,
+            context=context,
+            attempts=attempts,
+            timeout=timeout,
+        )
+
+    @staticmethod
+    def _content_value(response: Any) -> bytes:
+        return response.content  # type: ignore[no-any-return]
+
+    @staticmethod
+    def _headers_value(response: Any) -> Mapping[str, Any]:
+        return dict(response.headers)
+
+    @staticmethod
+    def _response_value(response: Any) -> Any:
+        return response
+
+    def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[bytes, Exception]:
+        """Perform an HTTP GET request.
+
+        Args:
+            url: Absolute URL to request.
+            headers: Optional per-request headers merged with defaults.
+            params: Optional query parameters.
+            timeout: Override timeout in seconds for this request.
+            allow_redirects: Whether redirects should be followed.
+            context: Optional caller context for logging/tracing.
+
+        Returns:
+            Result containing response bytes on success, or an error on failure.
+        """
+        resolved_timeout = self._get_timeout(timeout)
+        return self._request(
+            method="GET",
+            url=url,
+            context=context,
+            timeout=resolved_timeout,
+            request_fn=lambda: self._session.get(
+                url,
+                headers=headers,
+                params=self._merge_params(params),
+                timeout=resolved_timeout,
+                allow_redirects=allow_redirects,
+                verify=self._config.verify_tls,
+            ),
+            value_builder=self._content_value,
+        )
+
+    def head(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[Mapping[str, Any], Exception]:
+        """Perform an HTTP HEAD request.
+
+        Args:
+            url: Absolute URL to request.
+            headers: Optional per-request headers merged with defaults.
+            params: Optional query parameters.
+            timeout: Override timeout in seconds for this request.
+            allow_redirects: Whether redirects should be followed.
+            context: Optional caller context for logging/tracing.
+
+        Returns:
+            Result containing response metadata on success, or an error on
+            failure.
+        """
+        resolved_timeout = self._get_timeout(timeout)
+        return self._request(
+            method="HEAD",
+            url=url,
+            context=context,
+            timeout=resolved_timeout,
+            request_fn=lambda: self._session.head(
+                url,
+                headers=headers,
+                params=self._merge_params(params),
+                timeout=resolved_timeout,
+                allow_redirects=allow_redirects,
+                verify=self._config.verify_tls,
+            ),
+            value_builder=self._headers_value,
+        )
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        data: Any | None = None,
+        json: Any | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[bytes, Exception]:
+        """Perform an HTTP POST request.
+
+        Args:
+            url: Absolute URL to request.
+            headers: Optional per-request headers merged with defaults.
+            params: Optional query parameters.
+            data: Optional form/body payload.
+            json: Optional JSON payload (mutually exclusive with data).
+            timeout: Override timeout in seconds for this request.
+            allow_redirects: Whether redirects should be followed.
+            context: Optional caller context for logging/tracing.
+
+        Returns:
+            Result containing response bytes on success, or an error on failure.
+        """
+        resolved_timeout = self._get_timeout(timeout)
+        return self._request(
+            method="POST",
+            url=url,
+            context=context,
+            timeout=resolved_timeout,
+            request_fn=lambda: self._session.post(
+                url,
+                headers=headers,
+                params=self._merge_params(params),
+                data=data,
+                json=json,
+                timeout=resolved_timeout,
+                allow_redirects=allow_redirects,
+                verify=self._config.verify_tls,
+            ),
+            value_builder=self._content_value,
+        )
+
+    def download(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[Any, Exception]:
+        """Stream a download request.
+
+        Args:
+            url: Absolute URL to request.
+            headers: Optional per-request headers merged with defaults.
+            params: Optional query parameters.
+            timeout: Override timeout in seconds for this request.
+            allow_redirects: Whether redirects should be followed.
+            context: Optional caller context for logging/tracing.
+
+        Returns:
+            Result containing a curl-cffi response object with ``iter_content``
+            and ``iter_lines`` for streaming, or an error on failure.
+        """
+        resolved_timeout = self._get_timeout(timeout)
+        return self._request(
+            method="GET",
+            url=url,
+            context=context,
+            timeout=resolved_timeout,
+            request_fn=lambda: self._session.get(
+                url,
+                headers=headers,
+                params=self._merge_params(params),
+                timeout=resolved_timeout,
+                allow_redirects=allow_redirects,
+                stream=True,
+                verify=self._config.verify_tls,
+            ),
+            value_builder=self._response_value,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+# pyright: reportUnknownMemberType=false, reportUnusedFunction=false
+from collections.abc import Generator
+
+import pytest
+
+import ladon.networking.config as _cfg
+
+
+@pytest.fixture(autouse=True)
+def _reset_cffi_impersonate_cache() -> Generator[None, None, None]:
+    """Reset the module-level curl-cffi BrowserType cache between tests.
+
+    Prevents a test that mutates ladon.networking.config._cffi_valid_impersonate
+    from poisoning the cache seen by later tests in the same process.
+    """
+    _cfg._cffi_valid_impersonate = None  # type: ignore[attr-defined]
+    yield
+    _cfg._cffi_valid_impersonate = None  # type: ignore[attr-defined]

--- a/tests/test_async_curl_client.py
+++ b/tests/test_async_curl_client.py
@@ -1,0 +1,704 @@
+# pyright: reportUnknownParameterType=false, reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false, reportMissingParameterType=false
+# pyright: reportUnknownArgumentType=false, reportPrivateUsage=false
+"""Tests for AsyncCurlHttpClient — the curl-cffi async backend.
+
+Mirrors test_async_client.py in structure and coverage. curl-cffi's
+AsyncSession is mocked with AsyncMock (same pattern as test_curl_client.py
+but with async callables) so no live network calls are made.
+
+All tests are async (asyncio_mode = "auto" in pyproject.toml).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+pytest.importorskip(
+    "curl_cffi"
+)  # skip entire module when [cffi] extra not installed
+from curl_cffi.requests import exceptions as cffi_exc  # noqa: E402
+
+from ladon.networking.async_curl_client import AsyncCurlHttpClient
+from ladon.networking.config import HttpClientConfig
+from ladon.networking.errors import (
+    CircuitOpenError,
+    HttpClientError,
+    RateLimitedError,
+    RequestTimeoutError,
+    TransientNetworkError,
+)
+from ladon.networking.proxy_pool import RoundRobinProxyPool
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(
+    *,
+    content: bytes = b"",
+    status: int = 200,
+    url: str = "http://example.com",
+    reason: str = "OK",
+) -> Mock:
+    response = Mock()
+    response.content = content
+    response.status_code = status
+    response.url = url
+    response.reason = reason
+    response.elapsed.total_seconds.return_value = 0.1
+    response.headers = {"Content-Type": "application/json"}
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config() -> HttpClientConfig:
+    return HttpClientConfig(
+        user_agent="TestAgent/1.0",
+        default_headers={"X-Test": "yes"},
+        timeout_seconds=5.0,
+    )
+
+
+@pytest.fixture
+async def client(
+    config: HttpClientConfig,
+) -> AsyncGenerator[AsyncCurlHttpClient, None]:
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Construction guardrails
+# ---------------------------------------------------------------------------
+
+
+def test_import_error_when_curl_cffi_unavailable(
+    config: HttpClientConfig,
+) -> None:
+    import ladon.networking.async_curl_client as m
+
+    original = m._curl_cffi_available
+    m._curl_cffi_available = False
+    try:
+        with pytest.raises(
+            ImportError, match="pip install ladon-crawl\\[cffi\\]"
+        ):
+            AsyncCurlHttpClient(config, impersonate="chrome136")
+    finally:
+        m._curl_cffi_available = original
+
+
+def test_respect_robots_raises_not_implemented() -> None:
+    with pytest.raises(NotImplementedError, match="respect_robots_txt"):
+        AsyncCurlHttpClient(
+            HttpClientConfig(respect_robots_txt=True), impersonate="chrome136"
+        )
+
+
+def test_invalid_impersonate_raises_value_error(
+    config: HttpClientConfig,
+) -> None:
+    with pytest.raises(ValueError, match="notabrowser"):
+        AsyncCurlHttpClient(config, impersonate="notabrowser")
+
+
+def test_impersonate_property(config: HttpClientConfig) -> None:
+    client = AsyncCurlHttpClient(config, impersonate="chrome136")
+    assert client.impersonate == "chrome136"
+
+
+def test_authbase_raises_value_error() -> None:
+    from requests.auth import HTTPDigestAuth
+
+    config = HttpClientConfig(
+        auth=HTTPDigestAuth("user", "pass"), timeout_seconds=5.0
+    )
+    with pytest.raises(
+        ValueError, match="curl-cffi only supports HTTP Basic Auth"
+    ):
+        AsyncCurlHttpClient(config, impersonate="chrome136")
+
+
+def test_basic_auth_tuple_accepted() -> None:
+    config = HttpClientConfig(auth=("user", "pass"), timeout_seconds=5.0)
+    client = AsyncCurlHttpClient(config, impersonate="chrome136")
+    assert client.impersonate == "chrome136"
+
+
+# ---------------------------------------------------------------------------
+# Context manager & lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_context_manager_closes_session(config: HttpClientConfig) -> None:
+    closed: list[bool] = []
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        original_close = c._session.close
+        c._session.close = AsyncMock(side_effect=lambda: closed.append(True))
+    assert closed == [True]
+    c._session.close = original_close
+
+
+async def test_context_manager_returns_client_instance(
+    config: HttpClientConfig,
+) -> None:
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        assert isinstance(c, AsyncCurlHttpClient)
+
+
+async def test_init_sets_user_agent_and_default_headers(
+    client: AsyncCurlHttpClient,
+) -> None:
+    assert client._session.headers["User-Agent"] == "TestAgent/1.0"
+    assert client._session.headers["X-Test"] == "yes"
+
+
+# ---------------------------------------------------------------------------
+# GET
+# ---------------------------------------------------------------------------
+
+
+async def test_get_success_returns_normalized_metadata(
+    client: AsyncCurlHttpClient,
+) -> None:
+    client._session.get = AsyncMock(
+        return_value=_mock_response(content=b"hello")
+    )
+
+    result = await client.get("http://example.com")
+
+    assert result.ok
+    assert result.value == b"hello"
+    assert result.meta["method"] == "GET"
+    assert result.meta["url"] == "http://example.com"
+    assert result.meta["status_code"] == 200
+    assert result.meta["attempts"] == 1
+    assert result.meta["timeout_s"] == 5.0
+    assert result.meta["elapsed_s"] == 0.1
+    client._session.get.assert_awaited_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        timeout=5.0,
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+async def test_get_uses_override_timeout(client: AsyncCurlHttpClient) -> None:
+    client._session.get = AsyncMock(
+        return_value=_mock_response(content=b"hello")
+    )
+
+    result = await client.get("http://example.com", timeout=2.5)
+
+    assert result.ok
+    assert result.meta["timeout_s"] == 2.5
+    client._session.get.assert_awaited_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        timeout=2.5,
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+async def test_get_rejects_non_positive_timeout_override(
+    client: AsyncCurlHttpClient,
+) -> None:
+    with pytest.raises(ValueError):
+        await client.get("http://example.com", timeout=0)
+    with pytest.raises(ValueError):
+        await client.get("http://example.com", timeout=-1)
+
+
+async def test_get_uses_connect_read_timeout_tuple() -> None:
+    config = HttpClientConfig(
+        connect_timeout_seconds=1.0,
+        read_timeout_seconds=3.0,
+    )
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(return_value=_mock_response(content=b"ok"))
+
+        result = await c.get("http://example.com")
+
+        assert result.ok
+        assert result.meta["timeout_s"] == (1.0, 3.0)
+        c._session.get.assert_awaited_once_with(
+            "http://example.com",
+            headers=None,
+            params=None,
+            timeout=(1.0, 3.0),
+            allow_redirects=True,
+            verify=True,
+        )
+
+
+async def test_get_respects_verify_tls_false() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, verify_tls=False)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(return_value=_mock_response(content=b"ok"))
+
+        result = await c.get("http://example.com")
+
+        assert result.ok
+        c._session.get.assert_awaited_once_with(
+            "http://example.com",
+            headers=None,
+            params=None,
+            timeout=5.0,
+            allow_redirects=True,
+            verify=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_get_timeout_retries_and_tracks_attempts() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=2)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(side_effect=cffi_exc.Timeout("timed out"))
+
+        result = await c.get("http://example.com")
+
+        assert not result.ok
+        assert isinstance(result.error, RequestTimeoutError)
+        assert result.meta["attempts"] == 3
+        assert result.meta["final_error"] == "Timeout"
+        assert c._session.get.await_count == 3
+
+
+async def test_connection_error_retried_internally() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=1)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(
+            side_effect=cffi_exc.ConnectionError("refused")
+        )
+
+        result = await c.get("http://example.com")
+
+        assert not result.ok
+        assert isinstance(result.error, TransientNetworkError)
+        assert result.meta["attempts"] == 2
+        assert result.meta["final_error"] == "ConnectionError"
+
+
+async def test_generic_request_exception_does_not_retry() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=3)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(
+            side_effect=cffi_exc.RequestException("boom")
+        )
+
+        result = await c.get("http://example.com")
+
+        assert not result.ok
+        assert isinstance(result.error, HttpClientError)
+        assert result.meta["attempts"] == 1
+        assert c._session.get.await_count == 1
+
+
+async def test_post_timeout_is_not_retried() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=3)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.post = AsyncMock(side_effect=cffi_exc.Timeout("timed out"))
+
+        result = await c.post("http://example.com", json={"foo": "bar"})
+
+        assert not result.ok
+        assert isinstance(result.error, RequestTimeoutError)
+        assert result.meta["attempts"] == 1
+        assert c._session.post.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# HEAD / POST / download
+# ---------------------------------------------------------------------------
+
+
+async def test_head_success_returns_headers(
+    client: AsyncCurlHttpClient,
+) -> None:
+    client._session.head = AsyncMock(return_value=_mock_response(content=b""))
+
+    result = await client.head("http://example.com")
+
+    assert result.ok
+    assert result.value == {"Content-Type": "application/json"}
+    assert result.meta["method"] == "HEAD"
+    client._session.head.assert_awaited_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        timeout=5.0,
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+async def test_post_success(client: AsyncCurlHttpClient) -> None:
+    client._session.post = AsyncMock(
+        return_value=_mock_response(content=b"created", status=201)
+    )
+
+    result = await client.post("http://example.com", json={"foo": "bar"})
+
+    assert result.ok
+    assert result.value == b"created"
+    assert result.meta["method"] == "POST"
+    assert result.meta["status_code"] == 201
+    client._session.post.assert_awaited_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        data=None,
+        json={"foo": "bar"},
+        timeout=5.0,
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+async def test_download_success(client: AsyncCurlHttpClient) -> None:
+    mock_response = _mock_response(url="http://example.com/file")
+    client._session.get = AsyncMock(return_value=mock_response)
+
+    result = await client.download("http://example.com/file")
+
+    assert result.ok
+    assert result.value is mock_response
+    assert result.meta["method"] == "GET"
+    client._session.get.assert_awaited_once_with(
+        "http://example.com/file",
+        headers=None,
+        params=None,
+        timeout=5.0,
+        allow_redirects=True,
+        stream=True,
+        verify=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Context / metadata
+# ---------------------------------------------------------------------------
+
+
+async def test_context_is_merged_into_metadata(
+    client: AsyncCurlHttpClient,
+) -> None:
+    client._session.get = AsyncMock(return_value=_mock_response(content=b"ok"))
+
+    result = await client.get(
+        "http://example.com",
+        context={"house": "sothebys", "crawler": "canary"},
+    )
+
+    assert result.ok
+    assert result.meta["house"] == "sothebys"
+    assert result.meta["crawler"] == "canary"
+    assert result.meta["context"] == {"house": "sothebys", "crawler": "canary"}
+
+
+async def test_context_cannot_override_canonical_metadata(
+    client: AsyncCurlHttpClient,
+) -> None:
+    client._session.get = AsyncMock(
+        return_value=_mock_response(
+            content=b"ok", url="http://response.example"
+        )
+    )
+
+    result = await client.get(
+        "http://example.com",
+        context={"url": "http://context.example", "method": "PATCH"},
+    )
+
+    assert result.ok
+    assert result.meta["url"] == "http://response.example"
+    assert result.meta["method"] == "GET"
+    assert result.meta["context"]["url"] == "http://context.example"
+    assert result.meta["context"]["method"] == "PATCH"
+
+
+# ---------------------------------------------------------------------------
+# ImpersonateError
+# ---------------------------------------------------------------------------
+
+
+async def test_impersonate_error_returns_http_client_error(
+    client: AsyncCurlHttpClient,
+) -> None:
+    """ImpersonateError (a RequestException subclass) maps to HttpClientError."""
+    client._session.get = AsyncMock(
+        side_effect=cffi_exc.ImpersonateError("impersonation failed")
+    )
+
+    result = await client.get("http://example.com")
+
+    assert not result.ok
+    assert isinstance(result.error, HttpClientError)
+    assert "impersonation failed" in str(result.error)
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit (429 / 503)
+# ---------------------------------------------------------------------------
+
+
+async def test_rate_limit_exhausted_returns_error() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=1)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(
+            side_effect=[
+                _mock_response(
+                    status=429, content=b"", reason="Too Many Requests"
+                ),
+                _mock_response(
+                    status=429, content=b"", reason="Too Many Requests"
+                ),
+            ]
+        )
+
+        result = await c.get("http://example.com")
+
+    assert not result.ok
+    assert isinstance(result.error, RateLimitedError)
+    assert result.error.status_code == 429
+    assert c._session.get.await_count == 2
+
+
+async def test_rate_limit_retry_then_success() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=1)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(
+            side_effect=[
+                _mock_response(
+                    status=429, content=b"", reason="Too Many Requests"
+                ),
+                _mock_response(content=b"ok"),
+            ]
+        )
+
+        result = await c.get("http://example.com")
+
+    assert result.ok
+    assert result.value == b"ok"
+    assert c._session.get.await_count == 2
+
+
+async def test_post_429_not_retried() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=2)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.post = AsyncMock(
+            return_value=_mock_response(
+                status=429, content=b"", reason="Too Many Requests"
+            )
+        )
+
+        result = await c.post("http://example.com")
+
+    assert result.ok
+    assert result.meta["status_code"] == 429
+    assert result.meta["attempts"] == 1
+    assert c._session.post.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+async def test_circuit_breaker_opens_after_threshold() -> None:
+    config = HttpClientConfig(
+        timeout_seconds=5.0,
+        circuit_breaker_failure_threshold=2,
+        circuit_breaker_recovery_seconds=60.0,
+    )
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(
+            side_effect=cffi_exc.ConnectionError("refused")
+        )
+
+        await c.get("http://example.com")
+        await c.get("http://example.com")
+        result = await c.get("http://example.com")
+
+    assert not result.ok
+    assert isinstance(result.error, CircuitOpenError)
+    assert result.meta["attempts"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Proxy pool
+# ---------------------------------------------------------------------------
+
+
+async def test_proxy_pool_rotation() -> None:
+    pool = RoundRobinProxyPool(
+        [{"https": "http://proxy1:8080"}, {"https": "http://proxy2:8080"}]
+    )
+    config = HttpClientConfig(proxy_pool=pool, timeout_seconds=5.0)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(return_value=_mock_response(content=b"ok"))
+
+        r1 = await c.get("http://example.com")
+        r2 = await c.get("http://example.com")
+
+    assert r1.ok and r2.ok
+
+
+# ---------------------------------------------------------------------------
+# default_params / auth
+# ---------------------------------------------------------------------------
+
+
+def test_per_request_params_override_defaults() -> None:
+    config = HttpClientConfig(
+        default_params={"api_key": "abc", "v": "1"}, timeout_seconds=5.0
+    )
+    c = AsyncCurlHttpClient(config, impersonate="chrome136")
+    merged = c._merge_params({"v": "2"})
+    assert merged == {"api_key": "abc", "v": "2"}
+
+
+async def test_default_params_merged_into_request(
+    client: AsyncCurlHttpClient,
+) -> None:
+    client._session.get = AsyncMock(return_value=_mock_response(content=b"ok"))
+
+    result = await client.get("http://example.com", params={"extra": "1"})
+
+    assert result.ok
+    client._session.get.assert_awaited_once_with(
+        "http://example.com",
+        headers=None,
+        params={"extra": "1"},
+        timeout=5.0,
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+def test_auth_wired_to_session() -> None:
+    cfg = HttpClientConfig(auth=("user", "secret"), timeout_seconds=5.0)
+    c = AsyncCurlHttpClient(cfg, impersonate="chrome136")
+    assert c._session.auth == ("user", "secret")
+
+
+# ---------------------------------------------------------------------------
+# set_crawl_delay
+# ---------------------------------------------------------------------------
+
+
+async def test_set_crawl_delay_stored(config: HttpClientConfig) -> None:
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c.set_crawl_delay("example.com", 2.5)
+        assert c._crawl_delay_overrides["example.com"] == 2.5
+
+
+async def test_set_crawl_delay_overwrites(config: HttpClientConfig) -> None:
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c.set_crawl_delay("example.com", 1.0)
+        c.set_crawl_delay("example.com", 3.0)
+        assert c._crawl_delay_overrides["example.com"] == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Backoff jitter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backoff_with_jitter_calls_sleep() -> None:
+    config = HttpClientConfig(
+        timeout_seconds=5.0,
+        retries=1,
+        backoff_base_seconds=1.0,
+        backoff_jitter=True,
+    )
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(
+            side_effect=[
+                cffi_exc.ConnectionError("refused"),
+                _mock_response(content=b"ok"),
+            ]
+        )
+        with patch(
+            "ladon.networking.async_curl_client.asyncio.sleep"
+        ) as mock_sleep:
+            mock_sleep.return_value = None
+            result = await c.get("http://example.com")
+
+    assert result.ok
+    mock_sleep.assert_called_once()
+    slept_for = mock_sleep.call_args[0][0]
+    assert 0.0 <= slept_for <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Retry-After as HTTP-date
+# ---------------------------------------------------------------------------
+
+
+async def test_retry_after_as_http_date_triggers_retry() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=1)
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        past_date_resp = _mock_response(status=429, reason="Too Many Requests")
+        past_date_resp.headers = {
+            "Retry-After": "Wed, 01 Jan 2020 00:00:00 GMT"
+        }
+        c._session.get = AsyncMock(
+            side_effect=[past_date_resp, _mock_response(content=b"ok")]
+        )
+
+        result = await c.get("http://example.com")
+
+    assert result.ok
+    assert result.value == b"ok"
+    assert c._session.get.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Per-host rate-limit sleep
+# ---------------------------------------------------------------------------
+
+
+async def test_rate_limit_sleep_enforced() -> None:
+    config = HttpClientConfig(
+        min_request_interval_seconds=2.0, timeout_seconds=5.0
+    )
+    async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
+        c._session.get = AsyncMock(return_value=_mock_response(content=b"ok"))
+        # Interval is measured end-to-start: timestamp written in finally after each attempt.
+        # First get() completes  → finally records 1000.0
+        # Second get() enforces  → now=1000.5, elapsed=0.5, remaining=1.5 → sleep(1.5)
+        # Second get() completes → finally records 1001.0
+        with (
+            patch(
+                "ladon.networking.async_curl_client.monotonic",
+                side_effect=[1000.0, 1000.5, 1001.0],
+            ),
+            patch(
+                "ladon.networking.async_curl_client.asyncio.sleep"
+            ) as mock_sleep,
+        ):
+            mock_sleep.return_value = None
+            await c.get("http://example.com")
+            await c.get("http://example.com")
+
+    mock_sleep.assert_called_once_with(pytest.approx(1.5, abs=1e-9))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -314,3 +314,19 @@ def test_context_cannot_override_canonical_metadata(mock_get, client):
     assert result.meta["method"] == "GET"
     assert result.meta["context"]["url"] == "http://context.example"
     assert result.meta["context"]["method"] == "PATCH"
+
+
+# ---------------------------------------------------------------------------
+# set_crawl_delay
+# ---------------------------------------------------------------------------
+
+
+def test_set_crawl_delay_stored(client):
+    client.set_crawl_delay("example.com", 2.5)
+    assert client._crawl_delay_overrides["example.com"] == 2.5
+
+
+def test_set_crawl_delay_overwrites(client):
+    client.set_crawl_delay("example.com", 1.0)
+    client.set_crawl_delay("example.com", 3.0)
+    assert client._crawl_delay_overrides["example.com"] == 3.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,8 @@ def test_config_defaults_are_stable():
     assert config.proxy_pool is None
     assert config.auth is None
     assert config.default_params is None
+    assert config.backend == "requests"
+    assert config.impersonate is None
 
 
 def test_config_default_headers_are_independent():
@@ -112,3 +114,51 @@ def test_config_rejects_invalid_retry_on_status_values():
         HttpClientConfig(retry_on_status=frozenset({99}))
     with pytest.raises(ValueError, match="retry_on_status"):
         HttpClientConfig(retry_on_status=frozenset({600}))
+
+
+# ---------------------------------------------------------------------------
+# backend / impersonate
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults_backend_requests():
+    config = HttpClientConfig()
+    assert config.backend == "requests"
+    assert config.impersonate is None
+
+
+def test_config_curl_cffi_backend_requires_impersonate():
+    with pytest.raises(ValueError, match="impersonate"):
+        HttpClientConfig(backend="curl-cffi")
+
+
+def test_config_curl_cffi_backend_with_impersonate_accepted():
+    config = HttpClientConfig(backend="curl-cffi", impersonate="chrome136")
+    assert config.backend == "curl-cffi"
+    assert config.impersonate == "chrome136"
+
+
+def test_config_impersonate_without_curl_cffi_backend_accepted():
+    # Storing an impersonate value with the default backend is allowed —
+    # make_http_client / make_async_http_client will ignore it.
+    config = HttpClientConfig(impersonate="chrome136")
+    assert config.backend == "requests"
+    assert config.impersonate == "chrome136"
+
+
+def test_config_unknown_impersonate_warns_when_curl_cffi_installed():
+    pytest.importorskip("curl_cffi", reason="curl-cffi not installed")
+    with pytest.warns(UserWarning, match="Unknown impersonate target"):
+        config = HttpClientConfig(
+            backend="curl-cffi", impersonate="notabrowser999"
+        )
+    assert config.impersonate == "notabrowser999"  # still accepted
+
+
+def test_config_valid_impersonate_does_not_warn():
+    pytest.importorskip("curl_cffi", reason="curl-cffi not installed")
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        HttpClientConfig(backend="curl-cffi", impersonate="chrome136")

--- a/tests/test_curl_client.py
+++ b/tests/test_curl_client.py
@@ -1,0 +1,713 @@
+# pyright: reportUnknownParameterType=false, reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false, reportMissingParameterType=false
+# pyright: reportUnknownArgumentType=false, reportPrivateUsage=false
+"""Tests for CurlHttpClient — the curl-cffi sync backend.
+
+Mirrors test_client.py in structure and coverage. curl-cffi's Session is
+mocked at the class level (same technique used for requests.Session) so no
+live network calls are made.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+pytest.importorskip(
+    "curl_cffi"
+)  # skip entire module when [cffi] extra not installed
+from curl_cffi.requests import exceptions as cffi_exc  # noqa: E402
+
+from ladon.networking.config import HttpClientConfig
+from ladon.networking.curl_client import CurlHttpClient
+from ladon.networking.errors import (
+    CircuitOpenError,
+    HttpClientError,
+    RateLimitedError,
+    RequestTimeoutError,
+    RobotsBlockedError,
+    TransientNetworkError,
+)
+from ladon.networking.proxy_pool import RoundRobinProxyPool
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(
+    *,
+    content: bytes = b"",
+    status: int = 200,
+    url: str = "http://example.com",
+    reason: str = "OK",
+) -> Mock:
+    response = Mock()
+    response.content = content
+    response.status_code = status
+    response.url = url
+    response.reason = reason
+    response.elapsed.total_seconds.return_value = 0.1
+    response.headers = {"Content-Type": "application/json"}
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config() -> HttpClientConfig:
+    return HttpClientConfig(
+        user_agent="TestAgent/1.0",
+        default_headers={"X-Test": "yes"},
+        timeout_seconds=5.0,
+    )
+
+
+@pytest.fixture
+def client(config: HttpClientConfig) -> CurlHttpClient:
+    return CurlHttpClient(config, impersonate="chrome136")
+
+
+# ---------------------------------------------------------------------------
+# Import guard & validation
+# ---------------------------------------------------------------------------
+
+
+def test_import_error_when_curl_cffi_unavailable(
+    config: HttpClientConfig,
+) -> None:
+    import ladon.networking.curl_client as m
+
+    original = m._curl_cffi_available
+    m._curl_cffi_available = False
+    try:
+        with pytest.raises(
+            ImportError, match="pip install ladon-crawl\\[cffi\\]"
+        ):
+            CurlHttpClient(config, impersonate="chrome136")
+    finally:
+        m._curl_cffi_available = original
+
+
+def test_invalid_impersonate_raises_value_error(
+    config: HttpClientConfig,
+) -> None:
+    with pytest.raises(ValueError, match="notabrowser"):
+        CurlHttpClient(config, impersonate="notabrowser")
+
+
+def test_valid_impersonate_does_not_raise(config: HttpClientConfig) -> None:
+    client = CurlHttpClient(config, impersonate="chrome136")
+    client.close()
+
+
+def test_authbase_raises_value_error() -> None:
+    from requests.auth import HTTPDigestAuth
+
+    config = HttpClientConfig(
+        auth=HTTPDigestAuth("user", "pass"), timeout_seconds=5.0
+    )
+    with pytest.raises(
+        ValueError, match="curl-cffi only supports HTTP Basic Auth"
+    ):
+        CurlHttpClient(config, impersonate="chrome136")
+
+
+def test_basic_auth_tuple_accepted() -> None:
+    config = HttpClientConfig(auth=("user", "pass"), timeout_seconds=5.0)
+    client = CurlHttpClient(config, impersonate="chrome136")
+    client.close()
+
+
+def test_impersonate_property(client: CurlHttpClient) -> None:
+    assert client.impersonate == "chrome136"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_close_closes_session(config: HttpClientConfig) -> None:
+    with patch("curl_cffi.requests.Session.close") as mock_close:
+        c = CurlHttpClient(config, impersonate="chrome136")
+        c.close()
+    mock_close.assert_called_once()
+
+
+def test_context_manager_closes_session_on_exit(
+    config: HttpClientConfig,
+) -> None:
+    with patch("curl_cffi.requests.Session.close") as mock_close:
+        with CurlHttpClient(config, impersonate="chrome136"):
+            pass
+    mock_close.assert_called_once()
+
+
+def test_context_manager_returns_client_instance(
+    config: HttpClientConfig,
+) -> None:
+    with CurlHttpClient(config, impersonate="chrome136") as c:
+        assert isinstance(c, CurlHttpClient)
+
+
+def test_init_sets_user_agent_and_default_headers(
+    client: CurlHttpClient,
+) -> None:
+    assert client._session.headers["User-Agent"] == "TestAgent/1.0"
+    assert client._session.headers["X-Test"] == "yes"
+
+
+# ---------------------------------------------------------------------------
+# GET
+# ---------------------------------------------------------------------------
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_get_success_returns_normalized_metadata(
+    mock_get: Mock, client: CurlHttpClient
+) -> None:
+    mock_get.return_value = _mock_response(content=b"hello")
+
+    result = client.get("http://example.com")
+
+    assert result.ok
+    assert result.value == b"hello"
+    assert result.meta["method"] == "GET"
+    assert result.meta["url"] == "http://example.com"
+    assert result.meta["status_code"] == 200
+    assert result.meta["attempts"] == 1
+    assert result.meta["timeout_s"] == 5.0
+    assert result.meta["elapsed_s"] == 0.1
+    mock_get.assert_called_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        timeout=5.0,
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_get_uses_override_timeout(
+    mock_get: Mock, client: CurlHttpClient
+) -> None:
+    mock_get.return_value = _mock_response(content=b"hello")
+
+    result = client.get("http://example.com", timeout=2.5)
+
+    assert result.ok
+    assert result.meta["timeout_s"] == 2.5
+    mock_get.assert_called_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        timeout=2.5,
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+def test_get_rejects_non_positive_timeout_override(
+    client: CurlHttpClient,
+) -> None:
+    with pytest.raises(ValueError):
+        client.get("http://example.com", timeout=0)
+    with pytest.raises(ValueError):
+        client.get("http://example.com", timeout=-1)
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_get_uses_connect_read_timeout_tuple(mock_get: Mock) -> None:
+    config = HttpClientConfig(
+        connect_timeout_seconds=1.0,
+        read_timeout_seconds=3.0,
+    )
+    c = CurlHttpClient(config, impersonate="chrome136")
+    mock_get.return_value = _mock_response(content=b"ok")
+
+    result = c.get("http://example.com")
+
+    assert result.ok
+    assert result.meta["timeout_s"] == (1.0, 3.0)
+    mock_get.assert_called_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        timeout=(1.0, 3.0),
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_get_respects_verify_tls_false(mock_get: Mock) -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, verify_tls=False)
+    c = CurlHttpClient(config, impersonate="chrome136")
+    mock_get.return_value = _mock_response(content=b"ok")
+
+    result = c.get("http://example.com")
+
+    assert result.ok
+    mock_get.assert_called_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        timeout=5.0,
+        allow_redirects=True,
+        verify=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour
+# ---------------------------------------------------------------------------
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_get_timeout_retries_and_tracks_attempts(mock_get: Mock) -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=2)
+    c = CurlHttpClient(config, impersonate="chrome136")
+    mock_get.side_effect = cffi_exc.Timeout("Timed out")
+
+    result = c.get("http://example.com")
+
+    assert not result.ok
+    assert isinstance(result.error, RequestTimeoutError)
+    assert result.meta["attempts"] == 3
+    assert result.meta["final_error"] == "Timeout"
+    assert mock_get.call_count == 3
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_connection_error_retried_internally(mock_get: Mock) -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=1)
+    c = CurlHttpClient(config, impersonate="chrome136")
+    mock_get.side_effect = cffi_exc.ConnectionError("refused")
+
+    result = c.get("http://example.com")
+
+    assert not result.ok
+    assert isinstance(result.error, TransientNetworkError)
+    assert result.meta["attempts"] == 2
+    assert result.meta["final_error"] == "ConnectionError"
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_generic_request_exception_does_not_retry(mock_get: Mock) -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=3)
+    c = CurlHttpClient(config, impersonate="chrome136")
+    mock_get.side_effect = cffi_exc.RequestException("boom")
+
+    result = c.get("http://example.com")
+
+    assert not result.ok
+    assert isinstance(result.error, HttpClientError)
+    assert result.meta["attempts"] == 1
+    assert mock_get.call_count == 1
+
+
+@patch("curl_cffi.requests.Session.post")
+def test_post_timeout_is_not_retried(mock_post: Mock) -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=3)
+    c = CurlHttpClient(config, impersonate="chrome136")
+    mock_post.side_effect = cffi_exc.Timeout("Timed out")
+
+    result = c.post("http://example.com", json={"foo": "bar"})
+
+    assert not result.ok
+    assert isinstance(result.error, RequestTimeoutError)
+    assert result.meta["attempts"] == 1
+    assert mock_post.call_count == 1
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_impersonate_error_returns_http_client_error(mock_get: Mock) -> None:
+    """ImpersonateError (a RequestException subclass) maps to HttpClientError."""
+    config = HttpClientConfig(timeout_seconds=5.0)
+    c = CurlHttpClient(config, impersonate="chrome136")
+    mock_get.side_effect = cffi_exc.ImpersonateError("impersonation failed")
+
+    result = c.get("http://example.com")
+
+    assert not result.ok
+    assert isinstance(result.error, HttpClientError)
+    assert "impersonation failed" in str(result.error)
+
+
+# ---------------------------------------------------------------------------
+# HEAD / POST / download
+# ---------------------------------------------------------------------------
+
+
+@patch("curl_cffi.requests.Session.head")
+def test_head_success_returns_headers(
+    mock_head: Mock, client: CurlHttpClient
+) -> None:
+    mock_head.return_value = _mock_response(content=b"")
+
+    result = client.head("http://example.com")
+
+    assert result.ok
+    assert result.value == {"Content-Type": "application/json"}
+    assert result.meta["method"] == "HEAD"
+    mock_head.assert_called_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        timeout=5.0,
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+@patch("curl_cffi.requests.Session.post")
+def test_post_success(mock_post: Mock, client: CurlHttpClient) -> None:
+    mock_post.return_value = _mock_response(content=b"created", status=201)
+
+    result = client.post("http://example.com", json={"foo": "bar"})
+
+    assert result.ok
+    assert result.value == b"created"
+    assert result.meta["method"] == "POST"
+    assert result.meta["status_code"] == 201
+    mock_post.assert_called_once_with(
+        "http://example.com",
+        headers=None,
+        params=None,
+        data=None,
+        json={"foo": "bar"},
+        timeout=5.0,
+        allow_redirects=True,
+        verify=True,
+    )
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_download_success(mock_get: Mock, client: CurlHttpClient) -> None:
+    mock_response = _mock_response(url="http://example.com/file")
+    mock_get.return_value = mock_response
+
+    result = client.download("http://example.com/file")
+
+    assert result.ok
+    assert result.value is mock_response
+    assert result.meta["method"] == "GET"
+    mock_get.assert_called_once_with(
+        "http://example.com/file",
+        headers=None,
+        params=None,
+        timeout=5.0,
+        allow_redirects=True,
+        stream=True,
+        verify=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Context / metadata
+# ---------------------------------------------------------------------------
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_context_is_merged_into_metadata(
+    mock_get: Mock, client: CurlHttpClient
+) -> None:
+    mock_get.return_value = _mock_response(content=b"ok")
+
+    result = client.get(
+        "http://example.com",
+        context={"house": "sothebys", "crawler": "canary"},
+    )
+
+    assert result.ok
+    assert result.meta["house"] == "sothebys"
+    assert result.meta["crawler"] == "canary"
+    assert result.meta["context"] == {"house": "sothebys", "crawler": "canary"}
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_context_cannot_override_canonical_metadata(
+    mock_get: Mock, client: CurlHttpClient
+) -> None:
+    mock_get.return_value = _mock_response(
+        content=b"ok", url="http://response.example"
+    )
+
+    result = client.get(
+        "http://example.com",
+        context={"url": "http://context.example", "method": "PATCH"},
+    )
+
+    assert result.ok
+    assert result.meta["url"] == "http://response.example"
+    assert result.meta["method"] == "GET"
+    assert result.meta["context"]["url"] == "http://context.example"
+    assert result.meta["context"]["method"] == "PATCH"
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit (429 / 503)
+# ---------------------------------------------------------------------------
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_rate_limit_exhausted_returns_error(mock_get: Mock) -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=1)
+    mock_get.side_effect = [
+        _mock_response(status=429, content=b"", reason="Too Many Requests"),
+        _mock_response(status=429, content=b"", reason="Too Many Requests"),
+    ]
+
+    c = CurlHttpClient(config, impersonate="chrome136")
+    result = c.get("http://example.com")
+
+    assert not result.ok
+    assert isinstance(result.error, RateLimitedError)
+    assert result.error.status_code == 429
+    assert mock_get.call_count == 2
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_rate_limit_retry_then_success(mock_get: Mock) -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=1)
+    mock_get.side_effect = [
+        _mock_response(status=429, content=b"", reason="Too Many Requests"),
+        _mock_response(content=b"ok"),
+    ]
+
+    c = CurlHttpClient(config, impersonate="chrome136")
+    result = c.get("http://example.com")
+
+    assert result.ok
+    assert result.value == b"ok"
+    assert mock_get.call_count == 2
+
+
+@patch("curl_cffi.requests.Session.post")
+def test_post_429_not_retried(mock_post: Mock) -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=2)
+    mock_post.return_value = _mock_response(
+        status=429, content=b"", reason="Too Many Requests"
+    )
+
+    c = CurlHttpClient(config, impersonate="chrome136")
+    result = c.post("http://example.com")
+
+    assert result.ok
+    assert result.meta["status_code"] == 429
+    assert result.meta["attempts"] == 1
+    assert mock_post.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_circuit_breaker_opens_after_threshold(mock_get: Mock) -> None:
+    config = HttpClientConfig(
+        timeout_seconds=5.0,
+        circuit_breaker_failure_threshold=2,
+        circuit_breaker_recovery_seconds=60.0,
+    )
+    mock_get.side_effect = cffi_exc.ConnectionError("refused")
+
+    c = CurlHttpClient(config, impersonate="chrome136")
+    c.get("http://example.com")
+    c.get("http://example.com")
+    result = c.get("http://example.com")
+
+    assert not result.ok
+    assert isinstance(result.error, CircuitOpenError)
+    assert result.meta["attempts"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Proxy pool
+# ---------------------------------------------------------------------------
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_proxy_pool_rotation(mock_get: Mock) -> None:
+    pool = RoundRobinProxyPool(
+        [{"https": "http://proxy1:8080"}, {"https": "http://proxy2:8080"}]
+    )
+    config = HttpClientConfig(proxy_pool=pool, timeout_seconds=5.0, retries=1)
+    mock_get.return_value = _mock_response(content=b"ok")
+
+    c = CurlHttpClient(config, impersonate="chrome136")
+    r1 = c.get("http://example.com")
+    r2 = c.get("http://example.com")
+
+    assert r1.ok and r2.ok
+
+
+# ---------------------------------------------------------------------------
+# default_params / auth
+# ---------------------------------------------------------------------------
+
+
+def test_per_request_params_override_defaults() -> None:
+    config = HttpClientConfig(
+        default_params={"api_key": "abc", "v": "1"}, timeout_seconds=5.0
+    )
+    c = CurlHttpClient(config, impersonate="chrome136")
+    merged = c._merge_params({"v": "2"})
+    assert merged == {"api_key": "abc", "v": "2"}
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_default_params_merged_into_request(mock_get: Mock) -> None:
+    config = HttpClientConfig(
+        default_params={"api_key": "abc"}, timeout_seconds=5.0
+    )
+    mock_get.return_value = _mock_response(content=b"ok")
+
+    c = CurlHttpClient(config, impersonate="chrome136")
+    result = c.get("http://example.com")
+
+    assert result.ok
+    call_kwargs = mock_get.call_args.kwargs
+    assert call_kwargs["params"] == {"api_key": "abc"}
+
+
+def test_auth_wired_to_session() -> None:
+    config = HttpClientConfig(auth=("user", "secret"), timeout_seconds=5.0)
+    c = CurlHttpClient(config, impersonate="chrome136")
+    assert c._session.auth == ("user", "secret")
+
+
+# ---------------------------------------------------------------------------
+# set_crawl_delay
+# ---------------------------------------------------------------------------
+
+
+def test_set_crawl_delay_stored(config: HttpClientConfig) -> None:
+    c = CurlHttpClient(config, impersonate="chrome136")
+    c.set_crawl_delay("example.com", 2.5)
+    assert c._crawl_delay_overrides["example.com"] == 2.5
+
+
+def test_set_crawl_delay_overwrites(config: HttpClientConfig) -> None:
+    c = CurlHttpClient(config, impersonate="chrome136")
+    c.set_crawl_delay("example.com", 1.0)
+    c.set_crawl_delay("example.com", 3.0)
+    assert c._crawl_delay_overrides["example.com"] == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Backoff jitter
+# ---------------------------------------------------------------------------
+
+
+@patch("ladon.networking.curl_client.sleep")
+@patch("curl_cffi.requests.Session.get")
+def test_backoff_with_jitter_calls_sleep(
+    mock_get: Mock, mock_sleep: Mock
+) -> None:
+    config = HttpClientConfig(
+        timeout_seconds=5.0,
+        retries=1,
+        backoff_base_seconds=1.0,
+        backoff_jitter=True,
+    )
+    mock_get.side_effect = [
+        cffi_exc.ConnectionError("refused"),
+        _mock_response(content=b"ok"),
+    ]
+
+    c = CurlHttpClient(config, impersonate="chrome136")
+    result = c.get("http://example.com")
+
+    assert result.ok
+    mock_sleep.assert_called_once()
+    slept_for = mock_sleep.call_args[0][0]
+    assert 0.0 <= slept_for <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Retry-After as HTTP-date
+# ---------------------------------------------------------------------------
+
+
+@patch("curl_cffi.requests.Session.get")
+def test_retry_after_as_http_date_triggers_retry(mock_get: Mock) -> None:
+    config = HttpClientConfig(timeout_seconds=5.0, retries=1)
+    past_date_resp = _mock_response(status=429, reason="Too Many Requests")
+    past_date_resp.headers = {"Retry-After": "Wed, 01 Jan 2020 00:00:00 GMT"}
+    mock_get.side_effect = [past_date_resp, _mock_response(content=b"ok")]
+
+    c = CurlHttpClient(config, impersonate="chrome136")
+    result = c.get("http://example.com")
+
+    assert result.ok
+    assert result.value == b"ok"
+    assert mock_get.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# robots.txt enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_robots_blocks_disallowed_url() -> None:
+    config = HttpClientConfig(respect_robots_txt=True, timeout_seconds=5.0)
+    c = CurlHttpClient(config, impersonate="chrome136")
+    c._robots_cache = Mock()
+    c._robots_cache.is_allowed.return_value = False
+
+    result = c.get("http://example.com/disallowed")
+
+    assert not result.ok
+    assert isinstance(result.error, RobotsBlockedError)
+
+
+def test_robots_crawl_delay_sets_override() -> None:
+    config = HttpClientConfig(
+        respect_robots_txt=True,
+        min_request_interval_seconds=0.5,
+        timeout_seconds=5.0,
+    )
+    c = CurlHttpClient(config, impersonate="chrome136")
+    c._robots_cache = Mock()
+    c._robots_cache.is_allowed.return_value = True
+    c._robots_cache.crawl_delay.return_value = 2.0
+    c._session.get = Mock(return_value=_mock_response(content=b"ok"))
+
+    result = c.get("http://example.com/page")
+
+    assert result.ok
+    assert c._crawl_delay_overrides.get("example.com") == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Per-host rate-limit sleep
+# ---------------------------------------------------------------------------
+
+
+@patch("ladon.networking.curl_client.sleep")
+@patch("ladon.networking.curl_client.monotonic")
+@patch("curl_cffi.requests.Session.get")
+def test_rate_limit_sleep_enforced(
+    mock_get: Mock, mock_monotonic: Mock, mock_sleep: Mock
+) -> None:
+    config = HttpClientConfig(
+        min_request_interval_seconds=2.0, timeout_seconds=5.0
+    )
+    mock_get.return_value = _mock_response(content=b"ok")
+    # Interval is measured end-to-start: timestamp written in finally after each attempt.
+    # First get() completes  → finally records 1000.0
+    # Second get() enforces  → now=1000.5, elapsed=0.5, remaining=1.5 → sleep(1.5)
+    # Second get() completes → finally records 1001.0
+    mock_monotonic.side_effect = [1000.0, 1000.5, 1001.0]
+
+    c = CurlHttpClient(config, impersonate="chrome136")
+    c.get("http://example.com")
+    c.get("http://example.com")
+
+    mock_sleep.assert_called_once_with(pytest.approx(1.5, abs=1e-9))

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,152 @@
+# pyright: reportUnknownParameterType=false, reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false, reportMissingParameterType=false
+# pyright: reportUnknownArgumentType=false, reportPrivateUsage=false
+"""Tests for make_http_client() and make_async_http_client() factory functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from ladon.networking import make_async_http_client, make_http_client
+from ladon.networking.async_client import AsyncHttpClient
+from ladon.networking.client import HttpClient
+from ladon.networking.config import HttpClientConfig
+
+# ---------------------------------------------------------------------------
+# make_http_client — sync factory
+# ---------------------------------------------------------------------------
+
+
+def test_make_http_client_default_returns_http_client() -> None:
+    config = HttpClientConfig(timeout_seconds=5.0)
+    client = make_http_client(config)
+    assert isinstance(client, HttpClient)
+    client.close()
+
+
+def test_make_http_client_requests_backend_explicit() -> None:
+    config = HttpClientConfig(backend="requests", timeout_seconds=5.0)
+    client = make_http_client(config)
+    assert isinstance(client, HttpClient)
+    client.close()
+
+
+def test_make_http_client_curl_cffi_backend() -> None:
+    pytest.importorskip("curl_cffi")
+    from ladon.networking.curl_client import CurlHttpClient
+
+    config = HttpClientConfig(
+        backend="curl-cffi", impersonate="chrome136", timeout_seconds=5.0
+    )
+    client = make_http_client(config)
+    assert isinstance(client, CurlHttpClient)
+    assert client.impersonate == "chrome136"
+    client.close()
+
+
+def test_make_http_client_curl_cffi_raises_import_error_when_unavailable() -> (
+    None
+):
+    pytest.importorskip("curl_cffi")
+    import ladon.networking.curl_client as m
+
+    original = m._curl_cffi_available
+    m._curl_cffi_available = False
+    try:
+        config = HttpClientConfig(
+            backend="curl-cffi", impersonate="chrome136", timeout_seconds=5.0
+        )
+        with pytest.raises(
+            ImportError, match="pip install ladon-crawl\\[cffi\\]"
+        ):
+            make_http_client(config)
+    finally:
+        m._curl_cffi_available = original
+
+
+def test_make_http_client_propagates_config() -> None:
+    config = HttpClientConfig(
+        timeout_seconds=10.0, user_agent="TestBot/1.0", retries=3
+    )
+    client = make_http_client(config)
+    assert isinstance(client, HttpClient)
+    assert client._config is config
+    client.close()
+
+
+# ---------------------------------------------------------------------------
+# make_async_http_client — async factory
+# ---------------------------------------------------------------------------
+
+
+async def test_make_async_http_client_default_returns_async_http_client() -> (
+    None
+):
+    config = HttpClientConfig(timeout_seconds=5.0)
+    client = make_async_http_client(config)
+    assert isinstance(client, AsyncHttpClient)
+    await client.aclose()
+
+
+async def test_make_async_http_client_requests_backend_explicit() -> None:
+    config = HttpClientConfig(backend="requests", timeout_seconds=5.0)
+    client = make_async_http_client(config)
+    assert isinstance(client, AsyncHttpClient)
+    await client.aclose()
+
+
+async def test_make_async_http_client_curl_cffi_backend() -> None:
+    pytest.importorskip("curl_cffi")
+    from ladon.networking.async_curl_client import AsyncCurlHttpClient
+
+    config = HttpClientConfig(
+        backend="curl-cffi", impersonate="chrome136", timeout_seconds=5.0
+    )
+    client = make_async_http_client(config)
+    assert isinstance(client, AsyncCurlHttpClient)
+    assert client.impersonate == "chrome136"
+    await client.aclose()
+
+
+def test_make_async_http_client_curl_cffi_raises_import_error_when_unavailable() -> (
+    None
+):
+    pytest.importorskip("curl_cffi")
+    import ladon.networking.async_curl_client as m
+
+    original = m._curl_cffi_available
+    m._curl_cffi_available = False
+    try:
+        config = HttpClientConfig(
+            backend="curl-cffi", impersonate="chrome136", timeout_seconds=5.0
+        )
+        with pytest.raises(
+            ImportError, match="pip install ladon-crawl\\[cffi\\]"
+        ):
+            make_async_http_client(config)
+    finally:
+        m._curl_cffi_available = original
+
+
+async def test_make_async_http_client_propagates_config() -> None:
+    config = HttpClientConfig(
+        timeout_seconds=10.0, user_agent="TestBot/1.0", retries=3
+    )
+    client = make_async_http_client(config)
+    assert isinstance(client, AsyncHttpClient)
+    assert client._config is config
+    await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Top-level namespace exports
+# ---------------------------------------------------------------------------
+
+
+def test_factories_exported_from_ladon_namespace() -> None:
+    import ladon
+
+    assert hasattr(ladon, "make_http_client")
+    assert hasattr(ladon, "make_async_http_client")
+    assert hasattr(ladon, "CurlHttpClient")
+    assert hasattr(ladon, "AsyncCurlHttpClient")


### PR DESCRIPTION
## Summary

- Adds `[cffi]` optional dependency group to `pyproject.toml`: `curl-cffi>=0.11,<1`
- Adds `CurlHttpClient` (sync) and `AsyncCurlHttpClient` (async) backed by curl-cffi for TLS fingerprint impersonation (JA3/JA4) to bypass Cloudflare L1+L2 challenges
- No impact on users who do not install the extra — `requests` and `httpx` remain the only hard deps
- CHANGELOG updated under `[Unreleased]`

## Dependency audit

| Item | Result |
|------|--------|
| License | MIT ✓ |
| Latest | 0.15.0 — active cadence (43 impersonate targets: chrome99–chrome146, firefox, safari, tor145) |
| Wheels | Binary (libcurl+BoringSSL bundled), no system-level `curl` required |
| Python | ≥3.8 — compatible with ladon's `>=3.11` floor |
| API compat | `Session.get/post/request/close`, `response.content/status_code/headers/ok` — drop-in for `requests.Session` ✓ |
| Async | `AsyncSession` with identical method surface ✓ |
| Exceptions | Mirrors `requests` names (`ConnectionError`, `Timeout`, `RequestException`, …) ✓ |

## Test plan

- [x] `pip install -e ".[cffi]"` installs without error
- [x] `pip install -e "."` (no extra) does **not** pull in `curl-cffi`
- [x] `python -c "from curl_cffi.requests import Session"` works in a `[cffi]` env
- [x] Full test suite passes (532 tests)

Closes #107