### PR TITLE
refactor(networking): extract _cffi_common — eliminate duplicated curl-cffi bootstrap

### DIFF
--- a/src/ladon/networking/_cffi_common.py
+++ b/src/ladon/networking/_cffi_common.py
@@ -1,0 +1,45 @@
+"""Shared curl-cffi bootstrap for CurlHttpClient and AsyncCurlHttpClient.
+
+Both client modules import from here so the try/except ImportError block and
+the import-time BrowserType frozenset are not duplicated.  The module name
+starts with ``_`` to signal it is an internal implementation detail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+cffi: Any
+cffi_exc: Any
+curl_cffi_available: bool
+valid_impersonate: frozenset[str]
+
+try:
+    from curl_cffi import (
+        requests as _cffi_mod,  # type: ignore[import-untyped, import-not-found]
+    )
+    from curl_cffi.requests import (
+        BrowserType as _BrowserType,  # type: ignore[import-untyped, import-not-found]
+    )
+    from curl_cffi.requests import (
+        exceptions as _cffi_exc_mod,  # type: ignore[import-untyped, import-not-found]
+    )
+
+    cffi = _cffi_mod  # type: ignore[assignment]
+    cffi_exc = _cffi_exc_mod  # type: ignore[assignment]
+    curl_cffi_available = True
+    valid_impersonate = frozenset(
+        b.value for b in _BrowserType  # type: ignore[union-attr]
+    )
+except ImportError:
+    cffi = None
+    cffi_exc = None
+    curl_cffi_available = False
+    valid_impersonate = frozenset()
+
+
+def import_error_msg(class_name: str) -> str:
+    return (
+        f"curl-cffi is required for {class_name}.\n"
+        "Install it with:  pip install ladon-crawl[cffi]"
+    )

--- a/src/ladon/networking/async_curl_client.py
+++ b/src/ladon/networking/async_curl_client.py
@@ -12,7 +12,8 @@ If curl-cffi is not installed, importing this module succeeds but
 instantiating ``AsyncCurlHttpClient`` raises ``ImportError`` with an
 actionable message.
 
-Blast radius: if curl-cffi changes its async API, only this file is affected.
+Blast radius: if curl-cffi changes its async session API, only this file is affected.
+Bootstrap symbols (cffi, cffi_exc, BrowserType) are owned by _cffi_common.py.
 """
 
 from __future__ import annotations
@@ -25,27 +26,11 @@ from time import monotonic
 from typing import Any, Callable, Coroutine, Mapping, TypeVar
 from urllib.parse import urlparse
 
-try:
-    from curl_cffi import (
-        requests as _cffi,  # type: ignore[import-untyped, import-not-found]
-    )
-    from curl_cffi.requests import (
-        BrowserType as _BrowserType,  # type: ignore[import-untyped, import-not-found]
-    )
-    from curl_cffi.requests import (
-        exceptions as _cffi_exc,  # type: ignore[import-untyped, import-not-found]
-    )
-
-    _curl_cffi_available: bool = True
-    _valid_impersonate: frozenset[str] = frozenset(
-        b.value for b in _BrowserType  # type: ignore[union-attr]
-    )
-except ImportError:
-    _cffi: Any = None
-    _cffi_exc: Any = None
-    _curl_cffi_available = False
-    _valid_impersonate = frozenset()
-
+from ._cffi_common import cffi as _cffi
+from ._cffi_common import cffi_exc as _cffi_exc
+from ._cffi_common import curl_cffi_available as _curl_cffi_available
+from ._cffi_common import import_error_msg as _import_error_msg
+from ._cffi_common import valid_impersonate as _valid_impersonate
 from .circuit_breaker import CircuitBreaker, CircuitState
 from .config import HttpClientConfig
 from .errors import (
@@ -60,11 +45,6 @@ from .types import Err, Ok, Result
 ResponseValue = TypeVar("ResponseValue")
 
 _AsyncRequestFn = Callable[[], Coroutine[Any, Any, Any]]
-
-_IMPORT_ERROR_MSG = (
-    "curl-cffi is required for AsyncCurlHttpClient.\n"
-    "Install it with:  pip install ladon-crawl[cffi]"
-)
 
 
 class AsyncCurlHttpClient:
@@ -94,7 +74,7 @@ class AsyncCurlHttpClient:
 
     def __init__(self, config: HttpClientConfig, *, impersonate: str) -> None:
         if not _curl_cffi_available:
-            raise ImportError(_IMPORT_ERROR_MSG)
+            raise ImportError(_import_error_msg(type(self).__name__))
         if config.respect_robots_txt:
             raise NotImplementedError(
                 "respect_robots_txt is not supported by AsyncCurlHttpClient; "

--- a/src/ladon/networking/curl_client.py
+++ b/src/ladon/networking/curl_client.py
@@ -12,7 +12,8 @@ If curl-cffi is not installed, importing this module succeeds but
 instantiating ``CurlHttpClient`` raises ``ImportError`` with an
 actionable message.
 
-Blast radius: if curl-cffi changes its API, only this file is affected.
+Blast radius: if curl-cffi changes its session API, only this file is affected.
+Bootstrap symbols (cffi, cffi_exc, BrowserType) are owned by _cffi_common.py.
 """
 
 from __future__ import annotations
@@ -24,27 +25,11 @@ from time import monotonic, sleep
 from typing import Any, Callable, Mapping, TypeVar
 from urllib.parse import urlparse
 
-try:
-    from curl_cffi import (
-        requests as _cffi,  # type: ignore[import-untyped, import-not-found]
-    )
-    from curl_cffi.requests import (
-        BrowserType as _BrowserType,  # type: ignore[import-untyped, import-not-found]
-    )
-    from curl_cffi.requests import (
-        exceptions as _cffi_exc,  # type: ignore[import-untyped, import-not-found]
-    )
-
-    _curl_cffi_available: bool = True
-    _valid_impersonate: frozenset[str] = frozenset(
-        b.value for b in _BrowserType  # type: ignore[union-attr]
-    )
-except ImportError:
-    _cffi: Any = None
-    _cffi_exc: Any = None
-    _curl_cffi_available = False
-    _valid_impersonate = frozenset()
-
+from ._cffi_common import cffi as _cffi
+from ._cffi_common import cffi_exc as _cffi_exc
+from ._cffi_common import curl_cffi_available as _curl_cffi_available
+from ._cffi_common import import_error_msg as _import_error_msg
+from ._cffi_common import valid_impersonate as _valid_impersonate
 from .circuit_breaker import CircuitBreaker, CircuitState
 from .config import HttpClientConfig
 from .errors import (
@@ -59,11 +44,6 @@ from .robots import RobotsCache
 from .types import Err, Ok, Result
 
 ResponseValue = TypeVar("ResponseValue")
-
-_IMPORT_ERROR_MSG = (
-    "curl-cffi is required for CurlHttpClient.\n"
-    "Install it with:  pip install ladon-crawl[cffi]"
-)
 
 
 class CurlHttpClient:
@@ -88,7 +68,7 @@ class CurlHttpClient:
 
     def __init__(self, config: HttpClientConfig, *, impersonate: str) -> None:
         if not _curl_cffi_available:
-            raise ImportError(_IMPORT_ERROR_MSG)
+            raise ImportError(_import_error_msg(type(self).__name__))
         if impersonate not in _valid_impersonate:
             raise ValueError(
                 f"Unknown impersonate target {impersonate!r}. "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,26 @@ from collections.abc import Generator
 
 import pytest
 
+import ladon.networking._cffi_common as _common
+import ladon.networking.async_curl_client as _acurl
 import ladon.networking.config as _cfg
+import ladon.networking.curl_client as _curl
 
 
 @pytest.fixture(autouse=True)
 def _reset_cffi_impersonate_cache() -> Generator[None, None, None]:
-    """Reset the module-level curl-cffi BrowserType cache between tests.
+    """Reset module-level curl-cffi state between tests.
 
-    Prevents a test that mutates ladon.networking.config._cffi_valid_impersonate
-    from poisoning the cache seen by later tests in the same process.
+    - config._cffi_valid_impersonate: lazy BrowserType cache; reset to None so
+      each test gets a fresh lookup.
+    - curl_client._curl_cffi_available / async_curl_client._curl_cffi_available:
+      re-exported from _cffi_common; reset after each test to the common value in
+      case a test flipped the flag without a finally block.
     """
     _cfg._cffi_valid_impersonate = None  # type: ignore[attr-defined]
+    _curl._curl_cffi_available = _common.curl_cffi_available  # type: ignore[attr-defined]
+    _acurl._curl_cffi_available = _common.curl_cffi_available  # type: ignore[attr-defined]
     yield
     _cfg._cffi_valid_impersonate = None  # type: ignore[attr-defined]
+    _curl._curl_cffi_available = _common.curl_cffi_available  # type: ignore[attr-defined]
+    _acurl._curl_cffi_available = _common.curl_cffi_available  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- Introduces `ladon/networking/_cffi_common.py` — a single module that owns the curl-cffi import-time bootstrap (`cffi`, `cffi_exc`, `curl_cffi_available`, `valid_impersonate`, `import_error_msg`)
- `curl_client.py` and `async_curl_client.py` replace their identical `try/except ImportError` blocks with imports from `_cffi_common`
- `tests/conftest.py` autouse fixture expanded to reset the re-exported `_curl_cffi_available` flag in both client modules after each test

## Why

`curl_client.py` and `async_curl_client.py` each contained an identical 18-line `try/except ImportError` block. Any change to curl-cffi bootstrap (new symbol, renamed exception, new BrowserType source) required touching both files. This is Step 0 of the policy pipeline deduplication tracked in issue #109; resolves deferred finding **H** from the PR #108 review.

## Type safety

`cffi` and `cffi_exc` are declared as `Any` at module scope before the `try/except`, so pyright sees a stable `Any` type regardless of branch — identical behaviour to the original inline blocks. Pyright strict mode: 0 errors.

## Test plan

- [x] `python -m pytest tests/ -x -q` → 532 passed (unchanged)
- [x] `python -m pyright src/ladon/networking/_cffi_common.py src/ladon/networking/curl_client.py src/ladon/networking/async_curl_client.py` → 0 errors
- [x] `python -c "from ladon.networking._cffi_common import curl_cffi_available, valid_impersonate; print(curl_cffi_available, len(valid_impersonate))"` → `True 43`

Closes deferred finding H · Part of #109