### PR TITLE
refactor(networking): extract SyncPolicyBase ABC (step 1 of #109)

### DIFF
--- a/docs/decisions/adr-012-session-contract-boundary.md
+++ b/docs/decisions/adr-012-session-contract-boundary.md
@@ -1,0 +1,85 @@
+---
+status: accepted
+date: 2026-05-17
+decision-makers: [Maintainers]
+informed: [Contributors]
+refs: [ADR-011, Issue #109]
+---
+
+# ADR-012 — Session Contract Boundary in `SyncPolicyBase`
+
+## Context and Problem Statement
+
+Issue #109 extracted the shared sync policy pipeline into `SyncPolicyBase`, an
+ABC subclassed by both `HttpClient` (requests) and `CurlHttpClient` (curl-cffi).
+After extraction, `_apply_proxy` — the only method in the base class that touches
+the underlying session — directly accessed `self._session.proxies`.  This leaks
+transport internals into the base class with no structural contract: if a third
+transport's session exposes proxies under a different name or shape, the failure
+is silent at import time and discovered only at runtime.
+
+Two options were considered for encoding the contract.
+
+## Decision Drivers
+
+* The base class must not silently assume session shape it has no structural
+  claim to.
+* Any third transport added in the future must get a compile-time or
+  construction-time signal when it fails to meet the contract.
+* The solution must be proportionate to the current scope: one access point
+  (`self._session.proxies`) in one method (`_apply_proxy`).
+* The solution must not introduce abstractions that will need to be unwound if
+  the scope grows.
+
+## Considered Options
+
+* **A — Abstract `_proxies` property (chosen)**
+* **B — `_SessionProtocol` typed on `_session`**
+
+## Decision Outcome
+
+**Chosen: Option A — abstract `_proxies` property.**
+
+`SyncPolicyBase` declares an abstract property `_proxies` returning
+`MutableMapping[str, str]`.  `_apply_proxy` uses `self._proxies` exclusively —
+it no longer touches `self._session` directly.  Each subclass implements
+`_proxies` by delegating to its own session object.
+
+This is proportionate: one access point, one abstract property, zero duplication
+of logic.  The pyright abstract-method check enforces the contract at
+class-definition time — a concrete subclass that forgets `_proxies` is a type
+error before any test runs.
+
+### When to evolve this decision
+
+If a **second** session-level concern ever needs to move into the base class
+(e.g., `_apply_headers`, `_apply_auth`), **do not add a second abstract
+property**.  That is the signal to switch to Option B: define a
+`_SessionProtocol` with the full surface the base needs, type
+`_session: _SessionProtocol`, and let structural subtyping do the work.
+At that point, each subclass drops its individual abstract properties and
+simply provides a conforming `_session` — one Protocol definition replaces
+*n* abstract properties across *m* transports.
+
+### Consequences
+
+* **Good**: `SyncPolicyBase` no longer touches `self._session` directly — the
+  session is fully encapsulated in each subclass.
+* **Good**: Missing `_proxies` implementation is a pyright type error and an
+  `abc` `TypeError` at instantiation, not a `KeyError` at runtime.
+* **Neutral**: Each subclass gains a one-line property boilerplate.  Acceptable
+  for two transports; the Protocol upgrade path eliminates it if transports
+  multiply.
+* **Bad**: The abstract-property pattern scales poorly: *n* concerns × *m*
+  transports = *n×m* boilerplate properties.  The "when to evolve" clause above
+  caps this at one property before the switch.
+
+## Rejected option
+
+**B — `_SessionProtocol`:** Correct at scale but premature today.  Defining a
+Protocol surface for a single `.proxies` access would require typing a contract
+for `requests.Session` and `curl_cffi.Session` alike — both of which have
+large, partially-typed APIs.  The Protocol would either be artificially narrow
+(and need expanding on every new access) or artificially wide (and pull in
+unnecessary coupling).  Better to let the surface reveal itself organically and
+switch when the second access point appears.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -18,6 +18,7 @@ chosen over the alternatives.
 | ADR-009 | Observability (metrics, structured logs) | Proposed — Phase 3 |
 | [ADR-010](adr-010-dual-license-model.md) | Dual-License Model (AGPL-3.0-only + Commercial) | Accepted |
 | [ADR-011](adr-011-curl-cffi-cloudflare-bypass.md) | curl-cffi as the Cloudflare-Bypass HTTP Backend | Accepted |
+| [ADR-012](adr-012-session-contract-boundary.md) | Session Contract Boundary in `SyncPolicyBase` | Accepted |
 
 ## Format
 

--- a/src/ladon/networking/_sync_policy_base.py
+++ b/src/ladon/networking/_sync_policy_base.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from random import uniform
 from time import monotonic, sleep
-from typing import Any, Callable, Mapping, Self, TypeVar
+from typing import Any, Callable, Mapping, MutableMapping, Self, TypeVar
 from urllib.parse import urlparse
 
 from .circuit_breaker import CircuitBreaker, CircuitState
@@ -84,6 +84,16 @@ class SyncPolicyBase(ABC):
         timeout: float | tuple[float, float],
     ) -> Result[Any, Exception]:
         """Map a transport exception to a Ladon error Result."""
+
+    @property
+    @abstractmethod
+    def _proxies(self) -> MutableMapping[str, str]:
+        """The session's proxy mapping.
+
+        Subclasses delegate to their transport session's proxy dict.
+        If a second session-level concern is ever needed here, switch to a
+        _SessionProtocol instead — see ADR-012.
+        """
 
     # ------------------------------------------------------------------ #
     # Concrete policy helpers                                              #
@@ -163,9 +173,9 @@ class SyncPolicyBase(ABC):
 
     def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
         """Update session proxy to *proxy*, clearing any previous setting."""
-        self._session.proxies.clear()
+        self._proxies.clear()
         if proxy is not None:
-            self._session.proxies.update(proxy)
+            self._proxies.update(proxy)
 
     def _merge_params(
         self, params: Mapping[str, str] | None

--- a/src/ladon/networking/_sync_policy_base.py
+++ b/src/ladon/networking/_sync_policy_base.py
@@ -250,7 +250,7 @@ class SyncPolicyBase(ABC):
         response: Any | None,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: float | tuple[float, float] | None,
+        timeout: float | tuple[float, float],
         final_error: str | None = None,
     ) -> dict[str, Any]:
         """Construct metadata dictionary from response and context."""
@@ -404,8 +404,7 @@ class SyncPolicyBase(ABC):
                     ),
                 )
             except Exception as exc:
-                if not self._is_transport_exception(exc):
-                    # pragma: no cover - defensive fallback for non-transport errors
+                if not self._is_transport_exception(exc):  # pragma: no cover
                     if cb is not None:
                         cb.record_failure()
                     return Err(

--- a/src/ladon/networking/_sync_policy_base.py
+++ b/src/ladon/networking/_sync_policy_base.py
@@ -38,7 +38,7 @@ class SyncPolicyBase(ABC):
     implement the four abstract methods that vary per transport library.
     """
 
-    _session: Any
+    _session: Any  # must be assigned by subclass __init__ before any request
 
     def __init__(self, config: HttpClientConfig) -> None:
         self._config = config
@@ -46,6 +46,14 @@ class SyncPolicyBase(ABC):
         self._circuit_breakers: dict[str, CircuitBreaker] = {}
         self._robots_cache: RobotsCache | None = None
         self._crawl_delay_overrides: dict[str, float] = {}
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "_session":
+            raise RuntimeError(
+                f"{type(self).__name__} must assign self._session in __init__ "
+                "before making any requests"
+            )
+        raise AttributeError(name)
 
     def __enter__(self) -> Self:
         return self

--- a/src/ladon/networking/_sync_policy_base.py
+++ b/src/ladon/networking/_sync_policy_base.py
@@ -1,0 +1,464 @@
+"""Shared policy pipeline for synchronous HTTP clients.
+
+Both ``HttpClient`` (requests) and ``CurlHttpClient`` (curl-cffi) subclass
+this ABC.  All policy logic — circuit breaking, retry loop, backoff, rate
+limiting, proxy rotation, robots.txt, and metadata assembly — lives here.
+The only differences between the two clients are the session library, its
+exception types, and the mapping of those exceptions to Ladon errors.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from random import uniform
+from time import monotonic, sleep
+from typing import Any, Callable, Mapping, Self, TypeVar
+from urllib.parse import urlparse
+
+from .circuit_breaker import CircuitBreaker, CircuitState
+from .config import HttpClientConfig
+from .errors import (
+    CircuitOpenError,
+    HttpClientError,
+    RateLimitedError,
+    RobotsBlockedError,
+)
+from .robots import RobotsCache
+from .types import Err, Ok, Result
+
+ResponseValue = TypeVar("ResponseValue")
+
+
+class SyncPolicyBase(ABC):
+    """Abstract base for synchronous HTTP clients with unified policy pipeline.
+
+    Subclasses must assign ``self._session`` before any request is made, and
+    implement the four abstract methods that vary per transport library.
+    """
+
+    _session: Any
+
+    def __init__(self, config: HttpClientConfig) -> None:
+        self._config = config
+        self._last_request_time: dict[str, float] = {}
+        self._circuit_breakers: dict[str, CircuitBreaker] = {}
+        self._robots_cache: RobotsCache | None = None
+        self._crawl_delay_overrides: dict[str, float] = {}
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the underlying session and release pooled connections."""
+
+    @abstractmethod
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True iff *exc* is a library transport exception, not a logic error."""
+
+    @abstractmethod
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
+        """Return True for transport errors that should trigger a retry."""
+
+    @abstractmethod
+    def _handle_request_exception(
+        self,
+        method: str,
+        request_url: str,
+        e: Exception,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: float | tuple[float, float],
+    ) -> Result[Any, Exception]:
+        """Map a transport exception to a Ladon error Result."""
+
+    # ------------------------------------------------------------------ #
+    # Concrete policy helpers                                              #
+    # ------------------------------------------------------------------ #
+
+    def _get_timeout(
+        self, override: float | None
+    ) -> float | tuple[float, float]:
+        """Resolve timeout preference."""
+        if override is not None:
+            if override <= 0:
+                raise ValueError("timeout override must be > 0 when provided")
+            return override
+        if (
+            self._config.connect_timeout_seconds is not None
+            and self._config.read_timeout_seconds is not None
+        ):
+            return (
+                self._config.connect_timeout_seconds,
+                self._config.read_timeout_seconds,
+            )
+        return self._config.timeout_seconds
+
+    def _max_attempts(self) -> int:
+        """Return the total number of attempts for one request."""
+        return 1 + max(0, self._config.retries)
+
+    def _sleep_between_attempts(self, attempt: int) -> None:
+        """Sleep between retry attempts using exponential backoff."""
+        backoff_base = self._config.backoff_base_seconds
+        if backoff_base <= 0:
+            return
+        cap = backoff_base * (2 ** max(0, attempt - 1))
+        sleep(uniform(0.0, cap) if self._config.backoff_jitter else cap)
+
+    @staticmethod
+    def _parse_retry_after(response: Any) -> float | None:
+        """Parse the ``Retry-After`` header from *response* into seconds.
+
+        Handles both delta-seconds (``"60"``) and HTTP-date
+        (``"Wed, 21 Oct 2015 07:28:00 GMT"``) forms per RFC 7231 §7.1.3.
+
+        Returns:
+            Seconds to wait (clamped to 0.0 minimum), or ``None`` if the
+            header is absent or cannot be parsed.
+        """
+        header = response.headers.get("Retry-After")
+        if header is None:
+            return None
+        try:
+            return max(0.0, float(header))
+        except ValueError:
+            pass
+        try:
+            dt = parsedate_to_datetime(str(header))
+            delta = (dt - datetime.now(tz=timezone.utc)).total_seconds()
+            return max(0.0, delta)
+        except Exception:  # fail-open: treat any unparseable date as absent
+            return None
+
+    def _sleep_for_retry_after(
+        self, retry_after: float | None, attempt: int
+    ) -> None:
+        """Sleep before a retry triggered by a rate-limiting HTTP response.
+
+        When *retry_after* is not ``None``: caps it at
+        ``max_retry_after_seconds``, then takes the longer of the capped value
+        and ``min_request_interval_seconds`` so the client's own politeness
+        policy is never violated.  Falls back to ``_sleep_between_attempts``
+        when *retry_after* is ``None``.
+        """
+        if retry_after is not None:
+            capped = min(retry_after, self._config.max_retry_after_seconds)
+            sleep(max(capped, self._config.min_request_interval_seconds))
+        else:
+            self._sleep_between_attempts(attempt)
+
+    def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
+        """Update session proxy to *proxy*, clearing any previous setting."""
+        self._session.proxies.clear()
+        if proxy is not None:
+            self._session.proxies.update(proxy)
+
+    def _merge_params(
+        self, params: Mapping[str, str] | None
+    ) -> Mapping[str, str] | None:
+        """Merge *params* with ``default_params``, per-request wins on collision."""
+        dp = self._config.default_params
+        if dp is None:
+            return params
+        merged = {**dp, **(params or {})}
+        return merged if merged else None
+
+    def _enforce_robots(self, url: str) -> None:
+        """Raise ``RobotsBlockedError`` if *url* is disallowed by robots.txt.
+
+        No-op when ``respect_robots_txt`` is False (the default) or when the
+        robots.txt fetch fails (fail-open behaviour).
+
+        Called before ``_enforce_rate_limit`` so that blocked requests are
+        rejected before the rate-limit slot is consumed — honouring the spirit
+        of the robots.txt contract: don't even waste a rate-limit slot on a
+        host that has explicitly opted out of being crawled.
+
+        Known limitation — robots.txt fetch bypasses rate-limiter
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ``RobotsCache`` fetches ``/robots.txt`` via a raw ``session.get``
+        call that is invisible to ``_enforce_rate_limit``.  On the first
+        request to any origin this produces two outbound HTTP requests to
+        that host in rapid succession (robots.txt fetch + the actual request),
+        regardless of ``min_request_interval_seconds``.  The cache guarantees
+        at most one robots.txt fetch per origin per session, so subsequent
+        requests to the same host are unaffected.  This trade-off is
+        documented in ADR-008.
+        """
+        if self._robots_cache is None:
+            return
+        if not self._robots_cache.is_allowed(url):
+            raise RobotsBlockedError(f"robots.txt disallows: {url}")
+        # Propagate Crawl-delay into the rate limiter for this host.
+        # HttpClientConfig is frozen so we maintain a side-table of per-host
+        # delay overrides rather than mutating config.
+        # Note: Crawl-delay is only registered here, on the *allowed* path.
+        # A domain that disallows all URLs but advertises Crawl-delay will
+        # have the delay present in RobotsCache._crawl_delays (populated at
+        # fetch time) but absent from _crawl_delay_overrides (since no request
+        # is ever made to that host, there is nothing to throttle).
+        delay = self._robots_cache.crawl_delay(url)
+        if delay is not None:
+            host = urlparse(url).netloc
+            current = self._config.min_request_interval_seconds
+            if delay > current:
+                self._crawl_delay_overrides[host] = delay
+
+    def _enforce_rate_limit(self, host: str) -> None:
+        """Enforce per-host politeness delay before issuing a request.
+
+        Sleeps for however long remains since the last request to *host*.
+        The timestamp is written by the ``_request`` loop's ``finally`` block
+        (end-to-start semantics), not here.
+
+        No-op when ``min_request_interval_seconds`` is zero (the default)
+        or when *host* is empty.
+        """
+        if not host:
+            return
+        interval = max(
+            self._config.min_request_interval_seconds,
+            self._crawl_delay_overrides.get(host, 0.0),
+        )
+        if interval <= 0:
+            return
+        last = self._last_request_time.get(host)
+        if last is not None:
+            elapsed = monotonic() - last
+            remaining = interval - elapsed
+            if remaining > 0:
+                sleep(remaining)
+
+    def _build_meta(
+        self,
+        method: str,
+        request_url: str,
+        response: Any | None,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: float | tuple[float, float] | None,
+        final_error: str | None = None,
+    ) -> dict[str, Any]:
+        """Construct metadata dictionary from response and context."""
+        meta: dict[str, Any] = {}
+        meta["method"] = method
+        meta["url"] = request_url
+        meta["attempts"] = attempts
+        meta["timeout_s"] = timeout
+        if context:
+            context_dict = dict(context)
+            meta["context"] = context_dict
+            for key, value in context_dict.items():
+                meta.setdefault(key, value)
+
+        if response is not None:
+            meta["status_code"] = response.status_code
+            meta["url"] = response.url
+            meta["reason"] = response.reason
+            try:
+                meta["elapsed_s"] = response.elapsed.total_seconds()
+            except AttributeError:
+                pass  # In case elapsed is not available or mocked
+        if final_error is not None:
+            meta["final_error"] = final_error
+
+        return meta
+
+    def _get_circuit_breaker(self, host: str) -> CircuitBreaker | None:
+        """Return the CircuitBreaker for *host*, or None if circuit breaking is disabled."""
+        threshold = self._config.circuit_breaker_failure_threshold
+        if threshold is None:
+            return None
+        if not host:
+            return None
+        if host not in self._circuit_breakers:
+            self._circuit_breakers[host] = CircuitBreaker(
+                threshold=threshold,
+                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
+            )
+        return self._circuit_breakers[host]
+
+    def circuit_state(self, url: str) -> CircuitState | None:
+        """Return the current circuit-breaker state for *url*'s host.
+
+        Returns ``None`` when the circuit breaker is disabled
+        (``circuit_breaker_failure_threshold`` is ``None``) or when no
+        request has been made to the host yet.
+
+        Intended for logging, metrics, and operational dashboards — lets
+        callers surface open circuits without touching private state.
+
+        Args:
+            url: Any URL on the host to query (only the ``netloc`` is used).
+        """
+        cb = self._circuit_breakers.get(urlparse(url).netloc)
+        if cb is None:
+            return None
+        return cb.state
+
+    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
+        """Override the per-host crawl delay for *host*.
+
+        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
+        when the override is larger.  Intended for callers that parse a site's
+        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
+        """
+        self._crawl_delay_overrides[host] = delay_seconds
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        context: Mapping[str, Any] | None,
+        timeout: float | tuple[float, float],
+        request_fn: Callable[[], Any],
+        value_builder: Callable[[Any], ResponseValue],
+    ) -> Result[ResponseValue, Exception]:
+        """Execute request with retries, circuit breaking, and normalised metadata."""
+        host = urlparse(url).netloc
+        cb = self._get_circuit_breaker(host)
+        if cb is not None and not cb.allow_request():
+            meta = self._build_meta(
+                method=method,
+                request_url=url,
+                response=None,
+                context=context,
+                attempts=0,
+                timeout=timeout,
+                final_error="CircuitOpenError",
+            )
+            return Err(CircuitOpenError(host), meta=meta)
+
+        try:
+            self._enforce_robots(url)
+        except RobotsBlockedError as exc:
+            meta = self._build_meta(
+                method=method,
+                request_url=url,
+                response=None,
+                context=context,
+                attempts=0,
+                timeout=timeout,
+                final_error="RobotsBlockedError",
+            )
+            return Err(exc, meta=meta)
+
+        self._enforce_rate_limit(host)
+        is_safe_method = method.upper() in {"GET", "HEAD"}
+        pool = self._config.proxy_pool
+        attempts = 0
+        last_error: Exception | None = None
+        last_blocked_response: Any = None
+        last_blocked_retry_after: float | None = None
+        current_proxy: Mapping[str, str] | None = None
+        if pool is not None:
+            current_proxy = pool.next_proxy()
+            self._apply_proxy(current_proxy)
+        for _ in range(self._max_attempts()):
+            attempts += 1
+            try:
+                response = request_fn()
+                if (
+                    response.status_code in self._config.retry_on_status
+                    and is_safe_method
+                ):
+                    last_blocked_retry_after = self._parse_retry_after(response)
+                    last_blocked_response = response
+                    last_error = None
+                    if attempts < self._max_attempts():
+                        if pool is not None:
+                            pool.mark_failure(current_proxy)
+                            current_proxy = pool.next_proxy()
+                            self._apply_proxy(current_proxy)
+                        self._sleep_for_retry_after(
+                            last_blocked_retry_after, attempts
+                        )
+                        continue
+                    break
+                if cb is not None:
+                    cb.record_success()
+                return Ok(
+                    value_builder(response),
+                    meta=self._build_meta(
+                        method=method,
+                        request_url=url,
+                        response=response,
+                        context=context,
+                        attempts=attempts,
+                        timeout=timeout,
+                    ),
+                )
+            except Exception as exc:
+                if not self._is_transport_exception(exc):
+                    # pragma: no cover - defensive fallback for non-transport errors
+                    if cb is not None:
+                        cb.record_failure()
+                    return Err(
+                        HttpClientError(str(exc)),
+                        meta=self._build_meta(
+                            method=method,
+                            request_url=url,
+                            response=None,
+                            context=context,
+                            attempts=attempts,
+                            timeout=timeout,
+                            final_error=type(exc).__name__,
+                        ),
+                    )
+                last_error = exc
+                last_blocked_response = None
+                last_blocked_retry_after = None
+                if (
+                    attempts >= self._max_attempts()
+                    or not self._is_retryable_exception(method, exc)
+                ):
+                    break
+                if pool is not None:
+                    pool.mark_failure(current_proxy)
+                    current_proxy = pool.next_proxy()
+                    self._apply_proxy(current_proxy)
+                self._sleep_between_attempts(attempts)
+            finally:
+                if host:
+                    self._last_request_time[host] = monotonic()
+
+        if last_blocked_response is not None:
+            if cb is not None:
+                cb.record_failure()
+            if pool is not None:
+                pool.mark_failure(current_proxy)
+            return Err(
+                RateLimitedError(
+                    last_blocked_response.status_code, last_blocked_retry_after
+                ),
+                meta=self._build_meta(
+                    method=method,
+                    request_url=url,
+                    response=last_blocked_response,
+                    context=context,
+                    attempts=attempts,
+                    timeout=timeout,
+                    final_error="RateLimitedError",
+                ),
+            )
+
+        assert last_error is not None
+        if cb is not None:
+            cb.record_failure()
+        if pool is not None:
+            pool.mark_failure(current_proxy)
+        return self._handle_request_exception(
+            method=method,
+            request_url=url,
+            e=last_error,
+            context=context,
+            attempts=attempts,
+            timeout=timeout,
+        )

--- a/src/ladon/networking/async_client.py
+++ b/src/ladon/networking/async_client.py
@@ -221,10 +221,8 @@ class AsyncHttpClient:
         except ValueError:
             pass
         try:
-            # parsedate_to_datetime has no type stubs; cast gives pyright a
-            # concrete datetime so downstream arithmetic is fully typed.
-            raw = parsedate_to_datetime(header)  # pyright: ignore
-            dt = cast(datetime, raw)
+            raw = parsedate_to_datetime(header)  # type: ignore
+            dt = cast(datetime, raw)  # pyright: ignore[reportUnnecessaryCast]
             delta = (dt - datetime.now(tz=timezone.utc)).total_seconds()
             return max(0.0, delta)
         except Exception:

--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -1,8 +1,8 @@
-"""Synchronous HTTP client interface for the Ladon networking layer.
+"""HttpClient — synchronous HTTP client for the Ladon networking layer.
 
-This module defines the public interface used by crawlers/adapters. It is
-policy-agnostic by design; retries, rate limits, circuit breaking, and
-robots enforcement are applied by the concrete implementation.
+Policy (retries, rate limits, circuit breaking, robots.txt) is provided by
+SyncPolicyBase.  This module contains only the requests-specific session
+setup and exception mapping.
 """
 
 from __future__ import annotations
@@ -67,6 +67,7 @@ class HttpClient(SyncPolicyBase):
         self._session.close()
 
     def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True for any requests library transport exception."""
         return isinstance(exc, requests.exceptions.RequestException)
 
     def _is_retryable_exception(self, method: str, exc: Exception) -> bool:

--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -7,7 +7,7 @@ setup and exception mapping.
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping
 
 import requests
 
@@ -67,7 +67,7 @@ class HttpClient(SyncPolicyBase):
         self._session.close()
 
     @property
-    def _proxies(self) -> dict[str, str]:
+    def _proxies(self) -> MutableMapping[str, str]:
         return self._session.proxies  # type: ignore[no-any-return]
 
     def _is_transport_exception(self, exc: Exception) -> bool:

--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -7,32 +7,22 @@ robots enforcement are applied by the concrete implementation.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
-from random import uniform
-from time import monotonic, sleep
-from typing import Any, Callable, Mapping, TypeVar
-from urllib.parse import urlparse
+from typing import Any, Mapping
 
 import requests
 
-from .circuit_breaker import CircuitBreaker, CircuitState
+from ._sync_policy_base import SyncPolicyBase
 from .config import HttpClientConfig
 from .errors import (
-    CircuitOpenError,
     HttpClientError,
-    RateLimitedError,
     RequestTimeoutError,
-    RobotsBlockedError,
     TransientNetworkError,
 )
 from .robots import RobotsCache
-from .types import Err, Ok, Result
-
-ResponseValue = TypeVar("ResponseValue")
+from .types import Err, Result
 
 
-class HttpClient:
+class HttpClient(SyncPolicyBase):
     """Core HTTP client interface (sync).
 
     All outbound HTTP in Ladon must go through this client to ensure consistent
@@ -52,10 +42,8 @@ class HttpClient:
         Args:
             config: Configuration for timeouts, headers, and policy settings.
         """
-        self._config = config
+        super().__init__(config)
         self._session = requests.Session()
-        self._last_request_time: dict[str, float] = {}
-        self._circuit_breakers: dict[str, CircuitBreaker] = {}
         if self._config.user_agent:
             self._session.headers["User-Agent"] = self._config.user_agent
         self._session.headers.update(self._config.default_headers)
@@ -63,7 +51,7 @@ class HttpClient:
             self._session.proxies.update(self._config.proxies)
         if self._config.auth is not None:
             self._session.auth = self._config.auth
-        self._robots_cache: RobotsCache | None = (
+        self._robots_cache = (
             RobotsCache(
                 self._session,
                 self._config.user_agent or "*",
@@ -73,234 +61,34 @@ class HttpClient:
             if self._config.respect_robots_txt
             else None
         )
-        # Per-host Crawl-delay overrides populated by _enforce_robots.
-        # These take precedence over min_request_interval_seconds when larger.
-        self._crawl_delay_overrides: dict[str, float] = {}
 
     def close(self) -> None:
         """Close the underlying session and release pooled connections."""
         self._session.close()
 
-    def __enter__(self) -> HttpClient:
-        return self
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        return isinstance(exc, requests.exceptions.RequestException)
 
-    def __exit__(self, *_: object) -> None:
-        self.close()
-
-    def _get_timeout(
-        self, override: float | None
-    ) -> float | tuple[float, float]:
-        """Resolve timeout preference."""
-        if override is not None:
-            if override <= 0:
-                raise ValueError("timeout override must be > 0 when provided")
-            return override
-        if (
-            self._config.connect_timeout_seconds is not None
-            and self._config.read_timeout_seconds is not None
-        ):
-            return (
-                self._config.connect_timeout_seconds,
-                self._config.read_timeout_seconds,
-            )
-        return self._config.timeout_seconds
-
-    def _max_attempts(self) -> int:
-        """Return the total number of attempts for one request."""
-        return 1 + max(0, self._config.retries)
-
-    def _is_retryable_exception(
-        self, method: str, error: requests.exceptions.RequestException
-    ) -> bool:
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
         """Return True for retryable transport errors."""
         if method.upper() not in {"GET", "HEAD"}:
             return False
         return isinstance(
-            error,
+            exc,
             (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
         )
-
-    def _sleep_between_attempts(self, attempt: int) -> None:
-        """Sleep between retry attempts using exponential backoff."""
-        backoff_base = self._config.backoff_base_seconds
-        if backoff_base <= 0:
-            return
-        cap = backoff_base * (2 ** max(0, attempt - 1))
-        sleep(uniform(0.0, cap) if self._config.backoff_jitter else cap)
-
-    @staticmethod
-    def _parse_retry_after(response: requests.Response) -> float | None:
-        """Parse the ``Retry-After`` header from *response* into seconds.
-
-        Handles both delta-seconds (``"60"``) and HTTP-date
-        (``"Wed, 21 Oct 2015 07:28:00 GMT"``) forms per RFC 7231 §7.1.3.
-
-        Returns:
-            Seconds to wait (clamped to 0.0 minimum), or ``None`` if the
-            header is absent or cannot be parsed.
-        """
-        header = response.headers.get("Retry-After")
-        if header is None:
-            return None
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            pass
-        try:
-            dt = parsedate_to_datetime(header)
-            delta = (dt - datetime.now(tz=timezone.utc)).total_seconds()
-            return max(0.0, delta)
-        except Exception:  # fail-open: treat any unparseable date as absent
-            return None
-
-    def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        """Sleep before a retry triggered by a rate-limiting HTTP response.
-
-        When *retry_after* is not ``None``: caps it at
-        ``max_retry_after_seconds``, then takes the longer of the capped value
-        and ``min_request_interval_seconds`` so the client's own politeness
-        policy is never violated.  Falls back to ``_sleep_between_attempts``
-        when *retry_after* is ``None``.
-        """
-        if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            sleep(max(capped, self._config.min_request_interval_seconds))
-        else:
-            self._sleep_between_attempts(attempt)
-
-    def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
-        """Update session proxy to *proxy*, clearing any previous setting."""
-        self._session.proxies.clear()
-        if proxy is not None:
-            self._session.proxies.update(proxy)
-
-    def _merge_params(
-        self, params: Mapping[str, str] | None
-    ) -> Mapping[str, str] | None:
-        """Merge *params* with ``default_params``, per-request wins on collision."""
-        dp = self._config.default_params
-        if dp is None:
-            return params
-        merged = {**dp, **(params or {})}
-        return merged if merged else None
-
-    def _enforce_robots(self, url: str) -> None:
-        """Raise ``RobotsBlockedError`` if *url* is disallowed by robots.txt.
-
-        No-op when ``respect_robots_txt`` is False (the default) or when the
-        robots.txt fetch fails (fail-open behaviour).
-
-        Called before ``_enforce_rate_limit`` so that blocked requests are
-        rejected before the rate-limit slot is consumed — honouring the spirit
-        of the robots.txt contract: don't even waste a rate-limit slot on a
-        host that has explicitly opted out of being crawled.
-
-        Known limitation — robots.txt fetch bypasses rate-limiter
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        ``RobotsCache`` fetches ``/robots.txt`` via a raw ``session.get``
-        call that is invisible to ``_enforce_rate_limit``.  On the first
-        request to any origin this produces two outbound HTTP requests to
-        that host in rapid succession (robots.txt fetch + the actual request),
-        regardless of ``min_request_interval_seconds``.  The cache guarantees
-        at most one robots.txt fetch per origin per session, so subsequent
-        requests to the same host are unaffected.  This trade-off is
-        documented in ADR-008.
-        """
-        if self._robots_cache is None:
-            return
-        if not self._robots_cache.is_allowed(url):
-            raise RobotsBlockedError(f"robots.txt disallows: {url}")
-        # Propagate Crawl-delay into the rate limiter for this host.
-        # HttpClientConfig is frozen so we maintain a side-table of per-host
-        # delay overrides rather than mutating config.
-        # Note: Crawl-delay is only registered here, on the *allowed* path.
-        # A domain that disallows all URLs but advertises Crawl-delay will
-        # have the delay present in RobotsCache._crawl_delays (populated at
-        # fetch time) but absent from _crawl_delay_overrides (since no request
-        # is ever made to that host, there is nothing to throttle).
-        delay = self._robots_cache.crawl_delay(url)
-        if delay is not None:
-            host = urlparse(url).netloc
-            current = self._config.min_request_interval_seconds
-            if delay > current:
-                self._crawl_delay_overrides[host] = delay
-
-    def _enforce_rate_limit(self, url: str) -> None:
-        """Enforce per-host politeness delay before issuing a request.
-
-        If ``min_request_interval_seconds`` is set, sleeps for however long
-        remains since the last request to the same host, then records the
-        current time as the new last-request timestamp for that host.
-
-        No-op when ``min_request_interval_seconds`` is zero (the default).
-        """
-        host = urlparse(url).netloc
-        if not host:
-            return  # malformed URL — skip rather than poisoning the empty-key slot
-        interval = max(
-            self._config.min_request_interval_seconds,
-            self._crawl_delay_overrides.get(host, 0.0),
-        )
-        if interval <= 0:
-            return
-        last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                sleep(remaining)
-        # Writes here (start-to-start semantics). The three other clients write
-        # in the _request finally block (end-to-start). Will be aligned in #109.
-        self._last_request_time[host] = monotonic()
-
-    def _build_meta(
-        self,
-        method: str,
-        request_url: str,
-        response: requests.Response | None,
-        context: Mapping[str, Any] | None,
-        attempts: int,
-        timeout: float | tuple[float, float] | None,
-        final_error: str | None = None,
-    ) -> dict[str, Any]:
-        """Construct metadata dictionary from response and context."""
-        meta: dict[str, Any] = {}
-        meta["method"] = method
-        meta["url"] = request_url
-        meta["attempts"] = attempts
-        meta["timeout_s"] = timeout
-        if context:
-            context_dict = dict(context)
-            meta["context"] = context_dict
-            for key, value in context_dict.items():
-                meta.setdefault(key, value)
-
-        if response is not None:
-            meta["status_code"] = response.status_code
-            meta["url"] = response.url
-            meta["reason"] = response.reason
-            try:
-                meta["elapsed_s"] = response.elapsed.total_seconds()
-            except AttributeError:
-                pass  # In case elapsed is not available or mocked
-        if final_error is not None:
-            meta["final_error"] = final_error
-
-        return meta
 
     def _handle_request_exception(
         self,
         method: str,
         request_url: str,
-        e: requests.exceptions.RequestException,
+        e: Exception,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: float | tuple[float, float] | None,
+        timeout: float | tuple[float, float],
     ) -> Result[Any, Exception]:
         """Map requests exceptions to Ladon errors."""
-        response = e.response
+        response = getattr(e, "response", None)
         meta = self._build_meta(
             method,
             request_url,
@@ -317,200 +105,7 @@ class HttpClient:
         if isinstance(e, requests.exceptions.ConnectionError):
             return Err(TransientNetworkError(str(e)), meta=meta)
 
-        # Generic fallback for other request exceptions
         return Err(HttpClientError(str(e)), meta=meta)
-
-    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
-        """Return the CircuitBreaker for the host of *url*, or None if disabled."""
-        threshold = self._config.circuit_breaker_failure_threshold
-        if threshold is None:
-            return None
-        host = urlparse(url).netloc
-        if not host:
-            return None
-        if host not in self._circuit_breakers:
-            self._circuit_breakers[host] = CircuitBreaker(
-                threshold=threshold,
-                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
-            )
-        return self._circuit_breakers[host]
-
-    def circuit_state(self, url: str) -> CircuitState | None:
-        """Return the current circuit-breaker state for *url*'s host.
-
-        Returns ``None`` when the circuit breaker is disabled
-        (``circuit_breaker_failure_threshold`` is ``None``) or when no
-        request has been made to the host yet.
-
-        Intended for logging, metrics, and operational dashboards — lets
-        callers surface open circuits without touching private state.
-
-        Args:
-            url: Any URL on the host to query (only the ``netloc`` is used).
-        """
-        cb = self._circuit_breakers.get(urlparse(url).netloc)
-        if cb is None:
-            return None
-        return cb.state
-
-    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
-        """Override the per-host crawl delay for *host*.
-
-        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
-        when the override is larger.  Intended for callers that parse a site's
-        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
-        """
-        self._crawl_delay_overrides[host] = delay_seconds
-
-    def _request(
-        self,
-        method: str,
-        url: str,
-        *,
-        context: Mapping[str, Any] | None,
-        timeout: float | tuple[float, float] | None,
-        request_fn: Callable[[], requests.Response],
-        value_builder: Callable[[requests.Response], ResponseValue],
-    ) -> Result[ResponseValue, Exception]:
-        """Execute request with retries and normalized metadata."""
-        cb = self._get_circuit_breaker(url)
-        if cb is not None and not cb.allow_request():
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="CircuitOpenError",
-            )
-            return Err(
-                CircuitOpenError(urlparse(url).netloc),
-                meta=meta,
-            )
-
-        try:
-            self._enforce_robots(url)
-        except RobotsBlockedError as exc:
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="RobotsBlockedError",
-            )
-            return Err(exc, meta=meta)
-
-        self._enforce_rate_limit(url)
-        is_safe_method = method.upper() in {"GET", "HEAD"}
-        pool = self._config.proxy_pool
-        attempts = 0
-        last_error: requests.exceptions.RequestException | None = None
-        last_blocked_response: requests.Response | None = None
-        last_blocked_retry_after: float | None = None
-        current_proxy: Mapping[str, str] | None = None
-        if pool is not None:
-            current_proxy = pool.next_proxy()
-            self._apply_proxy(current_proxy)
-        for _ in range(self._max_attempts()):
-            attempts += 1
-            try:
-                response = request_fn()
-                if (
-                    response.status_code in self._config.retry_on_status
-                    and is_safe_method
-                ):
-                    last_blocked_retry_after = self._parse_retry_after(response)
-                    last_blocked_response = response
-                    last_error = None
-                    if attempts < self._max_attempts():
-                        if pool is not None:
-                            pool.mark_failure(current_proxy)
-                            current_proxy = pool.next_proxy()
-                            self._apply_proxy(current_proxy)
-                        self._sleep_for_retry_after(
-                            last_blocked_retry_after, attempts
-                        )
-                        continue
-                    break
-                if cb is not None:
-                    cb.record_success()
-                return Ok(
-                    value_builder(response),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=response,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                    ),
-                )
-            except requests.exceptions.RequestException as exc:
-                last_error = exc
-                last_blocked_response = None
-                last_blocked_retry_after = None
-                if (
-                    attempts >= self._max_attempts()
-                    or not self._is_retryable_exception(method, exc)
-                ):
-                    break
-                if pool is not None:
-                    pool.mark_failure(current_proxy)
-                    current_proxy = pool.next_proxy()
-                    self._apply_proxy(current_proxy)
-                self._sleep_between_attempts(attempts)
-            except Exception as exc:  # pragma: no cover - defensive fallback
-                if cb is not None:
-                    cb.record_failure()
-                return Err(
-                    HttpClientError(str(exc)),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=None,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                        final_error=type(exc).__name__,
-                    ),
-                )
-
-        if last_blocked_response is not None:
-            if cb is not None:
-                cb.record_failure()
-            if pool is not None:
-                pool.mark_failure(current_proxy)
-            return Err(
-                RateLimitedError(
-                    last_blocked_response.status_code, last_blocked_retry_after
-                ),
-                meta=self._build_meta(
-                    method=method,
-                    request_url=url,
-                    response=last_blocked_response,
-                    context=context,
-                    attempts=attempts,
-                    timeout=timeout,
-                    final_error="RateLimitedError",
-                ),
-            )
-
-        assert last_error is not None
-        if cb is not None:
-            cb.record_failure()
-        if pool is not None:
-            pool.mark_failure(current_proxy)
-        return self._handle_request_exception(
-            method=method,
-            request_url=url,
-            e=last_error,
-            context=context,
-            attempts=attempts,
-            timeout=timeout,
-        )
 
     @staticmethod
     def _content_value(response: requests.Response) -> bytes:

--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -66,6 +66,10 @@ class HttpClient(SyncPolicyBase):
         """Close the underlying session and release pooled connections."""
         self._session.close()
 
+    @property
+    def _proxies(self) -> dict[str, str]:
+        return self._session.proxies  # type: ignore[no-any-return]
+
     def _is_transport_exception(self, exc: Exception) -> bool:
         """Return True for any requests library transport exception."""
         return isinstance(exc, requests.exceptions.RequestException)

--- a/src/ladon/networking/curl_client.py
+++ b/src/ladon/networking/curl_client.py
@@ -18,35 +18,25 @@ Bootstrap symbols (cffi, cffi_exc, BrowserType) are owned by _cffi_common.py.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
-from random import uniform
-from time import monotonic, sleep
-from typing import Any, Callable, Mapping, TypeVar
-from urllib.parse import urlparse
+from typing import Any, Mapping
 
 from ._cffi_common import cffi as _cffi
 from ._cffi_common import cffi_exc as _cffi_exc
 from ._cffi_common import curl_cffi_available as _curl_cffi_available
 from ._cffi_common import import_error_msg as _import_error_msg
 from ._cffi_common import valid_impersonate as _valid_impersonate
-from .circuit_breaker import CircuitBreaker, CircuitState
+from ._sync_policy_base import SyncPolicyBase
 from .config import HttpClientConfig
 from .errors import (
-    CircuitOpenError,
     HttpClientError,
-    RateLimitedError,
     RequestTimeoutError,
-    RobotsBlockedError,
     TransientNetworkError,
 )
 from .robots import RobotsCache
-from .types import Err, Ok, Result
-
-ResponseValue = TypeVar("ResponseValue")
+from .types import Err, Result
 
 
-class CurlHttpClient:
+class CurlHttpClient(SyncPolicyBase):
     """Sync HTTP client with TLS fingerprint impersonation via curl-cffi.
 
     Drop-in replacement for ``HttpClient`` for targets protected by
@@ -82,11 +72,9 @@ class CurlHttpClient:
                 "not supported. Use default_headers={'Authorization': '...'} "
                 "for Bearer tokens or other header-based schemes."
             )
-        self._config = config
+        super().__init__(config)
         self._impersonate = impersonate
         self._session: Any = _cffi.Session(impersonate=impersonate)
-        self._last_request_time: dict[str, float] = {}
-        self._circuit_breakers: dict[str, CircuitBreaker] = {}
         if self._config.user_agent:
             self._session.headers["User-Agent"] = self._config.user_agent
         self._session.headers.update(self._config.default_headers)
@@ -94,7 +82,7 @@ class CurlHttpClient:
             self._session.proxies.update(self._config.proxies)
         if self._config.auth is not None:
             self._session.auth = self._config.auth
-        self._robots_cache: RobotsCache | None = (
+        self._robots_cache = (
             RobotsCache(
                 self._session,
                 self._config.user_agent or "*",
@@ -104,7 +92,6 @@ class CurlHttpClient:
             if self._config.respect_robots_txt
             else None
         )
-        self._crawl_delay_overrides: dict[str, float] = {}
 
     @property
     def impersonate(self) -> str:
@@ -115,160 +102,26 @@ class CurlHttpClient:
         """Close the underlying session and release pooled connections."""
         self._session.close()
 
-    def __enter__(self) -> CurlHttpClient:
-        return self
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        return isinstance(exc, _cffi_exc.RequestException)
 
-    def __exit__(self, *_: object) -> None:
-        self.close()
-
-    def _get_timeout(
-        self, override: float | None
-    ) -> float | tuple[float, float]:
-        if override is not None:
-            if override <= 0:
-                raise ValueError("timeout override must be > 0 when provided")
-            return override
-        if (
-            self._config.connect_timeout_seconds is not None
-            and self._config.read_timeout_seconds is not None
-        ):
-            return (
-                self._config.connect_timeout_seconds,
-                self._config.read_timeout_seconds,
-            )
-        return self._config.timeout_seconds
-
-    def _max_attempts(self) -> int:
-        return 1 + max(0, self._config.retries)
-
-    def _is_retryable_exception(self, method: str, error: Any) -> bool:
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
         if method.upper() not in {"GET", "HEAD"}:
             return False
         # SSLError subclasses ConnectionError and will be retried here; cert
         # failures are not transient but exhausting retries is the safe default.
-        return isinstance(
-            error,
-            (_cffi_exc.Timeout, _cffi_exc.ConnectionError),
-        )
-
-    def _sleep_between_attempts(self, attempt: int) -> None:
-        backoff_base = self._config.backoff_base_seconds
-        if backoff_base <= 0:
-            return
-        cap = backoff_base * (2 ** max(0, attempt - 1))
-        sleep(uniform(0.0, cap) if self._config.backoff_jitter else cap)
-
-    @staticmethod
-    def _parse_retry_after(response: Any) -> float | None:
-        header = response.headers.get("Retry-After")
-        if header is None:
-            return None
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            pass
-        try:
-            dt: datetime = parsedate_to_datetime(str(header))
-            delta: float = (dt - datetime.now(tz=timezone.utc)).total_seconds()
-            return max(0.0, delta)
-        except Exception:
-            return None
-
-    def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            sleep(max(capped, self._config.min_request_interval_seconds))
-        else:
-            self._sleep_between_attempts(attempt)
-
-    def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
-        self._session.proxies.clear()
-        if proxy is not None:
-            self._session.proxies.update(proxy)
-
-    def _merge_params(
-        self, params: Mapping[str, str] | None
-    ) -> Mapping[str, str] | None:
-        dp = self._config.default_params
-        if dp is None:
-            return params
-        merged = {**dp, **(params or {})}
-        return merged if merged else None
-
-    def _enforce_robots(self, url: str) -> None:
-        if self._robots_cache is None:
-            return
-        if not self._robots_cache.is_allowed(url):
-            raise RobotsBlockedError(f"robots.txt disallows: {url}")
-        delay = self._robots_cache.crawl_delay(url)
-        if delay is not None:
-            host = urlparse(url).netloc
-            current = self._config.min_request_interval_seconds
-            if delay > current:
-                self._crawl_delay_overrides[host] = delay
-
-    def _enforce_rate_limit(self, url: str) -> None:
-        host = urlparse(url).netloc
-        if not host:
-            return
-        interval = max(
-            self._config.min_request_interval_seconds,
-            self._crawl_delay_overrides.get(host, 0.0),
-        )
-        if interval <= 0:
-            return
-        last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                sleep(remaining)
-
-    def _build_meta(
-        self,
-        method: str,
-        request_url: str,
-        response: Any | None,
-        context: Mapping[str, Any] | None,
-        attempts: int,
-        timeout: float | tuple[float, float] | None,
-        final_error: str | None = None,
-    ) -> dict[str, Any]:
-        meta: dict[str, Any] = {}
-        meta["method"] = method
-        meta["url"] = request_url
-        meta["attempts"] = attempts
-        meta["timeout_s"] = timeout
-        if context:
-            context_dict = dict(context)
-            meta["context"] = context_dict
-            for key, value in context_dict.items():
-                meta.setdefault(key, value)
-
-        if response is not None:
-            meta["status_code"] = response.status_code
-            meta["url"] = response.url
-            meta["reason"] = response.reason
-            try:
-                meta["elapsed_s"] = response.elapsed.total_seconds()
-            except AttributeError:
-                pass
-        if final_error is not None:
-            meta["final_error"] = final_error
-
-        return meta
+        return isinstance(exc, (_cffi_exc.Timeout, _cffi_exc.ConnectionError))
 
     def _handle_request_exception(
         self,
         method: str,
         request_url: str,
-        e: Any,
+        e: Exception,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: float | tuple[float, float] | None,
+        timeout: float | tuple[float, float],
     ) -> Result[Any, Exception]:
+        """Map curl-cffi exceptions to Ladon errors."""
         response = getattr(e, "response", None)
         meta = self._build_meta(
             method,
@@ -287,190 +140,6 @@ class CurlHttpClient:
             return Err(TransientNetworkError(str(e)), meta=meta)
 
         return Err(HttpClientError(str(e)), meta=meta)
-
-    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
-        threshold = self._config.circuit_breaker_failure_threshold
-        if threshold is None:
-            return None
-        host = urlparse(url).netloc
-        if not host:
-            return None
-        if host not in self._circuit_breakers:
-            self._circuit_breakers[host] = CircuitBreaker(
-                threshold=threshold,
-                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
-            )
-        return self._circuit_breakers[host]
-
-    def circuit_state(self, url: str) -> CircuitState | None:
-        """Return the current circuit-breaker state for *url*'s host.
-
-        Returns ``None`` when circuit breaking is disabled or no request has
-        been made to the host yet.
-        """
-        cb = self._circuit_breakers.get(urlparse(url).netloc)
-        if cb is None:
-            return None
-        return cb.state
-
-    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
-        """Override the per-host crawl delay for *host*.
-
-        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
-        when the override is larger.  Intended for callers that parse a site's
-        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
-        """
-        self._crawl_delay_overrides[host] = delay_seconds
-
-    def _request(
-        self,
-        method: str,
-        url: str,
-        *,
-        context: Mapping[str, Any] | None,
-        timeout: float | tuple[float, float],
-        request_fn: Callable[[], Any],
-        value_builder: Callable[[Any], ResponseValue],
-    ) -> Result[ResponseValue, Exception]:
-        cb = self._get_circuit_breaker(url)
-        if cb is not None and not cb.allow_request():
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="CircuitOpenError",
-            )
-            return Err(CircuitOpenError(urlparse(url).netloc), meta=meta)
-
-        try:
-            self._enforce_robots(url)
-        except RobotsBlockedError as exc:
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="RobotsBlockedError",
-            )
-            return Err(exc, meta=meta)
-
-        self._enforce_rate_limit(url)
-        host = urlparse(url).netloc
-        is_safe_method = method.upper() in {"GET", "HEAD"}
-        pool = self._config.proxy_pool
-        attempts = 0
-        last_error: Any = None
-        last_blocked_response: Any = None
-        last_blocked_retry_after: float | None = None
-        current_proxy: Mapping[str, str] | None = None
-        if pool is not None:
-            current_proxy = pool.next_proxy()
-            self._apply_proxy(current_proxy)
-        for _ in range(self._max_attempts()):
-            attempts += 1
-            try:
-                response = request_fn()
-                if (
-                    response.status_code in self._config.retry_on_status
-                    and is_safe_method
-                ):
-                    last_blocked_retry_after = self._parse_retry_after(response)
-                    last_blocked_response = response
-                    last_error = None
-                    if attempts < self._max_attempts():
-                        if pool is not None:
-                            pool.mark_failure(current_proxy)
-                            current_proxy = pool.next_proxy()
-                            self._apply_proxy(current_proxy)
-                        self._sleep_for_retry_after(
-                            last_blocked_retry_after, attempts
-                        )
-                        continue
-                    break
-                if cb is not None:
-                    cb.record_success()
-                return Ok(
-                    value_builder(response),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=response,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                    ),
-                )
-            except _cffi_exc.RequestException as exc:
-                last_error = exc
-                last_blocked_response = None
-                last_blocked_retry_after = None
-                if (
-                    attempts >= self._max_attempts()
-                    or not self._is_retryable_exception(method, exc)
-                ):
-                    break
-                if pool is not None:
-                    pool.mark_failure(current_proxy)
-                    current_proxy = pool.next_proxy()
-                    self._apply_proxy(current_proxy)
-                self._sleep_between_attempts(attempts)
-            except Exception as exc:  # pragma: no cover - defensive fallback
-                if cb is not None:
-                    cb.record_failure()
-                return Err(
-                    HttpClientError(str(exc)),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=None,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                        final_error=type(exc).__name__,
-                    ),
-                )
-            finally:
-                if host:
-                    self._last_request_time[host] = monotonic()
-
-        if last_blocked_response is not None:
-            if cb is not None:
-                cb.record_failure()
-            if pool is not None:
-                pool.mark_failure(current_proxy)
-            return Err(
-                RateLimitedError(
-                    last_blocked_response.status_code, last_blocked_retry_after
-                ),
-                meta=self._build_meta(
-                    method=method,
-                    request_url=url,
-                    response=last_blocked_response,
-                    context=context,
-                    attempts=attempts,
-                    timeout=timeout,
-                    final_error="RateLimitedError",
-                ),
-            )
-
-        assert last_error is not None
-        if cb is not None:
-            cb.record_failure()
-        if pool is not None:
-            pool.mark_failure(current_proxy)
-        return self._handle_request_exception(
-            method=method,
-            request_url=url,
-            e=last_error,
-            context=context,
-            attempts=attempts,
-            timeout=timeout,
-        )
 
     @staticmethod
     def _content_value(response: Any) -> bytes:

--- a/src/ladon/networking/curl_client.py
+++ b/src/ladon/networking/curl_client.py
@@ -103,6 +103,7 @@ class CurlHttpClient(SyncPolicyBase):
         self._session.close()
 
     def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True for any curl-cffi transport exception."""
         return isinstance(exc, _cffi_exc.RequestException)
 
     def _is_retryable_exception(self, method: str, exc: Exception) -> bool:

--- a/src/ladon/networking/curl_client.py
+++ b/src/ladon/networking/curl_client.py
@@ -102,6 +102,10 @@ class CurlHttpClient(SyncPolicyBase):
         """Close the underlying session and release pooled connections."""
         self._session.close()
 
+    @property
+    def _proxies(self) -> dict[str, str]:
+        return self._session.proxies  # type: ignore[no-any-return]
+
     def _is_transport_exception(self, exc: Exception) -> bool:
         """Return True for any curl-cffi transport exception."""
         return isinstance(exc, _cffi_exc.RequestException)

--- a/src/ladon/networking/curl_client.py
+++ b/src/ladon/networking/curl_client.py
@@ -18,7 +18,7 @@ Bootstrap symbols (cffi, cffi_exc, BrowserType) are owned by _cffi_common.py.
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping
 
 from ._cffi_common import cffi as _cffi
 from ._cffi_common import cffi_exc as _cffi_exc
@@ -103,7 +103,7 @@ class CurlHttpClient(SyncPolicyBase):
         self._session.close()
 
     @property
-    def _proxies(self) -> dict[str, str]:
+    def _proxies(self) -> MutableMapping[str, str]:
         return self._session.proxies  # type: ignore[no-any-return]
 
     def _is_transport_exception(self, exc: Exception) -> bool:

--- a/tests/test_backoff_jitter.py
+++ b/tests/test_backoff_jitter.py
@@ -41,8 +41,8 @@ def test_backoff_jitter_can_be_enabled():
 
 
 class TestJitterDisabled:
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_deterministic_backoff_no_jitter(
         self, mock_get, mock_uniform, mock_sleep
@@ -58,8 +58,8 @@ class TestJitterDisabled:
         mock_uniform.assert_not_called()
         assert mock_sleep.call_args_list == [call(1.0), call(2.0)]
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_zero_base_no_sleep_no_uniform(
         self, mock_get, mock_uniform, mock_sleep
@@ -82,8 +82,8 @@ class TestJitterDisabled:
 
 
 class TestJitterEnabled:
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_jitter_calls_uniform_with_correct_caps(
         self, mock_get, mock_uniform, mock_sleep
@@ -106,8 +106,8 @@ class TestJitterEnabled:
         assert mock_uniform.call_args_list == [call(0.0, 1.0), call(0.0, 2.0)]
         assert mock_sleep.call_args_list == [call(0.37), call(0.37)]
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_jitter_sleep_uses_uniform_return_value(
         self, mock_get, mock_uniform, mock_sleep
@@ -128,8 +128,8 @@ class TestJitterEnabled:
         mock_uniform.assert_called_once_with(0.0, 4.0)
         mock_sleep.assert_called_once_with(1.23)
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_jitter_zero_base_is_noop(self, mock_get, mock_uniform, mock_sleep):
         config = HttpClientConfig(
@@ -146,8 +146,8 @@ class TestJitterEnabled:
         mock_uniform.assert_not_called()
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_jitter_cap_grows_exponentially(
         self, mock_get, mock_uniform, mock_sleep
@@ -175,8 +175,8 @@ class TestJitterEnabled:
 
 
 class TestJitterWithRetryAfterFallback:
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_retry_after_header_present_jitter_not_applied(
         self, mock_get, mock_uniform, mock_sleep
@@ -202,8 +202,8 @@ class TestJitterWithRetryAfterFallback:
         mock_uniform.assert_not_called()
         mock_sleep.assert_called_once_with(30.0)
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_retry_after_absent_jitter_applied_to_fallback(
         self, mock_get, mock_uniform, mock_sleep

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from time import monotonic
 from typing import Generator
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -283,7 +284,7 @@ class TestHttpClientCircuitBreaker:
         assert cb_client.circuit_state(url) is CircuitState.OPEN
 
         # Force into HALF_OPEN by backdating the timer.
-        cb = cb_client._get_circuit_breaker(url)  # type: ignore[attr-defined]
+        cb = cb_client._get_circuit_breaker(urlparse(url).netloc)  # type: ignore[attr-defined]
         assert cb is not None
         cb._opened_at = monotonic() - 61.0  # type: ignore[attr-defined]
 
@@ -340,7 +341,7 @@ class TestHttpClientCircuitBreaker:
             cb_client.get(url)  # opens
 
         # Backdate the timer to trigger HALF_OPEN on next allow_request().
-        cb = cb_client._get_circuit_breaker(url)  # type: ignore[attr-defined]
+        cb = cb_client._get_circuit_breaker(urlparse(url).netloc)  # type: ignore[attr-defined]
         assert cb is not None
         cb._opened_at = monotonic() - 61.0  # type: ignore[attr-defined]
         # Trigger the transition without completing a request.

--- a/tests/test_curl_client.py
+++ b/tests/test_curl_client.py
@@ -605,7 +605,7 @@ def test_set_crawl_delay_overwrites(config: HttpClientConfig) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("ladon.networking.curl_client.sleep")
+@patch("ladon.networking._sync_policy_base.sleep")
 @patch("curl_cffi.requests.Session.get")
 def test_backoff_with_jitter_calls_sleep(
     mock_get: Mock, mock_sleep: Mock
@@ -690,8 +690,8 @@ def test_robots_crawl_delay_sets_override() -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("ladon.networking.curl_client.sleep")
-@patch("ladon.networking.curl_client.monotonic")
+@patch("ladon.networking._sync_policy_base.sleep")
+@patch("ladon.networking._sync_policy_base.monotonic")
 @patch("curl_cffi.requests.Session.get")
 def test_rate_limit_sleep_enforced(
     mock_get: Mock, mock_monotonic: Mock, mock_sleep: Mock

--- a/tests/test_proxy_pool.py
+++ b/tests/test_proxy_pool.py
@@ -184,7 +184,7 @@ def test_proxy_pool_rotates_on_rate_limit_retry():
     with patch(
         "requests.Session.get", side_effect=[blocked, _make_ok_response()]
     ):
-        with patch("ladon.networking.client.sleep"):
+        with patch("ladon.networking._sync_policy_base.sleep"):
             client = HttpClient(config)
             client.get("https://example.com")
 

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -70,8 +70,8 @@ class TestRateLimitConfig:
 
 
 class TestRateLimitEnforcement:
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_first_request_no_sleep(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -84,8 +84,8 @@ class TestRateLimitEnforcement:
 
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_second_request_sleeps_remaining_interval(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -104,8 +104,8 @@ class TestRateLimitEnforcement:
         sleep_arg = mock_sleep.call_args[0][0]
         assert sleep_arg == pytest.approx(0.7, abs=1e-9)
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_request_after_full_interval_no_sleep(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -120,8 +120,8 @@ class TestRateLimitEnforcement:
 
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_different_hosts_not_rate_limited_against_each_other(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -136,8 +136,8 @@ class TestRateLimitEnforcement:
 
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_rate_limit_is_per_host_not_per_url_path(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -155,7 +155,7 @@ class TestRateLimitEnforcement:
         sleep_arg = mock_sleep.call_args[0][0]
         assert sleep_arg == pytest.approx(0.8, abs=1e-9)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_zero_interval_never_sleeps(self, mock_get, mock_sleep):
         """With default interval (0.0), sleep must never be called."""
@@ -169,8 +169,8 @@ class TestRateLimitEnforcement:
 
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_rate_limit_applies_to_consecutive_requests(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -186,8 +186,8 @@ class TestRateLimitEnforcement:
 
         assert mock_sleep.call_count == 1
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     @patch("requests.Session.head")
     @patch("requests.Session.post")

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -108,7 +108,7 @@ class TestParseRetryAfter:
 
 
 class TestRetryAfterBehavior:
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_no_retries_returns_rate_limited_error(
         self, mock_get, mock_sleep
@@ -127,7 +127,7 @@ class TestRetryAfterBehavior:
         assert result.meta["final_error"] == "RateLimitedError"
         mock_get.assert_called_once()
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_503_returns_rate_limited_error(self, mock_get, mock_sleep):
         client = HttpClient(HttpClientConfig(timeout_seconds=5.0))
@@ -141,7 +141,7 @@ class TestRetryAfterBehavior:
         assert isinstance(result.error, RateLimitedError)
         assert result.error.status_code == 503
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_with_retry_after_sleeps_and_succeeds(
         self, mock_get, mock_sleep
@@ -159,7 +159,7 @@ class TestRetryAfterBehavior:
         assert result.value == b"ok"
         mock_sleep.assert_called_once_with(45.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_retry_after_capped_at_max(self, mock_get, mock_sleep):
         config = HttpClientConfig(
@@ -176,7 +176,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         mock_sleep.assert_called_once_with(10.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_no_retry_after_falls_back_to_backoff(
         self, mock_get, mock_sleep
@@ -195,7 +195,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         mock_sleep.assert_called_once_with(2.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_exhausts_retries_returns_rate_limited_error(
         self, mock_get, mock_sleep
@@ -217,7 +217,7 @@ class TestRetryAfterBehavior:
         assert result.meta["final_error"] == "RateLimitedError"
         assert mock_get.call_count == 3
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.post")
     def test_post_429_not_retried_returns_ok(self, mock_post, mock_sleep):
         config = HttpClientConfig(timeout_seconds=5.0, retries=3)
@@ -231,7 +231,7 @@ class TestRetryAfterBehavior:
         mock_post.assert_called_once()
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.head")
     def test_head_429_retried_like_get(self, mock_head, mock_sleep):
         config = HttpClientConfig(timeout_seconds=5.0, retries=1)
@@ -247,7 +247,7 @@ class TestRetryAfterBehavior:
         assert mock_head.call_count == 2
         mock_sleep.assert_called_once_with(5.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_circuit_breaker_trips_on_exhausted_429(self, mock_get, mock_sleep):
         config = HttpClientConfig(
@@ -263,7 +263,7 @@ class TestRetryAfterBehavior:
         assert not result.ok
         assert client.circuit_state("http://example.com") == CircuitState.OPEN
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_empty_retry_on_status_returns_ok_for_429(
         self, mock_get, mock_sleep
@@ -280,7 +280,7 @@ class TestRetryAfterBehavior:
         assert result.meta["status_code"] == 429
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_custom_retry_on_status_403_retried(self, mock_get, mock_sleep):
         config = HttpClientConfig(
@@ -299,7 +299,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         assert mock_get.call_count == 2
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_meta_includes_status_and_reason_on_rate_limited_error(
         self, mock_get, mock_sleep
@@ -315,7 +315,7 @@ class TestRetryAfterBehavior:
         assert result.meta["reason"] == "Too Many Requests"
         assert result.meta["method"] == "GET"
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_retry_after_below_min_interval_sleeps_min_interval(
         self, mock_get, mock_sleep
@@ -337,7 +337,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         mock_sleep.assert_called_once_with(60.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_retry_after_above_min_interval_sleeps_retry_after(
         self, mock_get, mock_sleep
@@ -359,7 +359,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         mock_sleep.assert_called_once_with(45.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_download_429_retried_like_get(self, mock_get, mock_sleep):
         config = HttpClientConfig(timeout_seconds=5.0, retries=1)
@@ -379,7 +379,7 @@ class TestRetryAfterBehavior:
         assert mock_get.call_count == 2
         mock_sleep.assert_called_once_with(5.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_no_retry_after_backoff_increases_per_attempt(
         self, mock_get, mock_sleep

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -391,7 +391,7 @@ class TestRobotsCacheCrawlDelayVsRateLimit:
 
         Verifies that the override recorded by _enforce_robots is actually
         consumed by _enforce_rate_limit on the *next* request to the same host.
-        We patch ``ladon.networking.client.sleep`` so the test is instant.
+        We patch ``ladon.networking._sync_policy_base.sleep`` so the test is instant.
         """
         config = HttpClientConfig(
             respect_robots_txt=True,
@@ -409,7 +409,7 @@ class TestRobotsCacheCrawlDelayVsRateLimit:
                     "requests.Session.get",
                     return_value=_mock_robots_response(ROBOTS_WITH_DELAY),
                 ),
-                patch("ladon.networking.client.sleep") as mock_sleep,
+                patch("ladon.networking._sync_policy_base.sleep") as mock_sleep,
             ):
                 # First request: registers the Crawl-delay override, no sleep yet
                 # (no prior timestamp for this host).


### PR DESCRIPTION
## Summary

- Extracts the full synchronous policy pipeline into a new `SyncPolicyBase` ABC in `_sync_policy_base.py`. Both `HttpClient` and `CurlHttpClient` become thin subclasses (~60 lines of logic each) that supply a session and implement three abstract methods for transport-specific exception handling.
- Resolves **finding Q**: `urlparse(url).netloc` now computed once at the top of `_request` and passed as `host` throughout (circuit breaker, rate limiter, finally block).
- Resolves **finding R**: `_handle_request_exception` timeout param is `float | tuple[float, float]` (no spurious `| None`).
- Aligns `HttpClient` rate-limit semantics to **end-to-start**: timestamp written in `_request` finally block, not in `_enforce_rate_limit`. `_enforce_rate_limit(host)` now takes the pre-computed host string.
- `async_client._parse_retry_after`: targeted inline type-ignores replace the bare `# pyright: ignore`, surviving both pyright environments (with/without `email.utils` stubs).

## Files changed

| File | Change |
|------|--------|
| `_sync_policy_base.py` | **NEW** — `SyncPolicyBase` ABC with full policy pipeline |
| `client.py` | **REWRITE** — thin `HttpClient(SyncPolicyBase)` subclass |
| `curl_client.py` | **REWRITE** — thin `CurlHttpClient(SyncPolicyBase)` subclass |
| `async_client.py` | Fix targeted inline ignores in `_parse_retry_after` |
| `tests/test_backoff_jitter.py` etc. | Update mock patch targets to `_sync_policy_base` |

## Test plan

- [ ] All 532 tests pass
- [ ] Pyright strict-mode: 0 errors
- [ ] Pre-commit hooks pass (black, ruff, isort, pyright)