### PR TITLE
refactor(networking): extract AsyncPolicyBase ABC (step 2 of #109)

### DIFF
--- a/src/ladon/networking/_async_policy_base.py
+++ b/src/ladon/networking/_async_policy_base.py
@@ -150,7 +150,12 @@ class AsyncPolicyBase(ABC):
         return merged if merged else None
 
     async def _enforce_rate_limit(self, host: str) -> None:
-        """Enforce per-host politeness delay before issuing a request."""
+        """Enforce per-host politeness delay before issuing a request.
+
+        Only waits — does not stamp ``_last_request_time``.  All stamping is
+        done by the ``_request`` loop's ``finally`` block so that every actual
+        attempt (including retries) updates the timestamp.
+        """
         if not host:
             return
         interval = max(

--- a/src/ladon/networking/_async_policy_base.py
+++ b/src/ladon/networking/_async_policy_base.py
@@ -1,0 +1,364 @@
+"""Shared policy pipeline for asynchronous HTTP clients.
+
+Both ``AsyncHttpClient`` (httpx) and ``AsyncCurlHttpClient`` (curl-cffi)
+subclass this ABC.  All policy logic — circuit breaking, retry loop, backoff,
+rate limiting, proxy rotation, and metadata assembly — lives here.
+
+The differences between the two async clients:
+  - transport library and its exception types
+  - timeout representation (``httpx.Timeout`` vs ``float | tuple``)
+  - per-attempt client lifecycle (httpx creates a client per proxy; curl
+    mutates ``_session.proxies``) — encapsulated in ``_execute_attempt``
+  - ``_build_meta`` field names (httpx uses ``str(r.url)`` and
+    ``r.reason_phrase``; curl uses standard names) — ``AsyncHttpClient``
+    overrides ``_build_meta``
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from random import uniform
+from time import monotonic
+from typing import Any, Callable, Mapping, Self, TypeVar
+from urllib.parse import urlparse
+
+from .circuit_breaker import CircuitBreaker, CircuitState
+from .config import HttpClientConfig
+from .errors import (
+    CircuitOpenError,
+    HttpClientError,
+    RateLimitedError,
+)
+from .types import Err, Ok, Result
+
+ResponseValue = TypeVar("ResponseValue")
+
+
+class AsyncPolicyBase(ABC):
+    """Abstract base for asynchronous HTTP clients with unified policy pipeline.
+
+    Subclasses must implement the abstract methods that vary per transport
+    library.  All shared policy logic lives in this class.
+    """
+
+    def __init__(self, config: HttpClientConfig) -> None:
+        self._config = config
+        self._last_request_time: dict[str, float] = {}
+        self._circuit_breakers: dict[str, CircuitBreaker] = {}
+        self._crawl_delay_overrides: dict[str, float] = {}
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.aclose()
+
+    @abstractmethod
+    async def aclose(self) -> None:
+        """Close the underlying session and release pooled connections."""
+
+    @abstractmethod
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True iff *exc* is a library transport exception, not a logic error."""
+
+    @abstractmethod
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
+        """Return True for transport errors that should trigger a retry."""
+
+    @abstractmethod
+    async def _execute_attempt(
+        self,
+        request_fn: Any,
+        proxy: Mapping[str, str] | None,
+    ) -> Any:
+        """Execute one request attempt for the given proxy.
+
+        Handles proxy setup and per-attempt client lifecycle internally.
+        Transport exceptions must propagate normally — the caller catches them.
+        """
+
+    @abstractmethod
+    def _handle_request_exception(
+        self,
+        method: str,
+        request_url: str,
+        e: Exception,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: Any,
+    ) -> Result[Any, Exception]:
+        """Map a transport exception to a Ladon error Result."""
+
+    # ------------------------------------------------------------------ #
+    # Concrete policy helpers                                              #
+    # ------------------------------------------------------------------ #
+
+    def _max_attempts(self) -> int:
+        """Return the total number of attempts for one request."""
+        return 1 + max(0, self._config.retries)
+
+    async def _sleep_between_attempts(self, attempt: int) -> None:
+        """Sleep between retry attempts using exponential backoff."""
+        backoff_base = self._config.backoff_base_seconds
+        if backoff_base <= 0:
+            return
+        cap = backoff_base * (2 ** max(0, attempt - 1))
+        await asyncio.sleep(
+            uniform(0.0, cap) if self._config.backoff_jitter else cap
+        )
+
+    @staticmethod
+    def _parse_retry_after(response: Any) -> float | None:
+        """Parse the ``Retry-After`` header into seconds, or ``None`` if absent."""
+        header = response.headers.get("Retry-After")
+        if header is None:
+            return None
+        try:
+            return max(0.0, float(header))
+        except ValueError:
+            pass
+        try:
+            dt: datetime = parsedate_to_datetime(str(header))
+            delta: float = (dt - datetime.now(tz=timezone.utc)).total_seconds()
+            return max(0.0, delta)
+        except Exception:
+            return None
+
+    async def _sleep_for_retry_after(
+        self, retry_after: float | None, attempt: int
+    ) -> None:
+        """Sleep before a retry triggered by a rate-limiting HTTP response."""
+        if retry_after is not None:
+            capped = min(retry_after, self._config.max_retry_after_seconds)
+            await asyncio.sleep(
+                max(capped, self._config.min_request_interval_seconds)
+            )
+        else:
+            await self._sleep_between_attempts(attempt)
+
+    def _merge_params(
+        self, params: Mapping[str, str] | None
+    ) -> Mapping[str, str] | None:
+        """Merge *params* with ``default_params``, per-request wins on collision."""
+        dp = self._config.default_params
+        if dp is None:
+            return params
+        merged = {**dp, **(params or {})}
+        return merged if merged else None
+
+    async def _enforce_rate_limit(self, host: str) -> None:
+        """Enforce per-host politeness delay before issuing a request."""
+        if not host:
+            return
+        interval = max(
+            self._config.min_request_interval_seconds,
+            self._crawl_delay_overrides.get(host, 0.0),
+        )
+        if interval <= 0:
+            return
+        last = self._last_request_time.get(host)
+        if last is not None:
+            elapsed = monotonic() - last
+            remaining = interval - elapsed
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+
+    def _get_circuit_breaker(self, host: str) -> CircuitBreaker | None:
+        """Return the CircuitBreaker for *host*, or None if circuit breaking is disabled."""
+        threshold = self._config.circuit_breaker_failure_threshold
+        if threshold is None:
+            return None
+        if not host:
+            return None
+        if host not in self._circuit_breakers:
+            self._circuit_breakers[host] = CircuitBreaker(
+                threshold=threshold,
+                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
+            )
+        return self._circuit_breakers[host]
+
+    def circuit_state(self, url: str) -> CircuitState | None:
+        """Return the current circuit-breaker state for *url*'s host, or None."""
+        cb = self._circuit_breakers.get(urlparse(url).netloc)
+        return cb.state if cb is not None else None
+
+    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
+        """Override the per-host crawl delay for *host*.
+
+        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
+        when the override is larger.
+        """
+        self._crawl_delay_overrides[host] = delay_seconds
+
+    def _build_meta(
+        self,
+        method: str,
+        request_url: str,
+        response: Any | None,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: Any,
+        final_error: str | None = None,
+    ) -> dict[str, Any]:
+        """Construct metadata dictionary from response and context."""
+        meta: dict[str, Any] = {}
+        meta["method"] = method
+        meta["url"] = request_url
+        meta["attempts"] = attempts
+        meta["timeout_s"] = timeout
+        if context:
+            context_dict = dict(context)
+            meta["context"] = context_dict
+            for key, value in context_dict.items():
+                meta.setdefault(key, value)
+        if response is not None:
+            meta["status_code"] = response.status_code
+            meta["url"] = response.url
+            meta["reason"] = response.reason
+            try:
+                meta["elapsed_s"] = response.elapsed.total_seconds()
+            except AttributeError:
+                pass
+        if final_error is not None:
+            meta["final_error"] = final_error
+        return meta
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        context: Mapping[str, Any] | None,
+        timeout: Any,
+        request_fn: Any,
+        value_builder: Callable[[Any], ResponseValue],
+    ) -> Result[ResponseValue, Exception]:
+        """Execute async request with retries, circuit breaking, and rate limiting."""
+        host = urlparse(url).netloc
+        cb = self._get_circuit_breaker(host)
+        if cb is not None and not cb.allow_request():
+            meta = self._build_meta(
+                method=method,
+                request_url=url,
+                response=None,
+                context=context,
+                attempts=0,
+                timeout=timeout,
+                final_error="CircuitOpenError",
+            )
+            return Err(CircuitOpenError(host), meta=meta)
+
+        await self._enforce_rate_limit(host)
+        is_safe_method = method.upper() in {"GET", "HEAD"}
+        pool = self._config.proxy_pool
+        attempts = 0
+        last_error: Exception | None = None
+        last_blocked_response: Any = None
+        last_blocked_retry_after: float | None = None
+        current_proxy: Mapping[str, str] | None = None
+        if pool is not None:
+            current_proxy = pool.next_proxy()
+
+        for _ in range(self._max_attempts()):
+            attempts += 1
+            try:
+                response = await self._execute_attempt(
+                    request_fn, current_proxy
+                )
+                if (
+                    response.status_code in self._config.retry_on_status
+                    and is_safe_method
+                ):
+                    last_blocked_retry_after = self._parse_retry_after(response)
+                    last_blocked_response = response
+                    last_error = None
+                    if attempts < self._max_attempts():
+                        if pool is not None:
+                            pool.mark_failure(current_proxy)
+                            current_proxy = pool.next_proxy()
+                        await self._sleep_for_retry_after(
+                            last_blocked_retry_after, attempts
+                        )
+                        continue
+                    break
+                if cb is not None:
+                    cb.record_success()
+                return Ok(
+                    value_builder(response),
+                    meta=self._build_meta(
+                        method=method,
+                        request_url=url,
+                        response=response,
+                        context=context,
+                        attempts=attempts,
+                        timeout=timeout,
+                    ),
+                )
+            except Exception as exc:
+                if not self._is_transport_exception(exc):  # pragma: no cover
+                    if cb is not None:
+                        cb.record_failure()
+                    return Err(
+                        HttpClientError(str(exc)),
+                        meta=self._build_meta(
+                            method=method,
+                            request_url=url,
+                            response=None,
+                            context=context,
+                            attempts=attempts,
+                            timeout=timeout,
+                            final_error=type(exc).__name__,
+                        ),
+                    )
+                last_error = exc
+                last_blocked_response = None
+                last_blocked_retry_after = None
+                if (
+                    attempts >= self._max_attempts()
+                    or not self._is_retryable_exception(method, exc)
+                ):
+                    break
+                if pool is not None:
+                    pool.mark_failure(current_proxy)
+                    current_proxy = pool.next_proxy()
+                await self._sleep_between_attempts(attempts)
+            finally:
+                if host:
+                    self._last_request_time[host] = monotonic()
+
+        if last_blocked_response is not None:
+            if cb is not None:
+                cb.record_failure()
+            if pool is not None:
+                pool.mark_failure(current_proxy)
+            return Err(
+                RateLimitedError(
+                    last_blocked_response.status_code, last_blocked_retry_after
+                ),
+                meta=self._build_meta(
+                    method=method,
+                    request_url=url,
+                    response=last_blocked_response,
+                    context=context,
+                    attempts=attempts,
+                    timeout=timeout,
+                    final_error="RateLimitedError",
+                ),
+            )
+
+        assert last_error is not None
+        if cb is not None:
+            cb.record_failure()
+        if pool is not None:
+            pool.mark_failure(current_proxy)
+        return self._handle_request_exception(
+            method=method,
+            request_url=url,
+            e=last_error,
+            context=context,
+            attempts=attempts,
+            timeout=timeout,
+        )

--- a/src/ladon/networking/async_client.py
+++ b/src/ladon/networking/async_client.py
@@ -1,45 +1,32 @@
-"""Asynchronous HTTP client for the Ladon networking layer (httpx backend).
+"""AsyncHttpClient — asynchronous HTTP client for the Ladon networking layer.
 
-``AsyncHttpClient`` is the **only** module in Ladon that imports ``httpx``.
-All three httpx API deltas vs ``requests`` are encapsulated as private
-methods so the rest of the codebase remains completely unaware of httpx:
+Policy (retries, rate limits, circuit breaking) is provided by
+AsyncPolicyBase.  This module contains only the httpx-specific session
+setup, timeout conversion, and exception mapping.
 
-  ``_to_httpx_proxies()``  — scheme key conversion + Transport wrapping
-  ``_to_httpx_timeout()``  — float/tuple → ``httpx.Timeout``
-  ``_build_meta()``        — ``str(r.url)``, ``r.reason_phrase``
-
-If httpx changes its API or is replaced, the blast radius is this file only.
+Three httpx API deltas vs the base are encapsulated here:
+  ``_to_httpx_proxies()`` — scheme key conversion + Transport wrapping
+  ``_to_httpx_timeout()`` — float/tuple → ``httpx.Timeout``
+  ``_build_meta()``        — ``str(r.url)``, ``r.reason_phrase``, redirect flag
 """
 
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
-from random import uniform
-from time import monotonic
-from typing import Any, Callable, Coroutine, Mapping, TypeVar, cast
-from urllib.parse import urlparse
+from typing import Any, Mapping
 
 import httpx
 
-from .circuit_breaker import CircuitBreaker, CircuitState
+from ._async_policy_base import AsyncPolicyBase
 from .config import HttpClientConfig
 from .errors import (
-    CircuitOpenError,
     HttpClientError,
-    RateLimitedError,
     RequestTimeoutError,
     TransientNetworkError,
 )
-from .types import Err, Ok, Result
-
-ResponseValue = TypeVar("ResponseValue")
-
-_RequestFn = Callable[[httpx.AsyncClient], Coroutine[Any, Any, httpx.Response]]
+from .types import Err, Result
 
 
-class AsyncHttpClient:
+class AsyncHttpClient(AsyncPolicyBase):
     """Core async HTTP client (httpx backend).
 
     All outbound async HTTP in Ladon must go through this client to ensure
@@ -74,11 +61,7 @@ class AsyncHttpClient:
                 "AsyncHttpClient only supports (username, password) tuple auth; "
                 "for other schemes use an httpx.Auth subclass directly"
             )
-
-        self._config = config
-        self._last_request_time: dict[str, float] = {}
-        self._circuit_breakers: dict[str, CircuitBreaker] = {}
-        self._crawl_delay_overrides: dict[str, float] = {}
+        super().__init__(config)
 
         headers: dict[str, str] = {}
         if config.user_agent:
@@ -104,12 +87,6 @@ class AsyncHttpClient:
     async def aclose(self) -> None:
         """Close the underlying httpx client and release connections."""
         await self._http.aclose()
-
-    async def __aenter__(self) -> AsyncHttpClient:
-        return self
-
-    async def __aexit__(self, *_: object) -> None:
-        await self.aclose()
 
     # ------------------------------------------------------------------
     # httpx API delta converters — the blast-radius boundary
@@ -158,7 +135,7 @@ class AsyncHttpClient:
         response: httpx.Response | None,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: httpx.Timeout | None,
+        timeout: Any,
         final_error: str | None = None,
     ) -> dict[str, Any]:
         meta: dict[str, Any] = {}
@@ -179,7 +156,7 @@ class AsyncHttpClient:
                 meta["redirected"] = True
             meta["reason"] = (
                 response.reason_phrase
-            )  # httpx renames .reason → .reason_phrase
+            )  # httpx: reason_phrase not reason
             try:
                 meta["elapsed_s"] = response.elapsed.total_seconds()
             except AttributeError:
@@ -189,115 +166,17 @@ class AsyncHttpClient:
         return meta
 
     # ------------------------------------------------------------------
-    # Internal helpers — mirrors HttpClient
+    # Abstract method implementations
     # ------------------------------------------------------------------
 
-    def _max_attempts(self) -> int:
-        return 1 + max(0, self._config.retries)
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True for any httpx transport exception."""
+        return isinstance(exc, httpx.RequestError)
 
-    def _is_retryable_exception(
-        self, method: str, error: httpx.RequestError
-    ) -> bool:
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
         if method.upper() not in {"GET", "HEAD"}:
             return False
-        return isinstance(error, (httpx.TimeoutException, httpx.ConnectError))
-
-    async def _sleep_between_attempts(self, attempt: int) -> None:
-        backoff_base = self._config.backoff_base_seconds
-        if backoff_base <= 0:
-            return
-        cap = backoff_base * (2 ** max(0, attempt - 1))
-        await asyncio.sleep(
-            uniform(0.0, cap) if self._config.backoff_jitter else cap
-        )
-
-    @staticmethod
-    def _parse_retry_after(response: httpx.Response) -> float | None:
-        header = response.headers.get("Retry-After")
-        if header is None:
-            return None
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            pass
-        try:
-            raw = parsedate_to_datetime(header)  # type: ignore
-            dt = cast(datetime, raw)  # pyright: ignore[reportUnnecessaryCast]
-            delta = (dt - datetime.now(tz=timezone.utc)).total_seconds()
-            return max(0.0, delta)
-        except Exception:
-            return None
-
-    async def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            await asyncio.sleep(
-                max(capped, self._config.min_request_interval_seconds)
-            )
-        else:
-            await self._sleep_between_attempts(attempt)
-
-    async def _enforce_rate_limit(self, url: str) -> None:
-        """Enforce per-host politeness delay before issuing a request.
-
-        Only waits — does not stamp ``_last_request_time``.  All stamping is
-        done by the ``_request`` loop's ``finally`` block so that every actual
-        attempt (including retries) updates the timestamp.
-        """
-        host = urlparse(url).netloc
-        if not host:
-            return
-        interval = max(
-            self._config.min_request_interval_seconds,
-            self._crawl_delay_overrides.get(host, 0.0),
-        )
-        if interval <= 0:
-            return
-        last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                await asyncio.sleep(remaining)
-
-    def _merge_params(
-        self, params: Mapping[str, str] | None
-    ) -> Mapping[str, str] | None:
-        dp = self._config.default_params
-        if dp is None:
-            return params
-        merged = {**dp, **(params or {})}
-        return merged if merged else None
-
-    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
-        threshold = self._config.circuit_breaker_failure_threshold
-        if threshold is None:
-            return None
-        host = urlparse(url).netloc
-        if not host:
-            return None
-        if host not in self._circuit_breakers:
-            self._circuit_breakers[host] = CircuitBreaker(
-                threshold=threshold,
-                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
-            )
-        return self._circuit_breakers[host]
-
-    def circuit_state(self, url: str) -> CircuitState | None:
-        """Return the current circuit-breaker state for *url*'s host, or None."""
-        cb = self._circuit_breakers.get(urlparse(url).netloc)
-        return cb.state if cb is not None else None
-
-    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
-        """Override the per-host crawl delay for *host*.
-
-        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
-        when the override is larger.  Intended for callers that parse a site's
-        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
-        """
-        self._crawl_delay_overrides[host] = delay_seconds
+        return isinstance(exc, (httpx.TimeoutException, httpx.ConnectError))
 
     def _client_for_proxy(
         self, proxy: Mapping[str, str] | None
@@ -319,15 +198,28 @@ class AsyncHttpClient:
             verify=self._config.verify_tls,
         )
 
+    async def _execute_attempt(
+        self,
+        request_fn: Any,
+        proxy: Mapping[str, str] | None,
+    ) -> Any:
+        client = self._client_for_proxy(proxy)
+        try:
+            return await request_fn(client)
+        finally:
+            if client is not self._http:
+                await client.aclose()
+
     def _handle_request_exception(
         self,
         method: str,
         request_url: str,
-        e: httpx.RequestError,
+        e: Exception,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: httpx.Timeout | None,
+        timeout: Any,
     ) -> Result[Any, Exception]:
+        """Map httpx exceptions to Ladon errors."""
         meta = self._build_meta(
             method,
             request_url,
@@ -351,135 +243,8 @@ class AsyncHttpClient:
             return Err(TransientNetworkError(str(e)), meta=meta)
         return Err(HttpClientError(str(e)), meta=meta)
 
-    async def _request(
-        self,
-        method: str,
-        url: str,
-        *,
-        context: Mapping[str, Any] | None,
-        timeout_obj: httpx.Timeout,
-        request_fn: _RequestFn,
-        value_builder: Callable[[httpx.Response], ResponseValue],
-    ) -> Result[ResponseValue, Exception]:
-        """Execute an async request with retries, circuit breaking, and rate limiting."""
-        cb = self._get_circuit_breaker(url)
-        if cb is not None and not cb.allow_request():
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout_obj,
-                final_error="CircuitOpenError",
-            )
-            return Err(CircuitOpenError(urlparse(url).netloc), meta=meta)
-
-        await self._enforce_rate_limit(url)
-        host = urlparse(url).netloc
-        is_safe_method = method.upper() in {"GET", "HEAD"}
-        pool = self._config.proxy_pool
-        attempts = 0
-        last_error: httpx.RequestError | None = None
-        last_blocked_response: httpx.Response | None = None
-        last_blocked_retry_after: float | None = None
-        current_proxy: Mapping[str, str] | None = None
-        if pool is not None:
-            current_proxy = pool.next_proxy()
-
-        for _ in range(self._max_attempts()):
-            attempts += 1
-            client = self._client_for_proxy(current_proxy)
-            should_close = client is not self._http
-            try:
-                response = await request_fn(client)
-                if (
-                    response.status_code in self._config.retry_on_status
-                    and is_safe_method
-                ):
-                    last_blocked_retry_after = self._parse_retry_after(response)
-                    last_blocked_response = response
-                    last_error = None
-                    if attempts < self._max_attempts():
-                        if pool is not None:
-                            pool.mark_failure(current_proxy)
-                            current_proxy = pool.next_proxy()
-                        await self._sleep_for_retry_after(
-                            last_blocked_retry_after, attempts
-                        )
-                        continue
-                    break
-                if cb is not None:
-                    cb.record_success()
-                return Ok(
-                    value_builder(response),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=response,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout_obj,
-                    ),
-                )
-            except httpx.RequestError as exc:
-                last_error = exc
-                last_blocked_response = None
-                last_blocked_retry_after = None
-                if (
-                    attempts >= self._max_attempts()
-                    or not self._is_retryable_exception(method, exc)
-                ):
-                    break
-                if pool is not None:
-                    pool.mark_failure(current_proxy)
-                    current_proxy = pool.next_proxy()
-                await self._sleep_between_attempts(attempts)
-            finally:
-                # Stamp after every attempt so the next _request call sees an
-                # accurate "last request time" even when retries consumed seconds.
-                if host:
-                    self._last_request_time[host] = monotonic()
-                if should_close:
-                    await client.aclose()
-
-        if last_blocked_response is not None:
-            if cb is not None:
-                cb.record_failure()
-            if pool is not None:
-                pool.mark_failure(current_proxy)
-            return Err(
-                RateLimitedError(
-                    last_blocked_response.status_code,
-                    last_blocked_retry_after,
-                ),
-                meta=self._build_meta(
-                    method=method,
-                    request_url=url,
-                    response=last_blocked_response,
-                    context=context,
-                    attempts=attempts,
-                    timeout=timeout_obj,
-                    final_error="RateLimitedError",
-                ),
-            )
-
-        assert last_error is not None
-        if cb is not None:
-            cb.record_failure()
-        if pool is not None:
-            pool.mark_failure(current_proxy)
-        return self._handle_request_exception(
-            method=method,
-            request_url=url,
-            e=last_error,
-            context=context,
-            attempts=attempts,
-            timeout=timeout_obj,
-        )
-
     # ------------------------------------------------------------------
-    # Public API — mirrors HttpClient
+    # Public API
     # ------------------------------------------------------------------
 
     async def get(
@@ -513,7 +278,7 @@ class AsyncHttpClient:
             method="GET",
             url=url,
             context=context,
-            timeout_obj=timeout_obj,
+            timeout=timeout_obj,
             request_fn=_fn,
             value_builder=lambda r: r.content,
         )
@@ -549,7 +314,7 @@ class AsyncHttpClient:
             method="HEAD",
             url=url,
             context=context,
-            timeout_obj=timeout_obj,
+            timeout=timeout_obj,
             request_fn=_fn,
             value_builder=lambda r: dict(r.headers),
         )
@@ -589,7 +354,7 @@ class AsyncHttpClient:
             method="POST",
             url=url,
             context=context,
-            timeout_obj=timeout_obj,
+            timeout=timeout_obj,
             request_fn=_fn,
             value_builder=lambda r: r.content,
         )
@@ -626,7 +391,7 @@ class AsyncHttpClient:
             method="GET",
             url=url,
             context=context,
-            timeout_obj=timeout_obj,
+            timeout=timeout_obj,
             request_fn=_fn,
             value_builder=lambda r: r,
         )

--- a/src/ladon/networking/async_curl_client.py
+++ b/src/ladon/networking/async_curl_client.py
@@ -18,36 +18,24 @@ Bootstrap symbols (cffi, cffi_exc, BrowserType) are owned by _cffi_common.py.
 
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
-from random import uniform
-from time import monotonic
-from typing import Any, Callable, Coroutine, Mapping, TypeVar
-from urllib.parse import urlparse
+from typing import Any, Mapping
 
+from ._async_policy_base import AsyncPolicyBase
 from ._cffi_common import cffi as _cffi
 from ._cffi_common import cffi_exc as _cffi_exc
 from ._cffi_common import curl_cffi_available as _curl_cffi_available
 from ._cffi_common import import_error_msg as _import_error_msg
 from ._cffi_common import valid_impersonate as _valid_impersonate
-from .circuit_breaker import CircuitBreaker, CircuitState
 from .config import HttpClientConfig
 from .errors import (
-    CircuitOpenError,
     HttpClientError,
-    RateLimitedError,
     RequestTimeoutError,
     TransientNetworkError,
 )
-from .types import Err, Ok, Result
-
-ResponseValue = TypeVar("ResponseValue")
-
-_AsyncRequestFn = Callable[[], Coroutine[Any, Any, Any]]
+from .types import Err, Result
 
 
-class AsyncCurlHttpClient:
+class AsyncCurlHttpClient(AsyncPolicyBase):
     """Async HTTP client with TLS fingerprint impersonation via curl-cffi.
 
     Drop-in async replacement for ``AsyncHttpClient`` for targets protected
@@ -93,12 +81,9 @@ class AsyncCurlHttpClient:
                 "not supported. Use default_headers={'Authorization': '...'} "
                 "for Bearer tokens or other header-based schemes."
             )
-        self._config = config
+        super().__init__(config)
         self._impersonate = impersonate
         self._session: Any = _cffi.AsyncSession(impersonate=impersonate)
-        self._last_request_time: dict[str, float] = {}
-        self._circuit_breakers: dict[str, CircuitBreaker] = {}
-        self._crawl_delay_overrides: dict[str, float] = {}
         if self._config.user_agent:
             self._session.headers["User-Agent"] = self._config.user_agent
         self._session.headers.update(self._config.default_headers)
@@ -115,12 +100,6 @@ class AsyncCurlHttpClient:
     async def aclose(self) -> None:
         """Close the underlying session and release pooled connections."""
         await self._session.close()
-
-    async def __aenter__(self) -> AsyncCurlHttpClient:
-        return self
-
-    async def __aexit__(self, *_: object) -> None:
-        await self.aclose()
 
     def _get_timeout(
         self, override: float | None
@@ -139,124 +118,41 @@ class AsyncCurlHttpClient:
             )
         return self._config.timeout_seconds
 
-    def _max_attempts(self) -> int:
-        return 1 + max(0, self._config.retries)
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True for any curl-cffi transport exception."""
+        return isinstance(exc, _cffi_exc.RequestException)
 
-    def _is_retryable_exception(self, method: str, error: Any) -> bool:
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
         if method.upper() not in {"GET", "HEAD"}:
             return False
         # SSLError subclasses ConnectionError and will be retried here; cert
         # failures are not transient but exhausting retries is the safe default.
-        return isinstance(error, (_cffi_exc.Timeout, _cffi_exc.ConnectionError))
-
-    async def _sleep_between_attempts(self, attempt: int) -> None:
-        backoff_base = self._config.backoff_base_seconds
-        if backoff_base <= 0:
-            return
-        cap = backoff_base * (2 ** max(0, attempt - 1))
-        await asyncio.sleep(
-            uniform(0.0, cap) if self._config.backoff_jitter else cap
-        )
-
-    @staticmethod
-    def _parse_retry_after(response: Any) -> float | None:
-        header = response.headers.get("Retry-After")
-        if header is None:
-            return None
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            pass
-        try:
-            dt: datetime = parsedate_to_datetime(str(header))
-            delta: float = (dt - datetime.now(tz=timezone.utc)).total_seconds()
-            return max(0.0, delta)
-        except Exception:
-            return None
-
-    async def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            await asyncio.sleep(
-                max(capped, self._config.min_request_interval_seconds)
-            )
-        else:
-            await self._sleep_between_attempts(attempt)
+        return isinstance(exc, (_cffi_exc.Timeout, _cffi_exc.ConnectionError))
 
     def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
         self._session.proxies.clear()
         if proxy is not None:
             self._session.proxies.update(proxy)
 
-    def _merge_params(
-        self, params: Mapping[str, str] | None
-    ) -> Mapping[str, str] | None:
-        dp = self._config.default_params
-        if dp is None:
-            return params
-        merged = {**dp, **(params or {})}
-        return merged if merged else None
-
-    async def _enforce_rate_limit(self, url: str) -> None:
-        host = urlparse(url).netloc
-        if not host:
-            return
-        interval = max(
-            self._config.min_request_interval_seconds,
-            self._crawl_delay_overrides.get(host, 0.0),
-        )
-        if interval <= 0:
-            return
-        last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                await asyncio.sleep(remaining)
-
-    def _build_meta(
+    async def _execute_attempt(
         self,
-        method: str,
-        request_url: str,
-        response: Any | None,
-        context: Mapping[str, Any] | None,
-        attempts: int,
-        timeout: float | tuple[float, float] | None,
-        final_error: str | None = None,
-    ) -> dict[str, Any]:
-        meta: dict[str, Any] = {}
-        meta["method"] = method
-        meta["url"] = request_url
-        meta["attempts"] = attempts
-        meta["timeout_s"] = timeout
-        if context:
-            context_dict = dict(context)
-            meta["context"] = context_dict
-            for key, value in context_dict.items():
-                meta.setdefault(key, value)
-        if response is not None:
-            meta["status_code"] = response.status_code
-            meta["url"] = response.url
-            meta["reason"] = response.reason
-            try:
-                meta["elapsed_s"] = response.elapsed.total_seconds()
-            except AttributeError:
-                pass
-        if final_error is not None:
-            meta["final_error"] = final_error
-        return meta
+        request_fn: Any,
+        proxy: Mapping[str, str] | None,
+    ) -> Any:
+        if self._config.proxy_pool is not None:
+            self._apply_proxy(proxy)
+        return await request_fn()
 
     def _handle_request_exception(
         self,
         method: str,
         request_url: str,
-        e: Any,
+        e: Exception,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: float | tuple[float, float] | None,
+        timeout: Any,
     ) -> Result[Any, Exception]:
+        """Map curl-cffi exceptions to Ladon errors."""
         response = getattr(e, "response", None)
         meta = self._build_meta(
             method,
@@ -272,172 +168,6 @@ class AsyncCurlHttpClient:
         if isinstance(e, _cffi_exc.ConnectionError):
             return Err(TransientNetworkError(str(e)), meta=meta)
         return Err(HttpClientError(str(e)), meta=meta)
-
-    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
-        threshold = self._config.circuit_breaker_failure_threshold
-        if threshold is None:
-            return None
-        host = urlparse(url).netloc
-        if not host:
-            return None
-        if host not in self._circuit_breakers:
-            self._circuit_breakers[host] = CircuitBreaker(
-                threshold=threshold,
-                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
-            )
-        return self._circuit_breakers[host]
-
-    def circuit_state(self, url: str) -> CircuitState | None:
-        """Return the current circuit-breaker state for *url*'s host, or None."""
-        cb = self._circuit_breakers.get(urlparse(url).netloc)
-        return cb.state if cb is not None else None
-
-    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
-        """Override the per-host crawl delay for *host*.
-
-        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
-        when the override is larger.  Intended for callers that parse a site's
-        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
-        """
-        self._crawl_delay_overrides[host] = delay_seconds
-
-    async def _request(
-        self,
-        method: str,
-        url: str,
-        *,
-        context: Mapping[str, Any] | None,
-        timeout: float | tuple[float, float],
-        request_fn: _AsyncRequestFn,
-        value_builder: Callable[[Any], ResponseValue],
-    ) -> Result[ResponseValue, Exception]:
-        cb = self._get_circuit_breaker(url)
-        if cb is not None and not cb.allow_request():
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="CircuitOpenError",
-            )
-            return Err(CircuitOpenError(urlparse(url).netloc), meta=meta)
-
-        await self._enforce_rate_limit(url)
-        host = urlparse(url).netloc
-        is_safe_method = method.upper() in {"GET", "HEAD"}
-        pool = self._config.proxy_pool
-        attempts = 0
-        last_error: Any = None
-        last_blocked_response: Any = None
-        last_blocked_retry_after: float | None = None
-        current_proxy: Mapping[str, str] | None = None
-        if pool is not None:
-            current_proxy = pool.next_proxy()
-            self._apply_proxy(current_proxy)
-
-        for _ in range(self._max_attempts()):
-            attempts += 1
-            try:
-                response = await request_fn()
-                if (
-                    response.status_code in self._config.retry_on_status
-                    and is_safe_method
-                ):
-                    last_blocked_retry_after = self._parse_retry_after(response)
-                    last_blocked_response = response
-                    last_error = None
-                    if attempts < self._max_attempts():
-                        if pool is not None:
-                            pool.mark_failure(current_proxy)
-                            current_proxy = pool.next_proxy()
-                            self._apply_proxy(current_proxy)
-                        await self._sleep_for_retry_after(
-                            last_blocked_retry_after, attempts
-                        )
-                        continue
-                    break
-                if cb is not None:
-                    cb.record_success()
-                return Ok(
-                    value_builder(response),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=response,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                    ),
-                )
-            except _cffi_exc.RequestException as exc:
-                last_error = exc
-                last_blocked_response = None
-                last_blocked_retry_after = None
-                if (
-                    attempts >= self._max_attempts()
-                    or not self._is_retryable_exception(method, exc)
-                ):
-                    break
-                if pool is not None:
-                    pool.mark_failure(current_proxy)
-                    current_proxy = pool.next_proxy()
-                    self._apply_proxy(current_proxy)
-                await self._sleep_between_attempts(attempts)
-            except Exception as exc:  # pragma: no cover - defensive fallback
-                if cb is not None:
-                    cb.record_failure()
-                return Err(
-                    HttpClientError(str(exc)),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=None,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                        final_error=type(exc).__name__,
-                    ),
-                )
-            finally:
-                if host:
-                    self._last_request_time[host] = monotonic()
-
-        if last_blocked_response is not None:
-            if cb is not None:
-                cb.record_failure()
-            if pool is not None:
-                pool.mark_failure(current_proxy)
-            return Err(
-                RateLimitedError(
-                    last_blocked_response.status_code,
-                    last_blocked_retry_after,
-                ),
-                meta=self._build_meta(
-                    method=method,
-                    request_url=url,
-                    response=last_blocked_response,
-                    context=context,
-                    attempts=attempts,
-                    timeout=timeout,
-                    final_error="RateLimitedError",
-                ),
-            )
-
-        assert last_error is not None
-        if cb is not None:
-            cb.record_failure()
-        if pool is not None:
-            pool.mark_failure(current_proxy)
-        return self._handle_request_exception(
-            method=method,
-            request_url=url,
-            e=last_error,
-            context=context,
-            attempts=attempts,
-            timeout=timeout,
-        )
 
     async def get(
         self,

--- a/tests/test_async_curl_client.py
+++ b/tests/test_async_curl_client.py
@@ -639,7 +639,7 @@ async def test_backoff_with_jitter_calls_sleep() -> None:
             ]
         )
         with patch(
-            "ladon.networking.async_curl_client.asyncio.sleep"
+            "ladon.networking._async_policy_base.asyncio.sleep"
         ) as mock_sleep:
             mock_sleep.return_value = None
             result = await c.get("http://example.com")
@@ -690,11 +690,11 @@ async def test_rate_limit_sleep_enforced() -> None:
         # Second get() completes → finally records 1001.0
         with (
             patch(
-                "ladon.networking.async_curl_client.monotonic",
+                "ladon.networking._async_policy_base.monotonic",
                 side_effect=[1000.0, 1000.5, 1001.0],
             ),
             patch(
-                "ladon.networking.async_curl_client.asyncio.sleep"
+                "ladon.networking._async_policy_base.asyncio.sleep"
             ) as mock_sleep,
         ):
             mock_sleep.return_value = None


### PR DESCRIPTION
## Summary

- Extracts `AsyncPolicyBase(ABC)` into `_async_policy_base.py`, holding the full shared async policy pipeline
- `AsyncHttpClient` and `AsyncCurlHttpClient` become thin subclasses implementing five abstract methods
- Eliminates ~570 lines of duplicated policy logic across the two async clients

## Design notes

**`_execute_attempt` as the key abstraction**: The two async transports have fundamentally different per-attempt lifecycles — httpx creates a fresh `AsyncClient` per proxy and closes it in `finally`; curl-cffi mutates `_session.proxies`. Both patterns are encapsulated in `_execute_attempt(request_fn, proxy)` without exposing any session internals to the base.

**`_build_meta` concrete with override**: The base provides curl-compatible defaults; `AsyncHttpClient` overrides for httpx-specific field names (`reason_phrase`, `str(url)`, `redirected` flag).

**No `_proxies` abstract property**: Unlike the sync base (ADR-012), the async base never touches `_session` directly — proxy handling is fully delegated to `_execute_attempt`. The ADR-012 upgrade path (Protocol) is not triggered here.

## Test plan

- [ ] `python -m pytest` — 532/532 pass
- [ ] `python -m pyright src/ladon/networking/` — 0 errors
- [ ] Patch targets in `test_async_curl_client.py` updated: `async_curl_client.{asyncio.sleep,monotonic}` → `_async_policy_base.{asyncio.sleep,monotonic}`