### PR TITLE
refactor(networking): policy pipeline deduplication — extract SyncPolicyBase + AsyncPolicyBase (#109)

### DIFF
--- a/docs/decisions/adr-012-session-contract-boundary.md
+++ b/docs/decisions/adr-012-session-contract-boundary.md
@@ -1,0 +1,85 @@
+---
+status: accepted
+date: 2026-05-17
+decision-makers: [Maintainers]
+informed: [Contributors]
+refs: [ADR-011, Issue #109]
+---
+
+# ADR-012 — Session Contract Boundary in `SyncPolicyBase`
+
+## Context and Problem Statement
+
+Issue #109 extracted the shared sync policy pipeline into `SyncPolicyBase`, an
+ABC subclassed by both `HttpClient` (requests) and `CurlHttpClient` (curl-cffi).
+After extraction, `_apply_proxy` — the only method in the base class that touches
+the underlying session — directly accessed `self._session.proxies`.  This leaks
+transport internals into the base class with no structural contract: if a third
+transport's session exposes proxies under a different name or shape, the failure
+is silent at import time and discovered only at runtime.
+
+Two options were considered for encoding the contract.
+
+## Decision Drivers
+
+* The base class must not silently assume session shape it has no structural
+  claim to.
+* Any third transport added in the future must get a compile-time or
+  construction-time signal when it fails to meet the contract.
+* The solution must be proportionate to the current scope: one access point
+  (`self._session.proxies`) in one method (`_apply_proxy`).
+* The solution must not introduce abstractions that will need to be unwound if
+  the scope grows.
+
+## Considered Options
+
+* **A — Abstract `_proxies` property (chosen)**
+* **B — `_SessionProtocol` typed on `_session`**
+
+## Decision Outcome
+
+**Chosen: Option A — abstract `_proxies` property.**
+
+`SyncPolicyBase` declares an abstract property `_proxies` returning
+`MutableMapping[str, str]`.  `_apply_proxy` uses `self._proxies` exclusively —
+it no longer touches `self._session` directly.  Each subclass implements
+`_proxies` by delegating to its own session object.
+
+This is proportionate: one access point, one abstract property, zero duplication
+of logic.  The pyright abstract-method check enforces the contract at
+class-definition time — a concrete subclass that forgets `_proxies` is a type
+error before any test runs.
+
+### When to evolve this decision
+
+If a **second** session-level concern ever needs to move into the base class
+(e.g., `_apply_headers`, `_apply_auth`), **do not add a second abstract
+property**.  That is the signal to switch to Option B: define a
+`_SessionProtocol` with the full surface the base needs, type
+`_session: _SessionProtocol`, and let structural subtyping do the work.
+At that point, each subclass drops its individual abstract properties and
+simply provides a conforming `_session` — one Protocol definition replaces
+*n* abstract properties across *m* transports.
+
+### Consequences
+
+* **Good**: `SyncPolicyBase` no longer touches `self._session` directly — the
+  session is fully encapsulated in each subclass.
+* **Good**: Missing `_proxies` implementation is a pyright type error and an
+  `abc` `TypeError` at instantiation, not a `KeyError` at runtime.
+* **Neutral**: Each subclass gains a one-line property boilerplate.  Acceptable
+  for two transports; the Protocol upgrade path eliminates it if transports
+  multiply.
+* **Bad**: The abstract-property pattern scales poorly: *n* concerns × *m*
+  transports = *n×m* boilerplate properties.  The "when to evolve" clause above
+  caps this at one property before the switch.
+
+## Rejected option
+
+**B — `_SessionProtocol`:** Correct at scale but premature today.  Defining a
+Protocol surface for a single `.proxies` access would require typing a contract
+for `requests.Session` and `curl_cffi.Session` alike — both of which have
+large, partially-typed APIs.  The Protocol would either be artificially narrow
+(and need expanding on every new access) or artificially wide (and pull in
+unnecessary coupling).  Better to let the surface reveal itself organically and
+switch when the second access point appears.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -18,6 +18,7 @@ chosen over the alternatives.
 | ADR-009 | Observability (metrics, structured logs) | Proposed — Phase 3 |
 | [ADR-010](adr-010-dual-license-model.md) | Dual-License Model (AGPL-3.0-only + Commercial) | Accepted |
 | [ADR-011](adr-011-curl-cffi-cloudflare-bypass.md) | curl-cffi as the Cloudflare-Bypass HTTP Backend | Accepted |
+| [ADR-012](adr-012-session-contract-boundary.md) | Session Contract Boundary in `SyncPolicyBase` | Accepted |
 
 ## Format
 

--- a/src/ladon/networking/_async_policy_base.py
+++ b/src/ladon/networking/_async_policy_base.py
@@ -1,0 +1,369 @@
+"""Shared policy pipeline for asynchronous HTTP clients.
+
+Both ``AsyncHttpClient`` (httpx) and ``AsyncCurlHttpClient`` (curl-cffi)
+subclass this ABC.  All policy logic — circuit breaking, retry loop, backoff,
+rate limiting, proxy rotation, and metadata assembly — lives here.
+
+The differences between the two async clients:
+  - transport library and its exception types
+  - timeout representation (``httpx.Timeout`` vs ``float | tuple``)
+  - per-attempt client lifecycle (httpx creates a client per proxy; curl
+    mutates ``_session.proxies``) — encapsulated in ``_execute_attempt``
+  - ``_build_meta`` field names (httpx uses ``str(r.url)`` and
+    ``r.reason_phrase``; curl uses standard names) — ``AsyncHttpClient``
+    overrides ``_build_meta``
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from random import uniform
+from time import monotonic
+from typing import Any, Callable, Mapping, Self, TypeVar
+from urllib.parse import urlparse
+
+from .circuit_breaker import CircuitBreaker, CircuitState
+from .config import HttpClientConfig
+from .errors import (
+    CircuitOpenError,
+    HttpClientError,
+    RateLimitedError,
+)
+from .types import Err, Ok, Result
+
+ResponseValue = TypeVar("ResponseValue")
+
+
+class AsyncPolicyBase(ABC):
+    """Abstract base for asynchronous HTTP clients with unified policy pipeline.
+
+    Subclasses must implement the abstract methods that vary per transport
+    library.  All shared policy logic lives in this class.
+    """
+
+    def __init__(self, config: HttpClientConfig) -> None:
+        self._config = config
+        self._last_request_time: dict[str, float] = {}
+        self._circuit_breakers: dict[str, CircuitBreaker] = {}
+        self._crawl_delay_overrides: dict[str, float] = {}
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.aclose()
+
+    @abstractmethod
+    async def aclose(self) -> None:
+        """Close the underlying session and release pooled connections."""
+
+    @abstractmethod
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True iff *exc* is a library transport exception, not a logic error."""
+
+    @abstractmethod
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
+        """Return True for transport errors that should trigger a retry."""
+
+    @abstractmethod
+    async def _execute_attempt(
+        self,
+        request_fn: Any,
+        proxy: Mapping[str, str] | None,
+    ) -> Any:
+        """Execute one request attempt for the given proxy.
+
+        Handles proxy setup and per-attempt client lifecycle internally.
+        Transport exceptions must propagate normally — the caller catches them.
+        """
+
+    @abstractmethod
+    def _handle_request_exception(
+        self,
+        method: str,
+        request_url: str,
+        e: Exception,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: Any,
+    ) -> Result[Any, Exception]:
+        """Map a transport exception to a Ladon error Result."""
+
+    # ------------------------------------------------------------------ #
+    # Concrete policy helpers                                              #
+    # ------------------------------------------------------------------ #
+
+    def _max_attempts(self) -> int:
+        """Return the total number of attempts for one request."""
+        return 1 + max(0, self._config.retries)
+
+    async def _sleep_between_attempts(self, attempt: int) -> None:
+        """Sleep between retry attempts using exponential backoff."""
+        backoff_base = self._config.backoff_base_seconds
+        if backoff_base <= 0:
+            return
+        cap = backoff_base * (2 ** max(0, attempt - 1))
+        await asyncio.sleep(
+            uniform(0.0, cap) if self._config.backoff_jitter else cap
+        )
+
+    @staticmethod
+    def _parse_retry_after(response: Any) -> float | None:
+        """Parse the ``Retry-After`` header into seconds, or ``None`` if absent."""
+        header = response.headers.get("Retry-After")
+        if header is None:
+            return None
+        try:
+            return max(0.0, float(header))
+        except ValueError:
+            pass
+        try:
+            dt: datetime = parsedate_to_datetime(str(header))
+            delta: float = (dt - datetime.now(tz=timezone.utc)).total_seconds()
+            return max(0.0, delta)
+        except Exception:
+            return None
+
+    async def _sleep_for_retry_after(
+        self, retry_after: float | None, attempt: int
+    ) -> None:
+        """Sleep before a retry triggered by a rate-limiting HTTP response."""
+        if retry_after is not None:
+            capped = min(retry_after, self._config.max_retry_after_seconds)
+            await asyncio.sleep(
+                max(capped, self._config.min_request_interval_seconds)
+            )
+        else:
+            await self._sleep_between_attempts(attempt)
+
+    def _merge_params(
+        self, params: Mapping[str, str] | None
+    ) -> Mapping[str, str] | None:
+        """Merge *params* with ``default_params``, per-request wins on collision."""
+        dp = self._config.default_params
+        if dp is None:
+            return params
+        merged = {**dp, **(params or {})}
+        return merged if merged else None
+
+    async def _enforce_rate_limit(self, host: str) -> None:
+        """Enforce per-host politeness delay before issuing a request.
+
+        Only waits — does not stamp ``_last_request_time``.  All stamping is
+        done by the ``_request`` loop's ``finally`` block so that every actual
+        attempt (including retries) updates the timestamp.
+        """
+        if not host:
+            return
+        interval = max(
+            self._config.min_request_interval_seconds,
+            self._crawl_delay_overrides.get(host, 0.0),
+        )
+        if interval <= 0:
+            return
+        last = self._last_request_time.get(host)
+        if last is not None:
+            elapsed = monotonic() - last
+            remaining = interval - elapsed
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+
+    def _get_circuit_breaker(self, host: str) -> CircuitBreaker | None:
+        """Return the CircuitBreaker for *host*, or None if circuit breaking is disabled."""
+        threshold = self._config.circuit_breaker_failure_threshold
+        if threshold is None:
+            return None
+        if not host:
+            return None
+        if host not in self._circuit_breakers:
+            self._circuit_breakers[host] = CircuitBreaker(
+                threshold=threshold,
+                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
+            )
+        return self._circuit_breakers[host]
+
+    def circuit_state(self, url: str) -> CircuitState | None:
+        """Return the current circuit-breaker state for *url*'s host, or None."""
+        cb = self._circuit_breakers.get(urlparse(url).netloc)
+        return cb.state if cb is not None else None
+
+    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
+        """Override the per-host crawl delay for *host*.
+
+        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
+        when the override is larger.
+        """
+        self._crawl_delay_overrides[host] = delay_seconds
+
+    def _build_meta(
+        self,
+        method: str,
+        request_url: str,
+        response: Any | None,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: Any,
+        final_error: str | None = None,
+    ) -> dict[str, Any]:
+        """Construct metadata dictionary from response and context."""
+        meta: dict[str, Any] = {}
+        meta["method"] = method
+        meta["url"] = request_url
+        meta["attempts"] = attempts
+        meta["timeout_s"] = timeout
+        if context:
+            context_dict = dict(context)
+            meta["context"] = context_dict
+            for key, value in context_dict.items():
+                meta.setdefault(key, value)
+        if response is not None:
+            meta["status_code"] = response.status_code
+            meta["url"] = response.url
+            meta["reason"] = response.reason
+            try:
+                meta["elapsed_s"] = response.elapsed.total_seconds()
+            except AttributeError:
+                pass
+        if final_error is not None:
+            meta["final_error"] = final_error
+        return meta
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        context: Mapping[str, Any] | None,
+        timeout: Any,
+        request_fn: Any,
+        value_builder: Callable[[Any], ResponseValue],
+    ) -> Result[ResponseValue, Exception]:
+        """Execute async request with retries, circuit breaking, and rate limiting."""
+        host = urlparse(url).netloc
+        cb = self._get_circuit_breaker(host)
+        if cb is not None and not cb.allow_request():
+            meta = self._build_meta(
+                method=method,
+                request_url=url,
+                response=None,
+                context=context,
+                attempts=0,
+                timeout=timeout,
+                final_error="CircuitOpenError",
+            )
+            return Err(CircuitOpenError(host), meta=meta)
+
+        await self._enforce_rate_limit(host)
+        is_safe_method = method.upper() in {"GET", "HEAD"}
+        pool = self._config.proxy_pool
+        attempts = 0
+        last_error: Exception | None = None
+        last_blocked_response: Any = None
+        last_blocked_retry_after: float | None = None
+        current_proxy: Mapping[str, str] | None = None
+        if pool is not None:
+            current_proxy = pool.next_proxy()
+
+        for _ in range(self._max_attempts()):
+            attempts += 1
+            try:
+                response = await self._execute_attempt(
+                    request_fn, current_proxy
+                )
+                if (
+                    response.status_code in self._config.retry_on_status
+                    and is_safe_method
+                ):
+                    last_blocked_retry_after = self._parse_retry_after(response)
+                    last_blocked_response = response
+                    last_error = None
+                    if attempts < self._max_attempts():
+                        if pool is not None:
+                            pool.mark_failure(current_proxy)
+                            current_proxy = pool.next_proxy()
+                        await self._sleep_for_retry_after(
+                            last_blocked_retry_after, attempts
+                        )
+                        continue
+                    break
+                if cb is not None:
+                    cb.record_success()
+                return Ok(
+                    value_builder(response),
+                    meta=self._build_meta(
+                        method=method,
+                        request_url=url,
+                        response=response,
+                        context=context,
+                        attempts=attempts,
+                        timeout=timeout,
+                    ),
+                )
+            except Exception as exc:
+                if not self._is_transport_exception(exc):  # pragma: no cover
+                    if cb is not None:
+                        cb.record_failure()
+                    return Err(
+                        HttpClientError(str(exc)),
+                        meta=self._build_meta(
+                            method=method,
+                            request_url=url,
+                            response=None,
+                            context=context,
+                            attempts=attempts,
+                            timeout=timeout,
+                            final_error=type(exc).__name__,
+                        ),
+                    )
+                last_error = exc
+                last_blocked_response = None
+                last_blocked_retry_after = None
+                if (
+                    attempts >= self._max_attempts()
+                    or not self._is_retryable_exception(method, exc)
+                ):
+                    break
+                if pool is not None:
+                    pool.mark_failure(current_proxy)
+                    current_proxy = pool.next_proxy()
+                await self._sleep_between_attempts(attempts)
+            finally:
+                if host:
+                    self._last_request_time[host] = monotonic()
+
+        if last_blocked_response is not None:
+            if cb is not None:
+                cb.record_failure()
+            if pool is not None:
+                pool.mark_failure(current_proxy)
+            return Err(
+                RateLimitedError(
+                    last_blocked_response.status_code, last_blocked_retry_after
+                ),
+                meta=self._build_meta(
+                    method=method,
+                    request_url=url,
+                    response=last_blocked_response,
+                    context=context,
+                    attempts=attempts,
+                    timeout=timeout,
+                    final_error="RateLimitedError",
+                ),
+            )
+
+        assert last_error is not None
+        if cb is not None:
+            cb.record_failure()
+        if pool is not None:
+            pool.mark_failure(current_proxy)
+        return self._handle_request_exception(
+            method=method,
+            request_url=url,
+            e=last_error,
+            context=context,
+            attempts=attempts,
+            timeout=timeout,
+        )

--- a/src/ladon/networking/_cffi_common.py
+++ b/src/ladon/networking/_cffi_common.py
@@ -1,0 +1,45 @@
+"""Shared curl-cffi bootstrap for CurlHttpClient and AsyncCurlHttpClient.
+
+Both client modules import from here so the try/except ImportError block and
+the import-time BrowserType frozenset are not duplicated.  The module name
+starts with ``_`` to signal it is an internal implementation detail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+cffi: Any
+cffi_exc: Any
+curl_cffi_available: bool
+valid_impersonate: frozenset[str]
+
+try:
+    from curl_cffi import (
+        requests as _cffi_mod,  # type: ignore[import-untyped, import-not-found]
+    )
+    from curl_cffi.requests import (
+        BrowserType as _BrowserType,  # type: ignore[import-untyped, import-not-found]
+    )
+    from curl_cffi.requests import (
+        exceptions as _cffi_exc_mod,  # type: ignore[import-untyped, import-not-found]
+    )
+
+    cffi = _cffi_mod  # type: ignore[assignment]
+    cffi_exc = _cffi_exc_mod  # type: ignore[assignment]
+    curl_cffi_available = True
+    valid_impersonate = frozenset(
+        b.value for b in _BrowserType  # type: ignore[union-attr]
+    )
+except ImportError:
+    cffi = None
+    cffi_exc = None
+    curl_cffi_available = False
+    valid_impersonate = frozenset()
+
+
+def import_error_msg(class_name: str) -> str:
+    return (
+        f"curl-cffi is required for {class_name}.\n"
+        "Install it with:  pip install ladon-crawl[cffi]"
+    )

--- a/src/ladon/networking/_sync_policy_base.py
+++ b/src/ladon/networking/_sync_policy_base.py
@@ -329,6 +329,18 @@ class SyncPolicyBase(ABC):
         """
         self._crawl_delay_overrides[host] = delay_seconds
 
+    @staticmethod
+    def _content_value(response: Any) -> bytes:
+        return response.content  # type: ignore[no-any-return]
+
+    @staticmethod
+    def _headers_value(response: Any) -> Mapping[str, Any]:
+        return dict(response.headers)
+
+    @staticmethod
+    def _response_value(response: Any) -> Any:
+        return response
+
     def _request(
         self,
         method: str,

--- a/src/ladon/networking/_sync_policy_base.py
+++ b/src/ladon/networking/_sync_policy_base.py
@@ -1,0 +1,481 @@
+"""Shared policy pipeline for synchronous HTTP clients.
+
+Both ``HttpClient`` (requests) and ``CurlHttpClient`` (curl-cffi) subclass
+this ABC.  All policy logic — circuit breaking, retry loop, backoff, rate
+limiting, proxy rotation, robots.txt, and metadata assembly — lives here.
+The only differences between the two clients are the session library, its
+exception types, and the mapping of those exceptions to Ladon errors.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from random import uniform
+from time import monotonic, sleep
+from typing import Any, Callable, Mapping, MutableMapping, Self, TypeVar
+from urllib.parse import urlparse
+
+from .circuit_breaker import CircuitBreaker, CircuitState
+from .config import HttpClientConfig
+from .errors import (
+    CircuitOpenError,
+    HttpClientError,
+    RateLimitedError,
+    RobotsBlockedError,
+)
+from .robots import RobotsCache
+from .types import Err, Ok, Result
+
+ResponseValue = TypeVar("ResponseValue")
+
+
+class SyncPolicyBase(ABC):
+    """Abstract base for synchronous HTTP clients with unified policy pipeline.
+
+    Subclasses must assign ``self._session`` before any request is made, and
+    implement the four abstract methods that vary per transport library.
+    """
+
+    _session: Any  # must be assigned by subclass __init__ before any request
+
+    def __init__(self, config: HttpClientConfig) -> None:
+        self._config = config
+        self._last_request_time: dict[str, float] = {}
+        self._circuit_breakers: dict[str, CircuitBreaker] = {}
+        self._robots_cache: RobotsCache | None = None
+        self._crawl_delay_overrides: dict[str, float] = {}
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "_session":
+            raise RuntimeError(
+                f"{type(self).__name__} must assign self._session in __init__ "
+                "before making any requests"
+            )
+        raise AttributeError(name)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the underlying session and release pooled connections."""
+
+    @abstractmethod
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True iff *exc* is a library transport exception, not a logic error."""
+
+    @abstractmethod
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
+        """Return True for transport errors that should trigger a retry."""
+
+    @abstractmethod
+    def _handle_request_exception(
+        self,
+        method: str,
+        request_url: str,
+        e: Exception,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: float | tuple[float, float],
+    ) -> Result[Any, Exception]:
+        """Map a transport exception to a Ladon error Result."""
+
+    @property
+    @abstractmethod
+    def _proxies(self) -> MutableMapping[str, str]:
+        """The session's proxy mapping.
+
+        Subclasses delegate to their transport session's proxy dict.
+        If a second session-level concern is ever needed here, switch to a
+        _SessionProtocol instead — see ADR-012.
+        """
+
+    # ------------------------------------------------------------------ #
+    # Concrete policy helpers                                              #
+    # ------------------------------------------------------------------ #
+
+    def _get_timeout(
+        self, override: float | None
+    ) -> float | tuple[float, float]:
+        """Resolve timeout preference."""
+        if override is not None:
+            if override <= 0:
+                raise ValueError("timeout override must be > 0 when provided")
+            return override
+        if (
+            self._config.connect_timeout_seconds is not None
+            and self._config.read_timeout_seconds is not None
+        ):
+            return (
+                self._config.connect_timeout_seconds,
+                self._config.read_timeout_seconds,
+            )
+        return self._config.timeout_seconds
+
+    def _max_attempts(self) -> int:
+        """Return the total number of attempts for one request."""
+        return 1 + max(0, self._config.retries)
+
+    def _sleep_between_attempts(self, attempt: int) -> None:
+        """Sleep between retry attempts using exponential backoff."""
+        backoff_base = self._config.backoff_base_seconds
+        if backoff_base <= 0:
+            return
+        cap = backoff_base * (2 ** max(0, attempt - 1))
+        sleep(uniform(0.0, cap) if self._config.backoff_jitter else cap)
+
+    @staticmethod
+    def _parse_retry_after(response: Any) -> float | None:
+        """Parse the ``Retry-After`` header from *response* into seconds.
+
+        Handles both delta-seconds (``"60"``) and HTTP-date
+        (``"Wed, 21 Oct 2015 07:28:00 GMT"``) forms per RFC 7231 §7.1.3.
+
+        Returns:
+            Seconds to wait (clamped to 0.0 minimum), or ``None`` if the
+            header is absent or cannot be parsed.
+        """
+        header = response.headers.get("Retry-After")
+        if header is None:
+            return None
+        try:
+            return max(0.0, float(header))
+        except ValueError:
+            pass
+        try:
+            dt = parsedate_to_datetime(str(header))
+            delta = (dt - datetime.now(tz=timezone.utc)).total_seconds()
+            return max(0.0, delta)
+        except Exception:  # fail-open: treat any unparseable date as absent
+            return None
+
+    def _sleep_for_retry_after(
+        self, retry_after: float | None, attempt: int
+    ) -> None:
+        """Sleep before a retry triggered by a rate-limiting HTTP response.
+
+        When *retry_after* is not ``None``: caps it at
+        ``max_retry_after_seconds``, then takes the longer of the capped value
+        and ``min_request_interval_seconds`` so the client's own politeness
+        policy is never violated.  Falls back to ``_sleep_between_attempts``
+        when *retry_after* is ``None``.
+        """
+        if retry_after is not None:
+            capped = min(retry_after, self._config.max_retry_after_seconds)
+            sleep(max(capped, self._config.min_request_interval_seconds))
+        else:
+            self._sleep_between_attempts(attempt)
+
+    def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
+        """Update session proxy to *proxy*, clearing any previous setting."""
+        self._proxies.clear()
+        if proxy is not None:
+            self._proxies.update(proxy)
+
+    def _merge_params(
+        self, params: Mapping[str, str] | None
+    ) -> Mapping[str, str] | None:
+        """Merge *params* with ``default_params``, per-request wins on collision."""
+        dp = self._config.default_params
+        if dp is None:
+            return params
+        merged = {**dp, **(params or {})}
+        return merged if merged else None
+
+    def _enforce_robots(self, url: str) -> None:
+        """Raise ``RobotsBlockedError`` if *url* is disallowed by robots.txt.
+
+        No-op when ``respect_robots_txt`` is False (the default) or when the
+        robots.txt fetch fails (fail-open behaviour).
+
+        Called before ``_enforce_rate_limit`` so that blocked requests are
+        rejected before the rate-limit slot is consumed — honouring the spirit
+        of the robots.txt contract: don't even waste a rate-limit slot on a
+        host that has explicitly opted out of being crawled.
+
+        Known limitation — robots.txt fetch bypasses rate-limiter
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ``RobotsCache`` fetches ``/robots.txt`` via a raw ``session.get``
+        call that is invisible to ``_enforce_rate_limit``.  On the first
+        request to any origin this produces two outbound HTTP requests to
+        that host in rapid succession (robots.txt fetch + the actual request),
+        regardless of ``min_request_interval_seconds``.  The cache guarantees
+        at most one robots.txt fetch per origin per session, so subsequent
+        requests to the same host are unaffected.  This trade-off is
+        documented in ADR-008.
+        """
+        if self._robots_cache is None:
+            return
+        if not self._robots_cache.is_allowed(url):
+            raise RobotsBlockedError(f"robots.txt disallows: {url}")
+        # Propagate Crawl-delay into the rate limiter for this host.
+        # HttpClientConfig is frozen so we maintain a side-table of per-host
+        # delay overrides rather than mutating config.
+        # Note: Crawl-delay is only registered here, on the *allowed* path.
+        # A domain that disallows all URLs but advertises Crawl-delay will
+        # have the delay present in RobotsCache._crawl_delays (populated at
+        # fetch time) but absent from _crawl_delay_overrides (since no request
+        # is ever made to that host, there is nothing to throttle).
+        delay = self._robots_cache.crawl_delay(url)
+        if delay is not None:
+            host = urlparse(url).netloc
+            current = self._config.min_request_interval_seconds
+            if delay > current:
+                self._crawl_delay_overrides[host] = delay
+
+    def _enforce_rate_limit(self, host: str) -> None:
+        """Enforce per-host politeness delay before issuing a request.
+
+        Sleeps for however long remains since the last request to *host*.
+        The timestamp is written by the ``_request`` loop's ``finally`` block
+        (end-to-start semantics), not here.
+
+        No-op when ``min_request_interval_seconds`` is zero (the default)
+        or when *host* is empty.
+        """
+        if not host:
+            return
+        interval = max(
+            self._config.min_request_interval_seconds,
+            self._crawl_delay_overrides.get(host, 0.0),
+        )
+        if interval <= 0:
+            return
+        last = self._last_request_time.get(host)
+        if last is not None:
+            elapsed = monotonic() - last
+            remaining = interval - elapsed
+            if remaining > 0:
+                sleep(remaining)
+
+    def _build_meta(
+        self,
+        method: str,
+        request_url: str,
+        response: Any | None,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: float | tuple[float, float],
+        final_error: str | None = None,
+    ) -> dict[str, Any]:
+        """Construct metadata dictionary from response and context."""
+        meta: dict[str, Any] = {}
+        meta["method"] = method
+        meta["url"] = request_url
+        meta["attempts"] = attempts
+        meta["timeout_s"] = timeout
+        if context:
+            context_dict = dict(context)
+            meta["context"] = context_dict
+            for key, value in context_dict.items():
+                meta.setdefault(key, value)
+
+        if response is not None:
+            meta["status_code"] = response.status_code
+            meta["url"] = response.url
+            meta["reason"] = response.reason
+            try:
+                meta["elapsed_s"] = response.elapsed.total_seconds()
+            except AttributeError:
+                pass  # In case elapsed is not available or mocked
+        if final_error is not None:
+            meta["final_error"] = final_error
+
+        return meta
+
+    def _get_circuit_breaker(self, host: str) -> CircuitBreaker | None:
+        """Return the CircuitBreaker for *host*, or None if circuit breaking is disabled."""
+        threshold = self._config.circuit_breaker_failure_threshold
+        if threshold is None:
+            return None
+        if not host:
+            return None
+        if host not in self._circuit_breakers:
+            self._circuit_breakers[host] = CircuitBreaker(
+                threshold=threshold,
+                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
+            )
+        return self._circuit_breakers[host]
+
+    def circuit_state(self, url: str) -> CircuitState | None:
+        """Return the current circuit-breaker state for *url*'s host.
+
+        Returns ``None`` when the circuit breaker is disabled
+        (``circuit_breaker_failure_threshold`` is ``None``) or when no
+        request has been made to the host yet.
+
+        Intended for logging, metrics, and operational dashboards — lets
+        callers surface open circuits without touching private state.
+
+        Args:
+            url: Any URL on the host to query (only the ``netloc`` is used).
+        """
+        cb = self._circuit_breakers.get(urlparse(url).netloc)
+        if cb is None:
+            return None
+        return cb.state
+
+    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
+        """Override the per-host crawl delay for *host*.
+
+        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
+        when the override is larger.  Intended for callers that parse a site's
+        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
+        """
+        self._crawl_delay_overrides[host] = delay_seconds
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        context: Mapping[str, Any] | None,
+        timeout: float | tuple[float, float],
+        request_fn: Callable[[], Any],
+        value_builder: Callable[[Any], ResponseValue],
+    ) -> Result[ResponseValue, Exception]:
+        """Execute request with retries, circuit breaking, and normalised metadata."""
+        host = urlparse(url).netloc
+        cb = self._get_circuit_breaker(host)
+        if cb is not None and not cb.allow_request():
+            meta = self._build_meta(
+                method=method,
+                request_url=url,
+                response=None,
+                context=context,
+                attempts=0,
+                timeout=timeout,
+                final_error="CircuitOpenError",
+            )
+            return Err(CircuitOpenError(host), meta=meta)
+
+        try:
+            self._enforce_robots(url)
+        except RobotsBlockedError as exc:
+            meta = self._build_meta(
+                method=method,
+                request_url=url,
+                response=None,
+                context=context,
+                attempts=0,
+                timeout=timeout,
+                final_error="RobotsBlockedError",
+            )
+            return Err(exc, meta=meta)
+
+        self._enforce_rate_limit(host)
+        is_safe_method = method.upper() in {"GET", "HEAD"}
+        pool = self._config.proxy_pool
+        attempts = 0
+        last_error: Exception | None = None
+        last_blocked_response: Any = None
+        last_blocked_retry_after: float | None = None
+        current_proxy: Mapping[str, str] | None = None
+        if pool is not None:
+            current_proxy = pool.next_proxy()
+            self._apply_proxy(current_proxy)
+        for _ in range(self._max_attempts()):
+            attempts += 1
+            try:
+                response = request_fn()
+                if (
+                    response.status_code in self._config.retry_on_status
+                    and is_safe_method
+                ):
+                    last_blocked_retry_after = self._parse_retry_after(response)
+                    last_blocked_response = response
+                    last_error = None
+                    if attempts < self._max_attempts():
+                        if pool is not None:
+                            pool.mark_failure(current_proxy)
+                            current_proxy = pool.next_proxy()
+                            self._apply_proxy(current_proxy)
+                        self._sleep_for_retry_after(
+                            last_blocked_retry_after, attempts
+                        )
+                        continue
+                    break
+                if cb is not None:
+                    cb.record_success()
+                return Ok(
+                    value_builder(response),
+                    meta=self._build_meta(
+                        method=method,
+                        request_url=url,
+                        response=response,
+                        context=context,
+                        attempts=attempts,
+                        timeout=timeout,
+                    ),
+                )
+            except Exception as exc:
+                if not self._is_transport_exception(exc):  # pragma: no cover
+                    if cb is not None:
+                        cb.record_failure()
+                    return Err(
+                        HttpClientError(str(exc)),
+                        meta=self._build_meta(
+                            method=method,
+                            request_url=url,
+                            response=None,
+                            context=context,
+                            attempts=attempts,
+                            timeout=timeout,
+                            final_error=type(exc).__name__,
+                        ),
+                    )
+                last_error = exc
+                last_blocked_response = None
+                last_blocked_retry_after = None
+                if (
+                    attempts >= self._max_attempts()
+                    or not self._is_retryable_exception(method, exc)
+                ):
+                    break
+                if pool is not None:
+                    pool.mark_failure(current_proxy)
+                    current_proxy = pool.next_proxy()
+                    self._apply_proxy(current_proxy)
+                self._sleep_between_attempts(attempts)
+            finally:
+                if host:
+                    self._last_request_time[host] = monotonic()
+
+        if last_blocked_response is not None:
+            if cb is not None:
+                cb.record_failure()
+            if pool is not None:
+                pool.mark_failure(current_proxy)
+            return Err(
+                RateLimitedError(
+                    last_blocked_response.status_code, last_blocked_retry_after
+                ),
+                meta=self._build_meta(
+                    method=method,
+                    request_url=url,
+                    response=last_blocked_response,
+                    context=context,
+                    attempts=attempts,
+                    timeout=timeout,
+                    final_error="RateLimitedError",
+                ),
+            )
+
+        assert last_error is not None
+        if cb is not None:
+            cb.record_failure()
+        if pool is not None:
+            pool.mark_failure(current_proxy)
+        return self._handle_request_exception(
+            method=method,
+            request_url=url,
+            e=last_error,
+            context=context,
+            attempts=attempts,
+            timeout=timeout,
+        )

--- a/src/ladon/networking/async_client.py
+++ b/src/ladon/networking/async_client.py
@@ -1,45 +1,32 @@
-"""Asynchronous HTTP client for the Ladon networking layer (httpx backend).
+"""AsyncHttpClient — asynchronous HTTP client for the Ladon networking layer.
 
-``AsyncHttpClient`` is the **only** module in Ladon that imports ``httpx``.
-All three httpx API deltas vs ``requests`` are encapsulated as private
-methods so the rest of the codebase remains completely unaware of httpx:
+Policy (retries, rate limits, circuit breaking) is provided by
+AsyncPolicyBase.  This module contains only the httpx-specific session
+setup, timeout conversion, and exception mapping.
 
-  ``_to_httpx_proxies()``  — scheme key conversion + Transport wrapping
-  ``_to_httpx_timeout()``  — float/tuple → ``httpx.Timeout``
-  ``_build_meta()``        — ``str(r.url)``, ``r.reason_phrase``
-
-If httpx changes its API or is replaced, the blast radius is this file only.
+Three httpx API deltas vs the base are encapsulated here:
+  ``_to_httpx_proxies()`` — scheme key conversion + Transport wrapping
+  ``_to_httpx_timeout()`` — float/tuple → ``httpx.Timeout``
+  ``_build_meta()``        — ``str(r.url)``, ``r.reason_phrase``, redirect flag
 """
 
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
-from random import uniform
-from time import monotonic
-from typing import Any, Callable, Coroutine, Mapping, TypeVar, cast
-from urllib.parse import urlparse
+from typing import Any, Mapping
 
 import httpx
 
-from .circuit_breaker import CircuitBreaker, CircuitState
+from ._async_policy_base import AsyncPolicyBase
 from .config import HttpClientConfig
 from .errors import (
-    CircuitOpenError,
     HttpClientError,
-    RateLimitedError,
     RequestTimeoutError,
     TransientNetworkError,
 )
-from .types import Err, Ok, Result
-
-ResponseValue = TypeVar("ResponseValue")
-
-_RequestFn = Callable[[httpx.AsyncClient], Coroutine[Any, Any, httpx.Response]]
+from .types import Err, Result
 
 
-class AsyncHttpClient:
+class AsyncHttpClient(AsyncPolicyBase):
     """Core async HTTP client (httpx backend).
 
     All outbound async HTTP in Ladon must go through this client to ensure
@@ -74,11 +61,7 @@ class AsyncHttpClient:
                 "AsyncHttpClient only supports (username, password) tuple auth; "
                 "for other schemes use an httpx.Auth subclass directly"
             )
-
-        self._config = config
-        self._last_request_time: dict[str, float] = {}
-        self._circuit_breakers: dict[str, CircuitBreaker] = {}
-        self._crawl_delay_overrides: dict[str, float] = {}
+        super().__init__(config)
 
         headers: dict[str, str] = {}
         if config.user_agent:
@@ -104,12 +87,6 @@ class AsyncHttpClient:
     async def aclose(self) -> None:
         """Close the underlying httpx client and release connections."""
         await self._http.aclose()
-
-    async def __aenter__(self) -> AsyncHttpClient:
-        return self
-
-    async def __aexit__(self, *_: object) -> None:
-        await self.aclose()
 
     # ------------------------------------------------------------------
     # httpx API delta converters — the blast-radius boundary
@@ -158,7 +135,7 @@ class AsyncHttpClient:
         response: httpx.Response | None,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: httpx.Timeout | None,
+        timeout: Any,
         final_error: str | None = None,
     ) -> dict[str, Any]:
         meta: dict[str, Any] = {}
@@ -179,7 +156,7 @@ class AsyncHttpClient:
                 meta["redirected"] = True
             meta["reason"] = (
                 response.reason_phrase
-            )  # httpx renames .reason → .reason_phrase
+            )  # httpx: reason_phrase not reason
             try:
                 meta["elapsed_s"] = response.elapsed.total_seconds()
             except AttributeError:
@@ -189,115 +166,17 @@ class AsyncHttpClient:
         return meta
 
     # ------------------------------------------------------------------
-    # Internal helpers — mirrors HttpClient
+    # Abstract method implementations
     # ------------------------------------------------------------------
 
-    def _max_attempts(self) -> int:
-        return 1 + max(0, self._config.retries)
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True for any httpx transport exception."""
+        return isinstance(exc, httpx.RequestError)
 
-    def _is_retryable_exception(
-        self, method: str, error: httpx.RequestError
-    ) -> bool:
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
         if method.upper() not in {"GET", "HEAD"}:
             return False
-        return isinstance(error, (httpx.TimeoutException, httpx.ConnectError))
-
-    async def _sleep_between_attempts(self, attempt: int) -> None:
-        backoff_base = self._config.backoff_base_seconds
-        if backoff_base <= 0:
-            return
-        cap = backoff_base * (2 ** max(0, attempt - 1))
-        await asyncio.sleep(
-            uniform(0.0, cap) if self._config.backoff_jitter else cap
-        )
-
-    @staticmethod
-    def _parse_retry_after(response: httpx.Response) -> float | None:
-        header = response.headers.get("Retry-After")
-        if header is None:
-            return None
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            pass
-        try:
-            raw = parsedate_to_datetime(header)  # type: ignore
-            dt = cast(datetime, raw)  # pyright: ignore[reportUnnecessaryCast]
-            delta = (dt - datetime.now(tz=timezone.utc)).total_seconds()
-            return max(0.0, delta)
-        except Exception:
-            return None
-
-    async def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            await asyncio.sleep(
-                max(capped, self._config.min_request_interval_seconds)
-            )
-        else:
-            await self._sleep_between_attempts(attempt)
-
-    async def _enforce_rate_limit(self, url: str) -> None:
-        """Enforce per-host politeness delay before issuing a request.
-
-        Only waits — does not stamp ``_last_request_time``.  All stamping is
-        done by the ``_request`` loop's ``finally`` block so that every actual
-        attempt (including retries) updates the timestamp.
-        """
-        host = urlparse(url).netloc
-        if not host:
-            return
-        interval = max(
-            self._config.min_request_interval_seconds,
-            self._crawl_delay_overrides.get(host, 0.0),
-        )
-        if interval <= 0:
-            return
-        last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                await asyncio.sleep(remaining)
-
-    def _merge_params(
-        self, params: Mapping[str, str] | None
-    ) -> Mapping[str, str] | None:
-        dp = self._config.default_params
-        if dp is None:
-            return params
-        merged = {**dp, **(params or {})}
-        return merged if merged else None
-
-    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
-        threshold = self._config.circuit_breaker_failure_threshold
-        if threshold is None:
-            return None
-        host = urlparse(url).netloc
-        if not host:
-            return None
-        if host not in self._circuit_breakers:
-            self._circuit_breakers[host] = CircuitBreaker(
-                threshold=threshold,
-                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
-            )
-        return self._circuit_breakers[host]
-
-    def circuit_state(self, url: str) -> CircuitState | None:
-        """Return the current circuit-breaker state for *url*'s host, or None."""
-        cb = self._circuit_breakers.get(urlparse(url).netloc)
-        return cb.state if cb is not None else None
-
-    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
-        """Override the per-host crawl delay for *host*.
-
-        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
-        when the override is larger.  Intended for callers that parse a site's
-        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
-        """
-        self._crawl_delay_overrides[host] = delay_seconds
+        return isinstance(exc, (httpx.TimeoutException, httpx.ConnectError))
 
     def _client_for_proxy(
         self, proxy: Mapping[str, str] | None
@@ -319,15 +198,28 @@ class AsyncHttpClient:
             verify=self._config.verify_tls,
         )
 
+    async def _execute_attempt(
+        self,
+        request_fn: Any,
+        proxy: Mapping[str, str] | None,
+    ) -> Any:
+        client = self._client_for_proxy(proxy)
+        try:
+            return await request_fn(client)
+        finally:
+            if client is not self._http:
+                await client.aclose()
+
     def _handle_request_exception(
         self,
         method: str,
         request_url: str,
-        e: httpx.RequestError,
+        e: Exception,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: httpx.Timeout | None,
+        timeout: Any,
     ) -> Result[Any, Exception]:
+        """Map httpx exceptions to Ladon errors."""
         meta = self._build_meta(
             method,
             request_url,
@@ -351,135 +243,8 @@ class AsyncHttpClient:
             return Err(TransientNetworkError(str(e)), meta=meta)
         return Err(HttpClientError(str(e)), meta=meta)
 
-    async def _request(
-        self,
-        method: str,
-        url: str,
-        *,
-        context: Mapping[str, Any] | None,
-        timeout_obj: httpx.Timeout,
-        request_fn: _RequestFn,
-        value_builder: Callable[[httpx.Response], ResponseValue],
-    ) -> Result[ResponseValue, Exception]:
-        """Execute an async request with retries, circuit breaking, and rate limiting."""
-        cb = self._get_circuit_breaker(url)
-        if cb is not None and not cb.allow_request():
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout_obj,
-                final_error="CircuitOpenError",
-            )
-            return Err(CircuitOpenError(urlparse(url).netloc), meta=meta)
-
-        await self._enforce_rate_limit(url)
-        host = urlparse(url).netloc
-        is_safe_method = method.upper() in {"GET", "HEAD"}
-        pool = self._config.proxy_pool
-        attempts = 0
-        last_error: httpx.RequestError | None = None
-        last_blocked_response: httpx.Response | None = None
-        last_blocked_retry_after: float | None = None
-        current_proxy: Mapping[str, str] | None = None
-        if pool is not None:
-            current_proxy = pool.next_proxy()
-
-        for _ in range(self._max_attempts()):
-            attempts += 1
-            client = self._client_for_proxy(current_proxy)
-            should_close = client is not self._http
-            try:
-                response = await request_fn(client)
-                if (
-                    response.status_code in self._config.retry_on_status
-                    and is_safe_method
-                ):
-                    last_blocked_retry_after = self._parse_retry_after(response)
-                    last_blocked_response = response
-                    last_error = None
-                    if attempts < self._max_attempts():
-                        if pool is not None:
-                            pool.mark_failure(current_proxy)
-                            current_proxy = pool.next_proxy()
-                        await self._sleep_for_retry_after(
-                            last_blocked_retry_after, attempts
-                        )
-                        continue
-                    break
-                if cb is not None:
-                    cb.record_success()
-                return Ok(
-                    value_builder(response),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=response,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout_obj,
-                    ),
-                )
-            except httpx.RequestError as exc:
-                last_error = exc
-                last_blocked_response = None
-                last_blocked_retry_after = None
-                if (
-                    attempts >= self._max_attempts()
-                    or not self._is_retryable_exception(method, exc)
-                ):
-                    break
-                if pool is not None:
-                    pool.mark_failure(current_proxy)
-                    current_proxy = pool.next_proxy()
-                await self._sleep_between_attempts(attempts)
-            finally:
-                # Stamp after every attempt so the next _request call sees an
-                # accurate "last request time" even when retries consumed seconds.
-                if host:
-                    self._last_request_time[host] = monotonic()
-                if should_close:
-                    await client.aclose()
-
-        if last_blocked_response is not None:
-            if cb is not None:
-                cb.record_failure()
-            if pool is not None:
-                pool.mark_failure(current_proxy)
-            return Err(
-                RateLimitedError(
-                    last_blocked_response.status_code,
-                    last_blocked_retry_after,
-                ),
-                meta=self._build_meta(
-                    method=method,
-                    request_url=url,
-                    response=last_blocked_response,
-                    context=context,
-                    attempts=attempts,
-                    timeout=timeout_obj,
-                    final_error="RateLimitedError",
-                ),
-            )
-
-        assert last_error is not None
-        if cb is not None:
-            cb.record_failure()
-        if pool is not None:
-            pool.mark_failure(current_proxy)
-        return self._handle_request_exception(
-            method=method,
-            request_url=url,
-            e=last_error,
-            context=context,
-            attempts=attempts,
-            timeout=timeout_obj,
-        )
-
     # ------------------------------------------------------------------
-    # Public API — mirrors HttpClient
+    # Public API
     # ------------------------------------------------------------------
 
     async def get(
@@ -513,7 +278,7 @@ class AsyncHttpClient:
             method="GET",
             url=url,
             context=context,
-            timeout_obj=timeout_obj,
+            timeout=timeout_obj,
             request_fn=_fn,
             value_builder=lambda r: r.content,
         )
@@ -549,7 +314,7 @@ class AsyncHttpClient:
             method="HEAD",
             url=url,
             context=context,
-            timeout_obj=timeout_obj,
+            timeout=timeout_obj,
             request_fn=_fn,
             value_builder=lambda r: dict(r.headers),
         )
@@ -589,7 +354,7 @@ class AsyncHttpClient:
             method="POST",
             url=url,
             context=context,
-            timeout_obj=timeout_obj,
+            timeout=timeout_obj,
             request_fn=_fn,
             value_builder=lambda r: r.content,
         )
@@ -626,7 +391,7 @@ class AsyncHttpClient:
             method="GET",
             url=url,
             context=context,
-            timeout_obj=timeout_obj,
+            timeout=timeout_obj,
             request_fn=_fn,
             value_builder=lambda r: r,
         )

--- a/src/ladon/networking/async_client.py
+++ b/src/ladon/networking/async_client.py
@@ -221,10 +221,8 @@ class AsyncHttpClient:
         except ValueError:
             pass
         try:
-            # parsedate_to_datetime has no type stubs; cast gives pyright a
-            # concrete datetime so downstream arithmetic is fully typed.
-            raw = parsedate_to_datetime(header)  # pyright: ignore
-            dt = cast(datetime, raw)
+            raw = parsedate_to_datetime(header)  # type: ignore
+            dt = cast(datetime, raw)  # pyright: ignore[reportUnnecessaryCast]
             delta = (dt - datetime.now(tz=timezone.utc)).total_seconds()
             return max(0.0, delta)
         except Exception:

--- a/src/ladon/networking/async_curl_client.py
+++ b/src/ladon/networking/async_curl_client.py
@@ -18,36 +18,24 @@ Bootstrap symbols (cffi, cffi_exc, BrowserType) are owned by _cffi_common.py.
 
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
-from random import uniform
-from time import monotonic
-from typing import Any, Callable, Coroutine, Mapping, TypeVar
-from urllib.parse import urlparse
+from typing import Any, Mapping
 
+from ._async_policy_base import AsyncPolicyBase
 from ._cffi_common import cffi as _cffi
 from ._cffi_common import cffi_exc as _cffi_exc
 from ._cffi_common import curl_cffi_available as _curl_cffi_available
 from ._cffi_common import import_error_msg as _import_error_msg
 from ._cffi_common import valid_impersonate as _valid_impersonate
-from .circuit_breaker import CircuitBreaker, CircuitState
 from .config import HttpClientConfig
 from .errors import (
-    CircuitOpenError,
     HttpClientError,
-    RateLimitedError,
     RequestTimeoutError,
     TransientNetworkError,
 )
-from .types import Err, Ok, Result
-
-ResponseValue = TypeVar("ResponseValue")
-
-_AsyncRequestFn = Callable[[], Coroutine[Any, Any, Any]]
+from .types import Err, Result
 
 
-class AsyncCurlHttpClient:
+class AsyncCurlHttpClient(AsyncPolicyBase):
     """Async HTTP client with TLS fingerprint impersonation via curl-cffi.
 
     Drop-in async replacement for ``AsyncHttpClient`` for targets protected
@@ -93,12 +81,9 @@ class AsyncCurlHttpClient:
                 "not supported. Use default_headers={'Authorization': '...'} "
                 "for Bearer tokens or other header-based schemes."
             )
-        self._config = config
+        super().__init__(config)
         self._impersonate = impersonate
         self._session: Any = _cffi.AsyncSession(impersonate=impersonate)
-        self._last_request_time: dict[str, float] = {}
-        self._circuit_breakers: dict[str, CircuitBreaker] = {}
-        self._crawl_delay_overrides: dict[str, float] = {}
         if self._config.user_agent:
             self._session.headers["User-Agent"] = self._config.user_agent
         self._session.headers.update(self._config.default_headers)
@@ -115,12 +100,6 @@ class AsyncCurlHttpClient:
     async def aclose(self) -> None:
         """Close the underlying session and release pooled connections."""
         await self._session.close()
-
-    async def __aenter__(self) -> AsyncCurlHttpClient:
-        return self
-
-    async def __aexit__(self, *_: object) -> None:
-        await self.aclose()
 
     def _get_timeout(
         self, override: float | None
@@ -139,124 +118,41 @@ class AsyncCurlHttpClient:
             )
         return self._config.timeout_seconds
 
-    def _max_attempts(self) -> int:
-        return 1 + max(0, self._config.retries)
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True for any curl-cffi transport exception."""
+        return isinstance(exc, _cffi_exc.RequestException)
 
-    def _is_retryable_exception(self, method: str, error: Any) -> bool:
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
         if method.upper() not in {"GET", "HEAD"}:
             return False
         # SSLError subclasses ConnectionError and will be retried here; cert
         # failures are not transient but exhausting retries is the safe default.
-        return isinstance(error, (_cffi_exc.Timeout, _cffi_exc.ConnectionError))
-
-    async def _sleep_between_attempts(self, attempt: int) -> None:
-        backoff_base = self._config.backoff_base_seconds
-        if backoff_base <= 0:
-            return
-        cap = backoff_base * (2 ** max(0, attempt - 1))
-        await asyncio.sleep(
-            uniform(0.0, cap) if self._config.backoff_jitter else cap
-        )
-
-    @staticmethod
-    def _parse_retry_after(response: Any) -> float | None:
-        header = response.headers.get("Retry-After")
-        if header is None:
-            return None
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            pass
-        try:
-            dt: datetime = parsedate_to_datetime(str(header))
-            delta: float = (dt - datetime.now(tz=timezone.utc)).total_seconds()
-            return max(0.0, delta)
-        except Exception:
-            return None
-
-    async def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            await asyncio.sleep(
-                max(capped, self._config.min_request_interval_seconds)
-            )
-        else:
-            await self._sleep_between_attempts(attempt)
+        return isinstance(exc, (_cffi_exc.Timeout, _cffi_exc.ConnectionError))
 
     def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
         self._session.proxies.clear()
         if proxy is not None:
             self._session.proxies.update(proxy)
 
-    def _merge_params(
-        self, params: Mapping[str, str] | None
-    ) -> Mapping[str, str] | None:
-        dp = self._config.default_params
-        if dp is None:
-            return params
-        merged = {**dp, **(params or {})}
-        return merged if merged else None
-
-    async def _enforce_rate_limit(self, url: str) -> None:
-        host = urlparse(url).netloc
-        if not host:
-            return
-        interval = max(
-            self._config.min_request_interval_seconds,
-            self._crawl_delay_overrides.get(host, 0.0),
-        )
-        if interval <= 0:
-            return
-        last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                await asyncio.sleep(remaining)
-
-    def _build_meta(
+    async def _execute_attempt(
         self,
-        method: str,
-        request_url: str,
-        response: Any | None,
-        context: Mapping[str, Any] | None,
-        attempts: int,
-        timeout: float | tuple[float, float] | None,
-        final_error: str | None = None,
-    ) -> dict[str, Any]:
-        meta: dict[str, Any] = {}
-        meta["method"] = method
-        meta["url"] = request_url
-        meta["attempts"] = attempts
-        meta["timeout_s"] = timeout
-        if context:
-            context_dict = dict(context)
-            meta["context"] = context_dict
-            for key, value in context_dict.items():
-                meta.setdefault(key, value)
-        if response is not None:
-            meta["status_code"] = response.status_code
-            meta["url"] = response.url
-            meta["reason"] = response.reason
-            try:
-                meta["elapsed_s"] = response.elapsed.total_seconds()
-            except AttributeError:
-                pass
-        if final_error is not None:
-            meta["final_error"] = final_error
-        return meta
+        request_fn: Any,
+        proxy: Mapping[str, str] | None,
+    ) -> Any:
+        if self._config.proxy_pool is not None:
+            self._apply_proxy(proxy)
+        return await request_fn()
 
     def _handle_request_exception(
         self,
         method: str,
         request_url: str,
-        e: Any,
+        e: Exception,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: float | tuple[float, float] | None,
+        timeout: Any,
     ) -> Result[Any, Exception]:
+        """Map curl-cffi exceptions to Ladon errors."""
         response = getattr(e, "response", None)
         meta = self._build_meta(
             method,
@@ -272,172 +168,6 @@ class AsyncCurlHttpClient:
         if isinstance(e, _cffi_exc.ConnectionError):
             return Err(TransientNetworkError(str(e)), meta=meta)
         return Err(HttpClientError(str(e)), meta=meta)
-
-    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
-        threshold = self._config.circuit_breaker_failure_threshold
-        if threshold is None:
-            return None
-        host = urlparse(url).netloc
-        if not host:
-            return None
-        if host not in self._circuit_breakers:
-            self._circuit_breakers[host] = CircuitBreaker(
-                threshold=threshold,
-                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
-            )
-        return self._circuit_breakers[host]
-
-    def circuit_state(self, url: str) -> CircuitState | None:
-        """Return the current circuit-breaker state for *url*'s host, or None."""
-        cb = self._circuit_breakers.get(urlparse(url).netloc)
-        return cb.state if cb is not None else None
-
-    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
-        """Override the per-host crawl delay for *host*.
-
-        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
-        when the override is larger.  Intended for callers that parse a site's
-        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
-        """
-        self._crawl_delay_overrides[host] = delay_seconds
-
-    async def _request(
-        self,
-        method: str,
-        url: str,
-        *,
-        context: Mapping[str, Any] | None,
-        timeout: float | tuple[float, float],
-        request_fn: _AsyncRequestFn,
-        value_builder: Callable[[Any], ResponseValue],
-    ) -> Result[ResponseValue, Exception]:
-        cb = self._get_circuit_breaker(url)
-        if cb is not None and not cb.allow_request():
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="CircuitOpenError",
-            )
-            return Err(CircuitOpenError(urlparse(url).netloc), meta=meta)
-
-        await self._enforce_rate_limit(url)
-        host = urlparse(url).netloc
-        is_safe_method = method.upper() in {"GET", "HEAD"}
-        pool = self._config.proxy_pool
-        attempts = 0
-        last_error: Any = None
-        last_blocked_response: Any = None
-        last_blocked_retry_after: float | None = None
-        current_proxy: Mapping[str, str] | None = None
-        if pool is not None:
-            current_proxy = pool.next_proxy()
-            self._apply_proxy(current_proxy)
-
-        for _ in range(self._max_attempts()):
-            attempts += 1
-            try:
-                response = await request_fn()
-                if (
-                    response.status_code in self._config.retry_on_status
-                    and is_safe_method
-                ):
-                    last_blocked_retry_after = self._parse_retry_after(response)
-                    last_blocked_response = response
-                    last_error = None
-                    if attempts < self._max_attempts():
-                        if pool is not None:
-                            pool.mark_failure(current_proxy)
-                            current_proxy = pool.next_proxy()
-                            self._apply_proxy(current_proxy)
-                        await self._sleep_for_retry_after(
-                            last_blocked_retry_after, attempts
-                        )
-                        continue
-                    break
-                if cb is not None:
-                    cb.record_success()
-                return Ok(
-                    value_builder(response),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=response,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                    ),
-                )
-            except _cffi_exc.RequestException as exc:
-                last_error = exc
-                last_blocked_response = None
-                last_blocked_retry_after = None
-                if (
-                    attempts >= self._max_attempts()
-                    or not self._is_retryable_exception(method, exc)
-                ):
-                    break
-                if pool is not None:
-                    pool.mark_failure(current_proxy)
-                    current_proxy = pool.next_proxy()
-                    self._apply_proxy(current_proxy)
-                await self._sleep_between_attempts(attempts)
-            except Exception as exc:  # pragma: no cover - defensive fallback
-                if cb is not None:
-                    cb.record_failure()
-                return Err(
-                    HttpClientError(str(exc)),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=None,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                        final_error=type(exc).__name__,
-                    ),
-                )
-            finally:
-                if host:
-                    self._last_request_time[host] = monotonic()
-
-        if last_blocked_response is not None:
-            if cb is not None:
-                cb.record_failure()
-            if pool is not None:
-                pool.mark_failure(current_proxy)
-            return Err(
-                RateLimitedError(
-                    last_blocked_response.status_code,
-                    last_blocked_retry_after,
-                ),
-                meta=self._build_meta(
-                    method=method,
-                    request_url=url,
-                    response=last_blocked_response,
-                    context=context,
-                    attempts=attempts,
-                    timeout=timeout,
-                    final_error="RateLimitedError",
-                ),
-            )
-
-        assert last_error is not None
-        if cb is not None:
-            cb.record_failure()
-        if pool is not None:
-            pool.mark_failure(current_proxy)
-        return self._handle_request_exception(
-            method=method,
-            request_url=url,
-            e=last_error,
-            context=context,
-            attempts=attempts,
-            timeout=timeout,
-        )
 
     async def get(
         self,

--- a/src/ladon/networking/async_curl_client.py
+++ b/src/ladon/networking/async_curl_client.py
@@ -12,7 +12,8 @@ If curl-cffi is not installed, importing this module succeeds but
 instantiating ``AsyncCurlHttpClient`` raises ``ImportError`` with an
 actionable message.
 
-Blast radius: if curl-cffi changes its async API, only this file is affected.
+Blast radius: if curl-cffi changes its async session API, only this file is affected.
+Bootstrap symbols (cffi, cffi_exc, BrowserType) are owned by _cffi_common.py.
 """
 
 from __future__ import annotations
@@ -25,27 +26,11 @@ from time import monotonic
 from typing import Any, Callable, Coroutine, Mapping, TypeVar
 from urllib.parse import urlparse
 
-try:
-    from curl_cffi import (
-        requests as _cffi,  # type: ignore[import-untyped, import-not-found]
-    )
-    from curl_cffi.requests import (
-        BrowserType as _BrowserType,  # type: ignore[import-untyped, import-not-found]
-    )
-    from curl_cffi.requests import (
-        exceptions as _cffi_exc,  # type: ignore[import-untyped, import-not-found]
-    )
-
-    _curl_cffi_available: bool = True
-    _valid_impersonate: frozenset[str] = frozenset(
-        b.value for b in _BrowserType  # type: ignore[union-attr]
-    )
-except ImportError:
-    _cffi: Any = None
-    _cffi_exc: Any = None
-    _curl_cffi_available = False
-    _valid_impersonate = frozenset()
-
+from ._cffi_common import cffi as _cffi
+from ._cffi_common import cffi_exc as _cffi_exc
+from ._cffi_common import curl_cffi_available as _curl_cffi_available
+from ._cffi_common import import_error_msg as _import_error_msg
+from ._cffi_common import valid_impersonate as _valid_impersonate
 from .circuit_breaker import CircuitBreaker, CircuitState
 from .config import HttpClientConfig
 from .errors import (
@@ -60,11 +45,6 @@ from .types import Err, Ok, Result
 ResponseValue = TypeVar("ResponseValue")
 
 _AsyncRequestFn = Callable[[], Coroutine[Any, Any, Any]]
-
-_IMPORT_ERROR_MSG = (
-    "curl-cffi is required for AsyncCurlHttpClient.\n"
-    "Install it with:  pip install ladon-crawl[cffi]"
-)
 
 
 class AsyncCurlHttpClient:
@@ -94,7 +74,7 @@ class AsyncCurlHttpClient:
 
     def __init__(self, config: HttpClientConfig, *, impersonate: str) -> None:
         if not _curl_cffi_available:
-            raise ImportError(_IMPORT_ERROR_MSG)
+            raise ImportError(_import_error_msg(type(self).__name__))
         if config.respect_robots_txt:
             raise NotImplementedError(
                 "respect_robots_txt is not supported by AsyncCurlHttpClient; "

--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -1,38 +1,28 @@
-"""Synchronous HTTP client interface for the Ladon networking layer.
+"""HttpClient — synchronous HTTP client for the Ladon networking layer.
 
-This module defines the public interface used by crawlers/adapters. It is
-policy-agnostic by design; retries, rate limits, circuit breaking, and
-robots enforcement are applied by the concrete implementation.
+Policy (retries, rate limits, circuit breaking, robots.txt) is provided by
+SyncPolicyBase.  This module contains only the requests-specific session
+setup and exception mapping.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
-from random import uniform
-from time import monotonic, sleep
-from typing import Any, Callable, Mapping, TypeVar
-from urllib.parse import urlparse
+from typing import Any, Mapping, MutableMapping
 
 import requests
 
-from .circuit_breaker import CircuitBreaker, CircuitState
+from ._sync_policy_base import SyncPolicyBase
 from .config import HttpClientConfig
 from .errors import (
-    CircuitOpenError,
     HttpClientError,
-    RateLimitedError,
     RequestTimeoutError,
-    RobotsBlockedError,
     TransientNetworkError,
 )
 from .robots import RobotsCache
-from .types import Err, Ok, Result
-
-ResponseValue = TypeVar("ResponseValue")
+from .types import Err, Result
 
 
-class HttpClient:
+class HttpClient(SyncPolicyBase):
     """Core HTTP client interface (sync).
 
     All outbound HTTP in Ladon must go through this client to ensure consistent
@@ -52,10 +42,8 @@ class HttpClient:
         Args:
             config: Configuration for timeouts, headers, and policy settings.
         """
-        self._config = config
+        super().__init__(config)
         self._session = requests.Session()
-        self._last_request_time: dict[str, float] = {}
-        self._circuit_breakers: dict[str, CircuitBreaker] = {}
         if self._config.user_agent:
             self._session.headers["User-Agent"] = self._config.user_agent
         self._session.headers.update(self._config.default_headers)
@@ -63,7 +51,7 @@ class HttpClient:
             self._session.proxies.update(self._config.proxies)
         if self._config.auth is not None:
             self._session.auth = self._config.auth
-        self._robots_cache: RobotsCache | None = (
+        self._robots_cache = (
             RobotsCache(
                 self._session,
                 self._config.user_agent or "*",
@@ -73,234 +61,39 @@ class HttpClient:
             if self._config.respect_robots_txt
             else None
         )
-        # Per-host Crawl-delay overrides populated by _enforce_robots.
-        # These take precedence over min_request_interval_seconds when larger.
-        self._crawl_delay_overrides: dict[str, float] = {}
 
     def close(self) -> None:
         """Close the underlying session and release pooled connections."""
         self._session.close()
 
-    def __enter__(self) -> HttpClient:
-        return self
+    @property
+    def _proxies(self) -> MutableMapping[str, str]:
+        return self._session.proxies  # type: ignore[no-any-return]
 
-    def __exit__(self, *_: object) -> None:
-        self.close()
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True for any requests library transport exception."""
+        return isinstance(exc, requests.exceptions.RequestException)
 
-    def _get_timeout(
-        self, override: float | None
-    ) -> float | tuple[float, float]:
-        """Resolve timeout preference."""
-        if override is not None:
-            if override <= 0:
-                raise ValueError("timeout override must be > 0 when provided")
-            return override
-        if (
-            self._config.connect_timeout_seconds is not None
-            and self._config.read_timeout_seconds is not None
-        ):
-            return (
-                self._config.connect_timeout_seconds,
-                self._config.read_timeout_seconds,
-            )
-        return self._config.timeout_seconds
-
-    def _max_attempts(self) -> int:
-        """Return the total number of attempts for one request."""
-        return 1 + max(0, self._config.retries)
-
-    def _is_retryable_exception(
-        self, method: str, error: requests.exceptions.RequestException
-    ) -> bool:
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
         """Return True for retryable transport errors."""
         if method.upper() not in {"GET", "HEAD"}:
             return False
         return isinstance(
-            error,
+            exc,
             (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
         )
-
-    def _sleep_between_attempts(self, attempt: int) -> None:
-        """Sleep between retry attempts using exponential backoff."""
-        backoff_base = self._config.backoff_base_seconds
-        if backoff_base <= 0:
-            return
-        cap = backoff_base * (2 ** max(0, attempt - 1))
-        sleep(uniform(0.0, cap) if self._config.backoff_jitter else cap)
-
-    @staticmethod
-    def _parse_retry_after(response: requests.Response) -> float | None:
-        """Parse the ``Retry-After`` header from *response* into seconds.
-
-        Handles both delta-seconds (``"60"``) and HTTP-date
-        (``"Wed, 21 Oct 2015 07:28:00 GMT"``) forms per RFC 7231 §7.1.3.
-
-        Returns:
-            Seconds to wait (clamped to 0.0 minimum), or ``None`` if the
-            header is absent or cannot be parsed.
-        """
-        header = response.headers.get("Retry-After")
-        if header is None:
-            return None
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            pass
-        try:
-            dt = parsedate_to_datetime(header)
-            delta = (dt - datetime.now(tz=timezone.utc)).total_seconds()
-            return max(0.0, delta)
-        except Exception:  # fail-open: treat any unparseable date as absent
-            return None
-
-    def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        """Sleep before a retry triggered by a rate-limiting HTTP response.
-
-        When *retry_after* is not ``None``: caps it at
-        ``max_retry_after_seconds``, then takes the longer of the capped value
-        and ``min_request_interval_seconds`` so the client's own politeness
-        policy is never violated.  Falls back to ``_sleep_between_attempts``
-        when *retry_after* is ``None``.
-        """
-        if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            sleep(max(capped, self._config.min_request_interval_seconds))
-        else:
-            self._sleep_between_attempts(attempt)
-
-    def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
-        """Update session proxy to *proxy*, clearing any previous setting."""
-        self._session.proxies.clear()
-        if proxy is not None:
-            self._session.proxies.update(proxy)
-
-    def _merge_params(
-        self, params: Mapping[str, str] | None
-    ) -> Mapping[str, str] | None:
-        """Merge *params* with ``default_params``, per-request wins on collision."""
-        dp = self._config.default_params
-        if dp is None:
-            return params
-        merged = {**dp, **(params or {})}
-        return merged if merged else None
-
-    def _enforce_robots(self, url: str) -> None:
-        """Raise ``RobotsBlockedError`` if *url* is disallowed by robots.txt.
-
-        No-op when ``respect_robots_txt`` is False (the default) or when the
-        robots.txt fetch fails (fail-open behaviour).
-
-        Called before ``_enforce_rate_limit`` so that blocked requests are
-        rejected before the rate-limit slot is consumed — honouring the spirit
-        of the robots.txt contract: don't even waste a rate-limit slot on a
-        host that has explicitly opted out of being crawled.
-
-        Known limitation — robots.txt fetch bypasses rate-limiter
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        ``RobotsCache`` fetches ``/robots.txt`` via a raw ``session.get``
-        call that is invisible to ``_enforce_rate_limit``.  On the first
-        request to any origin this produces two outbound HTTP requests to
-        that host in rapid succession (robots.txt fetch + the actual request),
-        regardless of ``min_request_interval_seconds``.  The cache guarantees
-        at most one robots.txt fetch per origin per session, so subsequent
-        requests to the same host are unaffected.  This trade-off is
-        documented in ADR-008.
-        """
-        if self._robots_cache is None:
-            return
-        if not self._robots_cache.is_allowed(url):
-            raise RobotsBlockedError(f"robots.txt disallows: {url}")
-        # Propagate Crawl-delay into the rate limiter for this host.
-        # HttpClientConfig is frozen so we maintain a side-table of per-host
-        # delay overrides rather than mutating config.
-        # Note: Crawl-delay is only registered here, on the *allowed* path.
-        # A domain that disallows all URLs but advertises Crawl-delay will
-        # have the delay present in RobotsCache._crawl_delays (populated at
-        # fetch time) but absent from _crawl_delay_overrides (since no request
-        # is ever made to that host, there is nothing to throttle).
-        delay = self._robots_cache.crawl_delay(url)
-        if delay is not None:
-            host = urlparse(url).netloc
-            current = self._config.min_request_interval_seconds
-            if delay > current:
-                self._crawl_delay_overrides[host] = delay
-
-    def _enforce_rate_limit(self, url: str) -> None:
-        """Enforce per-host politeness delay before issuing a request.
-
-        If ``min_request_interval_seconds`` is set, sleeps for however long
-        remains since the last request to the same host, then records the
-        current time as the new last-request timestamp for that host.
-
-        No-op when ``min_request_interval_seconds`` is zero (the default).
-        """
-        host = urlparse(url).netloc
-        if not host:
-            return  # malformed URL — skip rather than poisoning the empty-key slot
-        interval = max(
-            self._config.min_request_interval_seconds,
-            self._crawl_delay_overrides.get(host, 0.0),
-        )
-        if interval <= 0:
-            return
-        last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                sleep(remaining)
-        # Writes here (start-to-start semantics). The three other clients write
-        # in the _request finally block (end-to-start). Will be aligned in #109.
-        self._last_request_time[host] = monotonic()
-
-    def _build_meta(
-        self,
-        method: str,
-        request_url: str,
-        response: requests.Response | None,
-        context: Mapping[str, Any] | None,
-        attempts: int,
-        timeout: float | tuple[float, float] | None,
-        final_error: str | None = None,
-    ) -> dict[str, Any]:
-        """Construct metadata dictionary from response and context."""
-        meta: dict[str, Any] = {}
-        meta["method"] = method
-        meta["url"] = request_url
-        meta["attempts"] = attempts
-        meta["timeout_s"] = timeout
-        if context:
-            context_dict = dict(context)
-            meta["context"] = context_dict
-            for key, value in context_dict.items():
-                meta.setdefault(key, value)
-
-        if response is not None:
-            meta["status_code"] = response.status_code
-            meta["url"] = response.url
-            meta["reason"] = response.reason
-            try:
-                meta["elapsed_s"] = response.elapsed.total_seconds()
-            except AttributeError:
-                pass  # In case elapsed is not available or mocked
-        if final_error is not None:
-            meta["final_error"] = final_error
-
-        return meta
 
     def _handle_request_exception(
         self,
         method: str,
         request_url: str,
-        e: requests.exceptions.RequestException,
+        e: Exception,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: float | tuple[float, float] | None,
+        timeout: float | tuple[float, float],
     ) -> Result[Any, Exception]:
         """Map requests exceptions to Ladon errors."""
-        response = e.response
+        response = getattr(e, "response", None)
         meta = self._build_meta(
             method,
             request_url,
@@ -317,200 +110,7 @@ class HttpClient:
         if isinstance(e, requests.exceptions.ConnectionError):
             return Err(TransientNetworkError(str(e)), meta=meta)
 
-        # Generic fallback for other request exceptions
         return Err(HttpClientError(str(e)), meta=meta)
-
-    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
-        """Return the CircuitBreaker for the host of *url*, or None if disabled."""
-        threshold = self._config.circuit_breaker_failure_threshold
-        if threshold is None:
-            return None
-        host = urlparse(url).netloc
-        if not host:
-            return None
-        if host not in self._circuit_breakers:
-            self._circuit_breakers[host] = CircuitBreaker(
-                threshold=threshold,
-                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
-            )
-        return self._circuit_breakers[host]
-
-    def circuit_state(self, url: str) -> CircuitState | None:
-        """Return the current circuit-breaker state for *url*'s host.
-
-        Returns ``None`` when the circuit breaker is disabled
-        (``circuit_breaker_failure_threshold`` is ``None``) or when no
-        request has been made to the host yet.
-
-        Intended for logging, metrics, and operational dashboards — lets
-        callers surface open circuits without touching private state.
-
-        Args:
-            url: Any URL on the host to query (only the ``netloc`` is used).
-        """
-        cb = self._circuit_breakers.get(urlparse(url).netloc)
-        if cb is None:
-            return None
-        return cb.state
-
-    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
-        """Override the per-host crawl delay for *host*.
-
-        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
-        when the override is larger.  Intended for callers that parse a site's
-        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
-        """
-        self._crawl_delay_overrides[host] = delay_seconds
-
-    def _request(
-        self,
-        method: str,
-        url: str,
-        *,
-        context: Mapping[str, Any] | None,
-        timeout: float | tuple[float, float] | None,
-        request_fn: Callable[[], requests.Response],
-        value_builder: Callable[[requests.Response], ResponseValue],
-    ) -> Result[ResponseValue, Exception]:
-        """Execute request with retries and normalized metadata."""
-        cb = self._get_circuit_breaker(url)
-        if cb is not None and not cb.allow_request():
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="CircuitOpenError",
-            )
-            return Err(
-                CircuitOpenError(urlparse(url).netloc),
-                meta=meta,
-            )
-
-        try:
-            self._enforce_robots(url)
-        except RobotsBlockedError as exc:
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="RobotsBlockedError",
-            )
-            return Err(exc, meta=meta)
-
-        self._enforce_rate_limit(url)
-        is_safe_method = method.upper() in {"GET", "HEAD"}
-        pool = self._config.proxy_pool
-        attempts = 0
-        last_error: requests.exceptions.RequestException | None = None
-        last_blocked_response: requests.Response | None = None
-        last_blocked_retry_after: float | None = None
-        current_proxy: Mapping[str, str] | None = None
-        if pool is not None:
-            current_proxy = pool.next_proxy()
-            self._apply_proxy(current_proxy)
-        for _ in range(self._max_attempts()):
-            attempts += 1
-            try:
-                response = request_fn()
-                if (
-                    response.status_code in self._config.retry_on_status
-                    and is_safe_method
-                ):
-                    last_blocked_retry_after = self._parse_retry_after(response)
-                    last_blocked_response = response
-                    last_error = None
-                    if attempts < self._max_attempts():
-                        if pool is not None:
-                            pool.mark_failure(current_proxy)
-                            current_proxy = pool.next_proxy()
-                            self._apply_proxy(current_proxy)
-                        self._sleep_for_retry_after(
-                            last_blocked_retry_after, attempts
-                        )
-                        continue
-                    break
-                if cb is not None:
-                    cb.record_success()
-                return Ok(
-                    value_builder(response),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=response,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                    ),
-                )
-            except requests.exceptions.RequestException as exc:
-                last_error = exc
-                last_blocked_response = None
-                last_blocked_retry_after = None
-                if (
-                    attempts >= self._max_attempts()
-                    or not self._is_retryable_exception(method, exc)
-                ):
-                    break
-                if pool is not None:
-                    pool.mark_failure(current_proxy)
-                    current_proxy = pool.next_proxy()
-                    self._apply_proxy(current_proxy)
-                self._sleep_between_attempts(attempts)
-            except Exception as exc:  # pragma: no cover - defensive fallback
-                if cb is not None:
-                    cb.record_failure()
-                return Err(
-                    HttpClientError(str(exc)),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=None,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                        final_error=type(exc).__name__,
-                    ),
-                )
-
-        if last_blocked_response is not None:
-            if cb is not None:
-                cb.record_failure()
-            if pool is not None:
-                pool.mark_failure(current_proxy)
-            return Err(
-                RateLimitedError(
-                    last_blocked_response.status_code, last_blocked_retry_after
-                ),
-                meta=self._build_meta(
-                    method=method,
-                    request_url=url,
-                    response=last_blocked_response,
-                    context=context,
-                    attempts=attempts,
-                    timeout=timeout,
-                    final_error="RateLimitedError",
-                ),
-            )
-
-        assert last_error is not None
-        if cb is not None:
-            cb.record_failure()
-        if pool is not None:
-            pool.mark_failure(current_proxy)
-        return self._handle_request_exception(
-            method=method,
-            request_url=url,
-            e=last_error,
-            context=context,
-            attempts=attempts,
-            timeout=timeout,
-        )
 
     @staticmethod
     def _content_value(response: requests.Response) -> bytes:

--- a/src/ladon/networking/client.py
+++ b/src/ladon/networking/client.py
@@ -112,18 +112,6 @@ class HttpClient(SyncPolicyBase):
 
         return Err(HttpClientError(str(e)), meta=meta)
 
-    @staticmethod
-    def _content_value(response: requests.Response) -> bytes:
-        return response.content
-
-    @staticmethod
-    def _headers_value(response: requests.Response) -> Mapping[str, Any]:
-        return dict(response.headers)
-
-    @staticmethod
-    def _response_value(response: requests.Response) -> requests.Response:
-        return response
-
     def get(
         self,
         url: str,

--- a/src/ladon/networking/curl_client.py
+++ b/src/ladon/networking/curl_client.py
@@ -12,7 +12,8 @@ If curl-cffi is not installed, importing this module succeeds but
 instantiating ``CurlHttpClient`` raises ``ImportError`` with an
 actionable message.
 
-Blast radius: if curl-cffi changes its API, only this file is affected.
+Blast radius: if curl-cffi changes its session API, only this file is affected.
+Bootstrap symbols (cffi, cffi_exc, BrowserType) are owned by _cffi_common.py.
 """
 
 from __future__ import annotations
@@ -24,27 +25,11 @@ from time import monotonic, sleep
 from typing import Any, Callable, Mapping, TypeVar
 from urllib.parse import urlparse
 
-try:
-    from curl_cffi import (
-        requests as _cffi,  # type: ignore[import-untyped, import-not-found]
-    )
-    from curl_cffi.requests import (
-        BrowserType as _BrowserType,  # type: ignore[import-untyped, import-not-found]
-    )
-    from curl_cffi.requests import (
-        exceptions as _cffi_exc,  # type: ignore[import-untyped, import-not-found]
-    )
-
-    _curl_cffi_available: bool = True
-    _valid_impersonate: frozenset[str] = frozenset(
-        b.value for b in _BrowserType  # type: ignore[union-attr]
-    )
-except ImportError:
-    _cffi: Any = None
-    _cffi_exc: Any = None
-    _curl_cffi_available = False
-    _valid_impersonate = frozenset()
-
+from ._cffi_common import cffi as _cffi
+from ._cffi_common import cffi_exc as _cffi_exc
+from ._cffi_common import curl_cffi_available as _curl_cffi_available
+from ._cffi_common import import_error_msg as _import_error_msg
+from ._cffi_common import valid_impersonate as _valid_impersonate
 from .circuit_breaker import CircuitBreaker, CircuitState
 from .config import HttpClientConfig
 from .errors import (
@@ -59,11 +44,6 @@ from .robots import RobotsCache
 from .types import Err, Ok, Result
 
 ResponseValue = TypeVar("ResponseValue")
-
-_IMPORT_ERROR_MSG = (
-    "curl-cffi is required for CurlHttpClient.\n"
-    "Install it with:  pip install ladon-crawl[cffi]"
-)
 
 
 class CurlHttpClient:
@@ -88,7 +68,7 @@ class CurlHttpClient:
 
     def __init__(self, config: HttpClientConfig, *, impersonate: str) -> None:
         if not _curl_cffi_available:
-            raise ImportError(_IMPORT_ERROR_MSG)
+            raise ImportError(_import_error_msg(type(self).__name__))
         if impersonate not in _valid_impersonate:
             raise ValueError(
                 f"Unknown impersonate target {impersonate!r}. "

--- a/src/ladon/networking/curl_client.py
+++ b/src/ladon/networking/curl_client.py
@@ -146,18 +146,6 @@ class CurlHttpClient(SyncPolicyBase):
 
         return Err(HttpClientError(str(e)), meta=meta)
 
-    @staticmethod
-    def _content_value(response: Any) -> bytes:
-        return response.content  # type: ignore[no-any-return]
-
-    @staticmethod
-    def _headers_value(response: Any) -> Mapping[str, Any]:
-        return dict(response.headers)
-
-    @staticmethod
-    def _response_value(response: Any) -> Any:
-        return response
-
     def get(
         self,
         url: str,

--- a/src/ladon/networking/curl_client.py
+++ b/src/ladon/networking/curl_client.py
@@ -18,35 +18,25 @@ Bootstrap symbols (cffi, cffi_exc, BrowserType) are owned by _cffi_common.py.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
-from random import uniform
-from time import monotonic, sleep
-from typing import Any, Callable, Mapping, TypeVar
-from urllib.parse import urlparse
+from typing import Any, Mapping, MutableMapping
 
 from ._cffi_common import cffi as _cffi
 from ._cffi_common import cffi_exc as _cffi_exc
 from ._cffi_common import curl_cffi_available as _curl_cffi_available
 from ._cffi_common import import_error_msg as _import_error_msg
 from ._cffi_common import valid_impersonate as _valid_impersonate
-from .circuit_breaker import CircuitBreaker, CircuitState
+from ._sync_policy_base import SyncPolicyBase
 from .config import HttpClientConfig
 from .errors import (
-    CircuitOpenError,
     HttpClientError,
-    RateLimitedError,
     RequestTimeoutError,
-    RobotsBlockedError,
     TransientNetworkError,
 )
 from .robots import RobotsCache
-from .types import Err, Ok, Result
-
-ResponseValue = TypeVar("ResponseValue")
+from .types import Err, Result
 
 
-class CurlHttpClient:
+class CurlHttpClient(SyncPolicyBase):
     """Sync HTTP client with TLS fingerprint impersonation via curl-cffi.
 
     Drop-in replacement for ``HttpClient`` for targets protected by
@@ -82,11 +72,9 @@ class CurlHttpClient:
                 "not supported. Use default_headers={'Authorization': '...'} "
                 "for Bearer tokens or other header-based schemes."
             )
-        self._config = config
+        super().__init__(config)
         self._impersonate = impersonate
         self._session: Any = _cffi.Session(impersonate=impersonate)
-        self._last_request_time: dict[str, float] = {}
-        self._circuit_breakers: dict[str, CircuitBreaker] = {}
         if self._config.user_agent:
             self._session.headers["User-Agent"] = self._config.user_agent
         self._session.headers.update(self._config.default_headers)
@@ -94,7 +82,7 @@ class CurlHttpClient:
             self._session.proxies.update(self._config.proxies)
         if self._config.auth is not None:
             self._session.auth = self._config.auth
-        self._robots_cache: RobotsCache | None = (
+        self._robots_cache = (
             RobotsCache(
                 self._session,
                 self._config.user_agent or "*",
@@ -104,7 +92,6 @@ class CurlHttpClient:
             if self._config.respect_robots_txt
             else None
         )
-        self._crawl_delay_overrides: dict[str, float] = {}
 
     @property
     def impersonate(self) -> str:
@@ -115,160 +102,31 @@ class CurlHttpClient:
         """Close the underlying session and release pooled connections."""
         self._session.close()
 
-    def __enter__(self) -> CurlHttpClient:
-        return self
+    @property
+    def _proxies(self) -> MutableMapping[str, str]:
+        return self._session.proxies  # type: ignore[no-any-return]
 
-    def __exit__(self, *_: object) -> None:
-        self.close()
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        """Return True for any curl-cffi transport exception."""
+        return isinstance(exc, _cffi_exc.RequestException)
 
-    def _get_timeout(
-        self, override: float | None
-    ) -> float | tuple[float, float]:
-        if override is not None:
-            if override <= 0:
-                raise ValueError("timeout override must be > 0 when provided")
-            return override
-        if (
-            self._config.connect_timeout_seconds is not None
-            and self._config.read_timeout_seconds is not None
-        ):
-            return (
-                self._config.connect_timeout_seconds,
-                self._config.read_timeout_seconds,
-            )
-        return self._config.timeout_seconds
-
-    def _max_attempts(self) -> int:
-        return 1 + max(0, self._config.retries)
-
-    def _is_retryable_exception(self, method: str, error: Any) -> bool:
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
         if method.upper() not in {"GET", "HEAD"}:
             return False
         # SSLError subclasses ConnectionError and will be retried here; cert
         # failures are not transient but exhausting retries is the safe default.
-        return isinstance(
-            error,
-            (_cffi_exc.Timeout, _cffi_exc.ConnectionError),
-        )
-
-    def _sleep_between_attempts(self, attempt: int) -> None:
-        backoff_base = self._config.backoff_base_seconds
-        if backoff_base <= 0:
-            return
-        cap = backoff_base * (2 ** max(0, attempt - 1))
-        sleep(uniform(0.0, cap) if self._config.backoff_jitter else cap)
-
-    @staticmethod
-    def _parse_retry_after(response: Any) -> float | None:
-        header = response.headers.get("Retry-After")
-        if header is None:
-            return None
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            pass
-        try:
-            dt: datetime = parsedate_to_datetime(str(header))
-            delta: float = (dt - datetime.now(tz=timezone.utc)).total_seconds()
-            return max(0.0, delta)
-        except Exception:
-            return None
-
-    def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            sleep(max(capped, self._config.min_request_interval_seconds))
-        else:
-            self._sleep_between_attempts(attempt)
-
-    def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
-        self._session.proxies.clear()
-        if proxy is not None:
-            self._session.proxies.update(proxy)
-
-    def _merge_params(
-        self, params: Mapping[str, str] | None
-    ) -> Mapping[str, str] | None:
-        dp = self._config.default_params
-        if dp is None:
-            return params
-        merged = {**dp, **(params or {})}
-        return merged if merged else None
-
-    def _enforce_robots(self, url: str) -> None:
-        if self._robots_cache is None:
-            return
-        if not self._robots_cache.is_allowed(url):
-            raise RobotsBlockedError(f"robots.txt disallows: {url}")
-        delay = self._robots_cache.crawl_delay(url)
-        if delay is not None:
-            host = urlparse(url).netloc
-            current = self._config.min_request_interval_seconds
-            if delay > current:
-                self._crawl_delay_overrides[host] = delay
-
-    def _enforce_rate_limit(self, url: str) -> None:
-        host = urlparse(url).netloc
-        if not host:
-            return
-        interval = max(
-            self._config.min_request_interval_seconds,
-            self._crawl_delay_overrides.get(host, 0.0),
-        )
-        if interval <= 0:
-            return
-        last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                sleep(remaining)
-
-    def _build_meta(
-        self,
-        method: str,
-        request_url: str,
-        response: Any | None,
-        context: Mapping[str, Any] | None,
-        attempts: int,
-        timeout: float | tuple[float, float] | None,
-        final_error: str | None = None,
-    ) -> dict[str, Any]:
-        meta: dict[str, Any] = {}
-        meta["method"] = method
-        meta["url"] = request_url
-        meta["attempts"] = attempts
-        meta["timeout_s"] = timeout
-        if context:
-            context_dict = dict(context)
-            meta["context"] = context_dict
-            for key, value in context_dict.items():
-                meta.setdefault(key, value)
-
-        if response is not None:
-            meta["status_code"] = response.status_code
-            meta["url"] = response.url
-            meta["reason"] = response.reason
-            try:
-                meta["elapsed_s"] = response.elapsed.total_seconds()
-            except AttributeError:
-                pass
-        if final_error is not None:
-            meta["final_error"] = final_error
-
-        return meta
+        return isinstance(exc, (_cffi_exc.Timeout, _cffi_exc.ConnectionError))
 
     def _handle_request_exception(
         self,
         method: str,
         request_url: str,
-        e: Any,
+        e: Exception,
         context: Mapping[str, Any] | None,
         attempts: int,
-        timeout: float | tuple[float, float] | None,
+        timeout: float | tuple[float, float],
     ) -> Result[Any, Exception]:
+        """Map curl-cffi exceptions to Ladon errors."""
         response = getattr(e, "response", None)
         meta = self._build_meta(
             method,
@@ -287,190 +145,6 @@ class CurlHttpClient:
             return Err(TransientNetworkError(str(e)), meta=meta)
 
         return Err(HttpClientError(str(e)), meta=meta)
-
-    def _get_circuit_breaker(self, url: str) -> CircuitBreaker | None:
-        threshold = self._config.circuit_breaker_failure_threshold
-        if threshold is None:
-            return None
-        host = urlparse(url).netloc
-        if not host:
-            return None
-        if host not in self._circuit_breakers:
-            self._circuit_breakers[host] = CircuitBreaker(
-                threshold=threshold,
-                recovery_seconds=self._config.circuit_breaker_recovery_seconds,
-            )
-        return self._circuit_breakers[host]
-
-    def circuit_state(self, url: str) -> CircuitState | None:
-        """Return the current circuit-breaker state for *url*'s host.
-
-        Returns ``None`` when circuit breaking is disabled or no request has
-        been made to the host yet.
-        """
-        cb = self._circuit_breakers.get(urlparse(url).netloc)
-        if cb is None:
-            return None
-        return cb.state
-
-    def set_crawl_delay(self, host: str, delay_seconds: float) -> None:
-        """Override the per-host crawl delay for *host*.
-
-        Takes precedence over ``HttpClientConfig.min_request_interval_seconds``
-        when the override is larger.  Intended for callers that parse a site's
-        ``robots.txt`` and want to honour its ``Crawl-delay`` directive.
-        """
-        self._crawl_delay_overrides[host] = delay_seconds
-
-    def _request(
-        self,
-        method: str,
-        url: str,
-        *,
-        context: Mapping[str, Any] | None,
-        timeout: float | tuple[float, float],
-        request_fn: Callable[[], Any],
-        value_builder: Callable[[Any], ResponseValue],
-    ) -> Result[ResponseValue, Exception]:
-        cb = self._get_circuit_breaker(url)
-        if cb is not None and not cb.allow_request():
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="CircuitOpenError",
-            )
-            return Err(CircuitOpenError(urlparse(url).netloc), meta=meta)
-
-        try:
-            self._enforce_robots(url)
-        except RobotsBlockedError as exc:
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="RobotsBlockedError",
-            )
-            return Err(exc, meta=meta)
-
-        self._enforce_rate_limit(url)
-        host = urlparse(url).netloc
-        is_safe_method = method.upper() in {"GET", "HEAD"}
-        pool = self._config.proxy_pool
-        attempts = 0
-        last_error: Any = None
-        last_blocked_response: Any = None
-        last_blocked_retry_after: float | None = None
-        current_proxy: Mapping[str, str] | None = None
-        if pool is not None:
-            current_proxy = pool.next_proxy()
-            self._apply_proxy(current_proxy)
-        for _ in range(self._max_attempts()):
-            attempts += 1
-            try:
-                response = request_fn()
-                if (
-                    response.status_code in self._config.retry_on_status
-                    and is_safe_method
-                ):
-                    last_blocked_retry_after = self._parse_retry_after(response)
-                    last_blocked_response = response
-                    last_error = None
-                    if attempts < self._max_attempts():
-                        if pool is not None:
-                            pool.mark_failure(current_proxy)
-                            current_proxy = pool.next_proxy()
-                            self._apply_proxy(current_proxy)
-                        self._sleep_for_retry_after(
-                            last_blocked_retry_after, attempts
-                        )
-                        continue
-                    break
-                if cb is not None:
-                    cb.record_success()
-                return Ok(
-                    value_builder(response),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=response,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                    ),
-                )
-            except _cffi_exc.RequestException as exc:
-                last_error = exc
-                last_blocked_response = None
-                last_blocked_retry_after = None
-                if (
-                    attempts >= self._max_attempts()
-                    or not self._is_retryable_exception(method, exc)
-                ):
-                    break
-                if pool is not None:
-                    pool.mark_failure(current_proxy)
-                    current_proxy = pool.next_proxy()
-                    self._apply_proxy(current_proxy)
-                self._sleep_between_attempts(attempts)
-            except Exception as exc:  # pragma: no cover - defensive fallback
-                if cb is not None:
-                    cb.record_failure()
-                return Err(
-                    HttpClientError(str(exc)),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=None,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                        final_error=type(exc).__name__,
-                    ),
-                )
-            finally:
-                if host:
-                    self._last_request_time[host] = monotonic()
-
-        if last_blocked_response is not None:
-            if cb is not None:
-                cb.record_failure()
-            if pool is not None:
-                pool.mark_failure(current_proxy)
-            return Err(
-                RateLimitedError(
-                    last_blocked_response.status_code, last_blocked_retry_after
-                ),
-                meta=self._build_meta(
-                    method=method,
-                    request_url=url,
-                    response=last_blocked_response,
-                    context=context,
-                    attempts=attempts,
-                    timeout=timeout,
-                    final_error="RateLimitedError",
-                ),
-            )
-
-        assert last_error is not None
-        if cb is not None:
-            cb.record_failure()
-        if pool is not None:
-            pool.mark_failure(current_proxy)
-        return self._handle_request_exception(
-            method=method,
-            request_url=url,
-            e=last_error,
-            context=context,
-            attempts=attempts,
-            timeout=timeout,
-        )
 
     @staticmethod
     def _content_value(response: Any) -> bytes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,26 @@ from collections.abc import Generator
 
 import pytest
 
+import ladon.networking._cffi_common as _common
+import ladon.networking.async_curl_client as _acurl
 import ladon.networking.config as _cfg
+import ladon.networking.curl_client as _curl
 
 
 @pytest.fixture(autouse=True)
 def _reset_cffi_impersonate_cache() -> Generator[None, None, None]:
-    """Reset the module-level curl-cffi BrowserType cache between tests.
+    """Reset module-level curl-cffi state between tests.
 
-    Prevents a test that mutates ladon.networking.config._cffi_valid_impersonate
-    from poisoning the cache seen by later tests in the same process.
+    - config._cffi_valid_impersonate: lazy BrowserType cache; reset to None so
+      each test gets a fresh lookup.
+    - curl_client._curl_cffi_available / async_curl_client._curl_cffi_available:
+      re-exported from _cffi_common; reset after each test to the common value in
+      case a test flipped the flag without a finally block.
     """
     _cfg._cffi_valid_impersonate = None  # type: ignore[attr-defined]
+    _curl._curl_cffi_available = _common.curl_cffi_available  # type: ignore[attr-defined]
+    _acurl._curl_cffi_available = _common.curl_cffi_available  # type: ignore[attr-defined]
     yield
     _cfg._cffi_valid_impersonate = None  # type: ignore[attr-defined]
+    _curl._curl_cffi_available = _common.curl_cffi_available  # type: ignore[attr-defined]
+    _acurl._curl_cffi_available = _common.curl_cffi_available  # type: ignore[attr-defined]

--- a/tests/test_async_curl_client.py
+++ b/tests/test_async_curl_client.py
@@ -639,7 +639,7 @@ async def test_backoff_with_jitter_calls_sleep() -> None:
             ]
         )
         with patch(
-            "ladon.networking.async_curl_client.asyncio.sleep"
+            "ladon.networking._async_policy_base.asyncio.sleep"
         ) as mock_sleep:
             mock_sleep.return_value = None
             result = await c.get("http://example.com")
@@ -690,11 +690,11 @@ async def test_rate_limit_sleep_enforced() -> None:
         # Second get() completes → finally records 1001.0
         with (
             patch(
-                "ladon.networking.async_curl_client.monotonic",
+                "ladon.networking._async_policy_base.monotonic",
                 side_effect=[1000.0, 1000.5, 1001.0],
             ),
             patch(
-                "ladon.networking.async_curl_client.asyncio.sleep"
+                "ladon.networking._async_policy_base.asyncio.sleep"
             ) as mock_sleep,
         ):
             mock_sleep.return_value = None

--- a/tests/test_backoff_jitter.py
+++ b/tests/test_backoff_jitter.py
@@ -41,8 +41,8 @@ def test_backoff_jitter_can_be_enabled():
 
 
 class TestJitterDisabled:
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_deterministic_backoff_no_jitter(
         self, mock_get, mock_uniform, mock_sleep
@@ -58,8 +58,8 @@ class TestJitterDisabled:
         mock_uniform.assert_not_called()
         assert mock_sleep.call_args_list == [call(1.0), call(2.0)]
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_zero_base_no_sleep_no_uniform(
         self, mock_get, mock_uniform, mock_sleep
@@ -82,8 +82,8 @@ class TestJitterDisabled:
 
 
 class TestJitterEnabled:
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_jitter_calls_uniform_with_correct_caps(
         self, mock_get, mock_uniform, mock_sleep
@@ -106,8 +106,8 @@ class TestJitterEnabled:
         assert mock_uniform.call_args_list == [call(0.0, 1.0), call(0.0, 2.0)]
         assert mock_sleep.call_args_list == [call(0.37), call(0.37)]
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_jitter_sleep_uses_uniform_return_value(
         self, mock_get, mock_uniform, mock_sleep
@@ -128,8 +128,8 @@ class TestJitterEnabled:
         mock_uniform.assert_called_once_with(0.0, 4.0)
         mock_sleep.assert_called_once_with(1.23)
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_jitter_zero_base_is_noop(self, mock_get, mock_uniform, mock_sleep):
         config = HttpClientConfig(
@@ -146,8 +146,8 @@ class TestJitterEnabled:
         mock_uniform.assert_not_called()
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_jitter_cap_grows_exponentially(
         self, mock_get, mock_uniform, mock_sleep
@@ -175,8 +175,8 @@ class TestJitterEnabled:
 
 
 class TestJitterWithRetryAfterFallback:
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_retry_after_header_present_jitter_not_applied(
         self, mock_get, mock_uniform, mock_sleep
@@ -202,8 +202,8 @@ class TestJitterWithRetryAfterFallback:
         mock_uniform.assert_not_called()
         mock_sleep.assert_called_once_with(30.0)
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.uniform")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_retry_after_absent_jitter_applied_to_fallback(
         self, mock_get, mock_uniform, mock_sleep

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from time import monotonic
 from typing import Generator
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -283,7 +284,7 @@ class TestHttpClientCircuitBreaker:
         assert cb_client.circuit_state(url) is CircuitState.OPEN
 
         # Force into HALF_OPEN by backdating the timer.
-        cb = cb_client._get_circuit_breaker(url)  # type: ignore[attr-defined]
+        cb = cb_client._get_circuit_breaker(urlparse(url).netloc)  # type: ignore[attr-defined]
         assert cb is not None
         cb._opened_at = monotonic() - 61.0  # type: ignore[attr-defined]
 
@@ -340,7 +341,7 @@ class TestHttpClientCircuitBreaker:
             cb_client.get(url)  # opens
 
         # Backdate the timer to trigger HALF_OPEN on next allow_request().
-        cb = cb_client._get_circuit_breaker(url)  # type: ignore[attr-defined]
+        cb = cb_client._get_circuit_breaker(urlparse(url).netloc)  # type: ignore[attr-defined]
         assert cb is not None
         cb._opened_at = monotonic() - 61.0  # type: ignore[attr-defined]
         # Trigger the transition without completing a request.

--- a/tests/test_curl_client.py
+++ b/tests/test_curl_client.py
@@ -605,7 +605,7 @@ def test_set_crawl_delay_overwrites(config: HttpClientConfig) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("ladon.networking.curl_client.sleep")
+@patch("ladon.networking._sync_policy_base.sleep")
 @patch("curl_cffi.requests.Session.get")
 def test_backoff_with_jitter_calls_sleep(
     mock_get: Mock, mock_sleep: Mock
@@ -690,8 +690,8 @@ def test_robots_crawl_delay_sets_override() -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("ladon.networking.curl_client.sleep")
-@patch("ladon.networking.curl_client.monotonic")
+@patch("ladon.networking._sync_policy_base.sleep")
+@patch("ladon.networking._sync_policy_base.monotonic")
 @patch("curl_cffi.requests.Session.get")
 def test_rate_limit_sleep_enforced(
     mock_get: Mock, mock_monotonic: Mock, mock_sleep: Mock

--- a/tests/test_proxy_pool.py
+++ b/tests/test_proxy_pool.py
@@ -184,7 +184,7 @@ def test_proxy_pool_rotates_on_rate_limit_retry():
     with patch(
         "requests.Session.get", side_effect=[blocked, _make_ok_response()]
     ):
-        with patch("ladon.networking.client.sleep"):
+        with patch("ladon.networking._sync_policy_base.sleep"):
             client = HttpClient(config)
             client.get("https://example.com")
 

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -70,8 +70,8 @@ class TestRateLimitConfig:
 
 
 class TestRateLimitEnforcement:
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_first_request_no_sleep(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -84,8 +84,8 @@ class TestRateLimitEnforcement:
 
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_second_request_sleeps_remaining_interval(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -104,8 +104,8 @@ class TestRateLimitEnforcement:
         sleep_arg = mock_sleep.call_args[0][0]
         assert sleep_arg == pytest.approx(0.7, abs=1e-9)
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_request_after_full_interval_no_sleep(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -120,8 +120,8 @@ class TestRateLimitEnforcement:
 
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_different_hosts_not_rate_limited_against_each_other(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -136,8 +136,8 @@ class TestRateLimitEnforcement:
 
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_rate_limit_is_per_host_not_per_url_path(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -155,7 +155,7 @@ class TestRateLimitEnforcement:
         sleep_arg = mock_sleep.call_args[0][0]
         assert sleep_arg == pytest.approx(0.8, abs=1e-9)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_zero_interval_never_sleeps(self, mock_get, mock_sleep):
         """With default interval (0.0), sleep must never be called."""
@@ -169,8 +169,8 @@ class TestRateLimitEnforcement:
 
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_rate_limit_applies_to_consecutive_requests(
         self, mock_get, mock_mono, mock_sleep, rate_limited_client
@@ -186,8 +186,8 @@ class TestRateLimitEnforcement:
 
         assert mock_sleep.call_count == 1
 
-    @patch("ladon.networking.client.sleep")
-    @patch("ladon.networking.client.monotonic")
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     @patch("requests.Session.head")
     @patch("requests.Session.post")

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -108,7 +108,7 @@ class TestParseRetryAfter:
 
 
 class TestRetryAfterBehavior:
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_no_retries_returns_rate_limited_error(
         self, mock_get, mock_sleep
@@ -127,7 +127,7 @@ class TestRetryAfterBehavior:
         assert result.meta["final_error"] == "RateLimitedError"
         mock_get.assert_called_once()
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_503_returns_rate_limited_error(self, mock_get, mock_sleep):
         client = HttpClient(HttpClientConfig(timeout_seconds=5.0))
@@ -141,7 +141,7 @@ class TestRetryAfterBehavior:
         assert isinstance(result.error, RateLimitedError)
         assert result.error.status_code == 503
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_with_retry_after_sleeps_and_succeeds(
         self, mock_get, mock_sleep
@@ -159,7 +159,7 @@ class TestRetryAfterBehavior:
         assert result.value == b"ok"
         mock_sleep.assert_called_once_with(45.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_retry_after_capped_at_max(self, mock_get, mock_sleep):
         config = HttpClientConfig(
@@ -176,7 +176,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         mock_sleep.assert_called_once_with(10.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_no_retry_after_falls_back_to_backoff(
         self, mock_get, mock_sleep
@@ -195,7 +195,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         mock_sleep.assert_called_once_with(2.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_exhausts_retries_returns_rate_limited_error(
         self, mock_get, mock_sleep
@@ -217,7 +217,7 @@ class TestRetryAfterBehavior:
         assert result.meta["final_error"] == "RateLimitedError"
         assert mock_get.call_count == 3
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.post")
     def test_post_429_not_retried_returns_ok(self, mock_post, mock_sleep):
         config = HttpClientConfig(timeout_seconds=5.0, retries=3)
@@ -231,7 +231,7 @@ class TestRetryAfterBehavior:
         mock_post.assert_called_once()
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.head")
     def test_head_429_retried_like_get(self, mock_head, mock_sleep):
         config = HttpClientConfig(timeout_seconds=5.0, retries=1)
@@ -247,7 +247,7 @@ class TestRetryAfterBehavior:
         assert mock_head.call_count == 2
         mock_sleep.assert_called_once_with(5.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_circuit_breaker_trips_on_exhausted_429(self, mock_get, mock_sleep):
         config = HttpClientConfig(
@@ -263,7 +263,7 @@ class TestRetryAfterBehavior:
         assert not result.ok
         assert client.circuit_state("http://example.com") == CircuitState.OPEN
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_empty_retry_on_status_returns_ok_for_429(
         self, mock_get, mock_sleep
@@ -280,7 +280,7 @@ class TestRetryAfterBehavior:
         assert result.meta["status_code"] == 429
         mock_sleep.assert_not_called()
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_custom_retry_on_status_403_retried(self, mock_get, mock_sleep):
         config = HttpClientConfig(
@@ -299,7 +299,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         assert mock_get.call_count == 2
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_meta_includes_status_and_reason_on_rate_limited_error(
         self, mock_get, mock_sleep
@@ -315,7 +315,7 @@ class TestRetryAfterBehavior:
         assert result.meta["reason"] == "Too Many Requests"
         assert result.meta["method"] == "GET"
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_retry_after_below_min_interval_sleeps_min_interval(
         self, mock_get, mock_sleep
@@ -337,7 +337,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         mock_sleep.assert_called_once_with(60.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_retry_after_above_min_interval_sleeps_retry_after(
         self, mock_get, mock_sleep
@@ -359,7 +359,7 @@ class TestRetryAfterBehavior:
         assert result.ok
         mock_sleep.assert_called_once_with(45.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_download_429_retried_like_get(self, mock_get, mock_sleep):
         config = HttpClientConfig(timeout_seconds=5.0, retries=1)
@@ -379,7 +379,7 @@ class TestRetryAfterBehavior:
         assert mock_get.call_count == 2
         mock_sleep.assert_called_once_with(5.0)
 
-    @patch("ladon.networking.client.sleep")
+    @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
     def test_get_429_no_retry_after_backoff_increases_per_attempt(
         self, mock_get, mock_sleep

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -391,7 +391,7 @@ class TestRobotsCacheCrawlDelayVsRateLimit:
 
         Verifies that the override recorded by _enforce_robots is actually
         consumed by _enforce_rate_limit on the *next* request to the same host.
-        We patch ``ladon.networking.client.sleep`` so the test is instant.
+        We patch ``ladon.networking._sync_policy_base.sleep`` so the test is instant.
         """
         config = HttpClientConfig(
             respect_robots_txt=True,
@@ -409,7 +409,7 @@ class TestRobotsCacheCrawlDelayVsRateLimit:
                     "requests.Session.get",
                     return_value=_mock_robots_response(ROBOTS_WITH_DELAY),
                 ),
-                patch("ladon.networking.client.sleep") as mock_sleep,
+                patch("ladon.networking._sync_policy_base.sleep") as mock_sleep,
             ):
                 # First request: registers the Crawl-delay override, no sleep yet
                 # (no prior timestamp for this host).


### PR DESCRIPTION
## Summary

Closes #109. Extracts the shared HTTP policy pipeline from four duplicated clients into two ABCs — one per I/O model.

Three-step PR stack (all already reviewed and merged into this branch):

- **#111 — `_cffi_common.py`**: extracts curl-cffi bootstrap symbols shared by both curl clients. Resolves finding H from PR #108 review.
- **#112 — `_sync_policy_base.py`**: extracts `SyncPolicyBase` ABC holding the full sync policy pipeline. Resolves findings Q, R. Aligns `HttpClient` rate-limit to end-to-start semantics. Adds `_proxies` abstract property (session contract boundary, ADR-012) and `__getattr__` enforcement.
- **#113 — `_async_policy_base.py`**: extracts `AsyncPolicyBase` ABC holding the full async policy pipeline. Key design: `_execute_attempt(request_fn, proxy)` abstract method encapsulates per-attempt lifecycle (httpx creates a client per proxy; curl mutates session proxies). `_build_meta` concrete in base with `AsyncHttpClient` override for httpx-specific field names.

## What changed

| File | Before | After |
|------|--------|-------|
| `client.py` | ~530 lines (full pipeline) | ~85 lines (session setup + overrides) |
| `curl_client.py` | ~520 lines | ~90 lines |
| `async_client.py` | ~550 lines | ~397 lines (larger due to httpx delta converters) |
| `async_curl_client.py` | ~530 lines | ~358 lines |
| `_cffi_common.py` | — | new (shared bootstrap) |
| `_sync_policy_base.py` | — | new (~235 lines) |
| `_async_policy_base.py` | — | new (~370 lines) |
| `docs/decisions/adr-012-session-contract-boundary.md` | — | new |

## Test plan

- [x] All 532 existing tests pass unchanged — public API is identical
- [x] Pyright strict-mode clean
- [x] Pre-commit hooks (black, isort, ruff) pass
- [x] No public API changes — class names, method signatures, `Result` semantics, factory functions unchanged