### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+### Fixed
+
+### Changed
+
 ---
 
 ## [0.3.0] — 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.3.0] — 2026-05-18
+
 ### Added
 
 - **`cffi` optional dependency group** — `pip install ladon-crawl[cffi]` installs
@@ -140,7 +144,8 @@ First public release.
   current counters are correct but the model will be simplified
 - Python 3.11, 3.12, and 3.13 supported; 3.10 and below are not
 
-[Unreleased]: https://github.com/MoonyFringers/ladon/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/MoonyFringers/ladon/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/MoonyFringers/ladon/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/MoonyFringers/ladon/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/MoonyFringers/ladon/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/MoonyFringers/ladon/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -172,29 +172,29 @@ and `AsyncSink` — the same structural-protocol pattern as the sync stack.
 `v0.2.0` — async crawling milestone. `AsyncHttpClient`, `AsyncCrawlPlugin`,
 and `async_run_crawl()` are stable and fully tested. The sync API is unchanged.
 
-What is in v0.2.0:
+What was added in v0.3.0:
+- **Cloudflare bypass** — `CurlHttpClient` / `AsyncCurlHttpClient` via
+  curl-cffi, `HttpClientConfig(backend="curl-cffi", impersonate="chrome136")`,
+  `make_http_client()` / `make_async_http_client()` factories (issue [#107](https://github.com/MoonyFringers/ladon/issues/107))
+
+What was added in v0.2.0:
 - **Async crawling** — `async_run_crawl()` + `AsyncHttpClient` (httpx backend)
 - **Async plugin protocols** — `AsyncSource`, `AsyncExpander`, `AsyncSink`, `AsyncCrawlPlugin`
 - `RunConfig.async_concurrency` — bounded leaf-fetch concurrency (default 10)
 
-What was in v0.1.0:
+What was added in v0.1.0:
 - HTTP 429/503 Retry-After respect and full-jitter backoff
 - Static and rotating proxy support (`ProxyPool`, `RoundRobinProxyPool`)
 - HTTP authentication — Basic, Digest, any `requests.auth.AuthBase`
 - Default query parameters via `HttpClientConfig(default_params=...)`
 
-What was in v0.0.1:
+What was added in v0.0.1:
 - SES protocol (Source / Expander / Sink) with structural typing
 - `run_crawl()` runner with leaf isolation and `RunResult` summary
 - `HttpClient` with retries, back-off, rate limiting, circuit breaker, robots.txt
 - `Storage` protocol with `LocalFileStorage`
 - `Repository` and `RunAudit` persistence protocols with `NullRepository`
 - `ladon run` / `ladon info` CLI
-
-What is in progress (unreleased):
-- **Cloudflare bypass** — `CurlHttpClient` / `AsyncCurlHttpClient` via
-  curl-cffi, `HttpClientConfig(backend="curl-cffi", impersonate="chrome136")`,
-  `make_http_client()` / `make_async_http_client()` factories (issue [#107](https://github.com/MoonyFringers/ladon/issues/107))
 
 What is coming:
 - `ladon-mimir` — async Wikipedia adapter for LLM fine-tuning (issue [#96](https://github.com/MoonyFringers/ladon/issues/96))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ladon-crawl"
-version = "0.2.0"
+version = "0.3.0"
 description = "A structured, resumable web crawling framework for AI-ready datasets."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -52,7 +52,9 @@ from .storage import (
 try:
     __version__ = version("ladon-crawl")
 except PackageNotFoundError:
-    __version__ = "0.0.1"  # editable install without metadata
+    __version__ = (
+        "0.3.0"  # editable install without metadata — bump with every release
+    )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

- Bump version to `0.3.0` in `pyproject.toml`
- Promote `[Unreleased]` CHANGELOG section to `[0.3.0] — 2026-05-18`
- Update CHANGELOG comparison links (`HEAD` now tracks `v0.3.0`)
- Update README version history: replace "in progress (unreleased)" with "added in v0.3.0", standardise past-tense headings for older versions, newest-first order

Closes #110

## After merge

Tag and push:
```
git tag v0.3.0
git push origin v0.3.0
```

## Test plan

- [ ] `pyproject.toml` version reads `0.3.0`
- [ ] CHANGELOG has `[0.3.0] — 2026-05-18` section with curl-cffi entries
- [ ] CHANGELOG `[Unreleased]` section is empty
- [ ] CHANGELOG comparison links point `v0.3.0...HEAD` and `v0.2.0...v0.3.0`
- [ ] README shows "What was added in v0.3.0" (not "in progress")
- [ ] After tagging: MkDocs version badge resolves to `v0.3.0`