### PR TITLE
feat(mcp): add LadonMCPAdapter ABC (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.3.1] — 2026-05-20
+
+### Added
+
+- **`ladon.mcp.LadonMCPAdapter`** — abstract base class for adapter packages that
+  want to expose data-plane MCP tools via `ladon-nous`. Adapters implement
+  `adapter_name`, `mcp_tools()`, and optionally `mcp_resources()`, then declare
+  themselves via the `ladon.mcp` Python entry-point group. No `fastmcp` import in
+  core — only `ladon-nous` requires that dependency.
+
+---
+
 ## [0.3.0] — 2026-05-18
 
 ### Added
@@ -150,7 +162,8 @@ First public release.
   current counters are correct but the model will be simplified
 - Python 3.11, 3.12, and 3.13 supported; 3.10 and below are not
 
-[Unreleased]: https://github.com/MoonyFringers/ladon/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/MoonyFringers/ladon/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/MoonyFringers/ladon/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/MoonyFringers/ladon/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/MoonyFringers/ladon/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/MoonyFringers/ladon/compare/v0.0.1...v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ladon-crawl"
-version = "0.3.0"
+version = "0.3.1"
 description = "A structured, resumable web crawling framework for AI-ready datasets."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -3,6 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .async_runner import async_run_crawl
+from .mcp import LadonMCPAdapter
 from .networking import make_async_http_client, make_http_client
 from .networking.async_client import AsyncHttpClient
 from .networking.async_curl_client import AsyncCurlHttpClient
@@ -53,7 +54,7 @@ try:
     __version__ = version("ladon-crawl")
 except PackageNotFoundError:
     __version__ = (
-        "0.3.0"  # editable install without metadata — bump with every release
+        "0.3.1"  # editable install without metadata — bump with every release
     )
 
 
@@ -113,5 +114,7 @@ __all__ = [
     "StorageKeyNotFoundError",
     "StorageReadError",
     "StorageWriteError",
+    # MCP adapter protocol
+    "LadonMCPAdapter",
     "__version__",
 ]

--- a/src/ladon/mcp/__init__.py
+++ b/src/ladon/mcp/__init__.py
@@ -1,0 +1,9 @@
+"""ladon.mcp — MCP adapter protocol for Ladon adapters.
+
+Adapters that want to expose data-plane tools via ladon-nous implement
+``LadonMCPAdapter`` and declare themselves via the ``ladon.mcp`` entry point.
+"""
+
+from .adapter import LadonMCPAdapter
+
+__all__ = ["LadonMCPAdapter"]

--- a/src/ladon/mcp/adapter.py
+++ b/src/ladon/mcp/adapter.py
@@ -1,0 +1,52 @@
+"""LadonMCPAdapter — base class for MCP data-plane adapter plugins."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable
+
+
+class LadonMCPAdapter(ABC):
+    """Base class for Ladon adapter packages that expose MCP tools.
+
+    Implement this in each adapter package (ladon-mimir, ladon-hermes, …) and
+    declare the concrete class via the ``ladon.mcp`` Python entry-point group::
+
+        # pyproject.toml
+        [project.entry-points."ladon.mcp"]
+        mimir = "ladon_mimir.mcp:MimirMCPAdapter"
+
+    ``ladon-nous`` discovers all registered adapters at startup and registers
+    their tools and resources on the FastMCP server automatically.
+
+    ABC is used (rather than a Protocol) because adapters explicitly opt in to
+    the MCP system — they know they are implementing this contract. ABC gives a
+    clear error at class-definition time when ``mcp_tools`` is forgotten.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    @property
+    @abstractmethod
+    def adapter_name(self) -> str:
+        """Short identifier used in tool name prefixes: ``mimir``, ``hermes``."""
+        ...
+
+    @abstractmethod
+    def mcp_tools(self) -> list[Callable[..., object]]:
+        """Plain callables to register as MCP tools on the ladon-nous server.
+
+        Each callable must have a descriptive docstring (used as the tool
+        description) and type-annotated parameters (used to build the JSON
+        schema). All database access **must** use ``read_only=True``.
+        """
+        ...
+
+    def mcp_resources(self) -> list[tuple[str, Callable[..., object]]]:
+        """Resource (uri_template, handler) pairs to register on the server.
+
+        The URI template follows FastMCP syntax, e.g.
+        ``"ladon://mimir/articles/{page_id}"``. Override to expose resources.
+        """
+        return []


### PR DESCRIPTION
## Summary

- Adds `ladon.mcp.LadonMCPAdapter` — abstract base class for adapter packages that want to expose data-plane MCP tools via `ladon-nous`
- Adapters implement `adapter_name`, `mcp_tools()`, and optionally `mcp_resources()`
- Entry-point group: `ladon.mcp` — installing an adapter auto-registers it in `ladon-nous`
- No `fastmcp` import in core — only `ladon-nous` requires that dependency

Part of the ladon-nous v0.2.0 / MCP plugin protocol rollout (issue #103).

## Test plan

- [ ] `from ladon.mcp import LadonMCPAdapter` works
- [ ] All 449 existing tests still pass
- [ ] ABC raises `TypeError` on instantiation without `adapter_name` or `mcp_tools()`