### PR TITLE
feat(plugins): MultiSourceSink and FetchPredicate (ADR-013)

### DIFF
--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -33,7 +33,13 @@ from .plugins import (
     Expander,
     Expansion,
     ExpansionNotReadyError,
+)
+from .plugins import FetchPredicate as FetchPredicate
+from .plugins import (
     LeafUnavailableError,
+)
+from .plugins import MultiSourceSink as MultiSourceSink
+from .plugins import (
     PartialExpansionError,
     PluginError,
     Ref,
@@ -77,6 +83,9 @@ __all__ = [
     # Plugin models
     "Ref",
     "Expansion",
+    # Multi-source resolution
+    "FetchPredicate",
+    "MultiSourceSink",
     # Plugin errors
     "PluginError",
     "ExpansionNotReadyError",

--- a/src/ladon/plugins/__init__.py
+++ b/src/ladon/plugins/__init__.py
@@ -22,7 +22,12 @@ from .errors import (
 )
 from .models import Expansion, Ref
 from .protocol import CrawlPlugin, Expander, Sink, Source
-from .resolution import FetchPredicate, MinWidthPredicate, MultiSourceSink
+from .resolution import (
+    FetchPredicate,
+    MinWidthPredicate,
+    MultiSourceSink,
+    image_width,
+)
 
 __all__ = [
     # Sync protocols
@@ -42,6 +47,7 @@ __all__ = [
     "FetchPredicate",
     "MultiSourceSink",
     "MinWidthPredicate",
+    "image_width",
     # Errors
     "PluginError",
     "ExpansionNotReadyError",

--- a/src/ladon/plugins/__init__.py
+++ b/src/ladon/plugins/__init__.py
@@ -24,9 +24,7 @@ from .models import Expansion, Ref
 from .protocol import CrawlPlugin, Expander, Sink, Source
 from .resolution import (
     FetchPredicate,
-    MinWidthPredicate,
     MultiSourceSink,
-    image_width,
 )
 
 __all__ = [
@@ -46,8 +44,6 @@ __all__ = [
     # Resolution
     "FetchPredicate",
     "MultiSourceSink",
-    "MinWidthPredicate",
-    "image_width",
     # Errors
     "PluginError",
     "ExpansionNotReadyError",

--- a/src/ladon/plugins/__init__.py
+++ b/src/ladon/plugins/__init__.py
@@ -22,6 +22,7 @@ from .errors import (
 )
 from .models import Expansion, Ref
 from .protocol import CrawlPlugin, Expander, Sink, Source
+from .resolution import FetchPredicate, MinWidthPredicate, MultiSourceSink
 
 __all__ = [
     # Sync protocols
@@ -37,6 +38,10 @@ __all__ = [
     # Models
     "Ref",
     "Expansion",
+    # Resolution
+    "FetchPredicate",
+    "MultiSourceSink",
+    "MinWidthPredicate",
     # Errors
     "PluginError",
     "ExpansionNotReadyError",

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -13,13 +13,13 @@ The loop pattern
         if not _should_try_source(source, ref):   # tier-skip, guards
             continue
         data = _fetch_from_source(source, ref, client)
-        if data is None:
-            continue                               # source returned nothing
+        if not data:
+            continue                               # source returned nothing / empty bytes
         if _is_better_candidate(data, ...):        # update best-seen fallback
             best = (data, source)
-        if all predicates pass:
+        if not predicates or all predicates pass:
             return (data, source)                  # accepted — stop
-    return best                                    # best-seen fallback
+    return best                                    # best-seen fallback (may be None)
 
 ``FetchPredicate`` is the extension point: adapters inject domain-specific
 acceptance criteria (image width, placeholder detection, price tolerance …)
@@ -51,6 +51,12 @@ class FetchPredicate(Protocol):
     Returns ``True`` if *data* is good enough to stop the resolution loop.
     Returns ``False`` to keep *data* as a fallback candidate and continue to
     the next source in search of a better result.
+
+    .. note::
+        ``isinstance(obj, FetchPredicate)`` only checks that an ``accepts``
+        attribute *exists* — it does not verify callability or signature.
+        Passing a mis-shaped object will raise ``TypeError`` at call time
+        inside :meth:`MultiSourceSink.resolve_multi`, not at construction.
     """
 
     def accepts(self, data: bytes, ref: Ref) -> bool:
@@ -136,6 +142,13 @@ class MultiSourceSink:
 
         Default: first non-None result wins (``best_source is None``).
         Override for domain-specific fallback ranking.
+
+        .. warning::
+            If a subclass overrides this to always return ``False`` (e.g. due
+            to a bug in the ranking logic), ``best_data`` is never updated and
+            :meth:`resolve_multi` returns ``(None, None)`` even when sources
+            produce data.  The caller cannot distinguish this from "no sources
+            returned data" without inspecting logs.
         """
         return best_source is None
 
@@ -169,7 +182,7 @@ class MultiSourceSink:
                 continue
 
             data = self._fetch_from_source(source, ref, client)
-            if data is None:
+            if not data:
                 logger.debug(
                     "resolution: %r returned no data for %s",
                     getattr(source, "name", source),

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -25,13 +25,6 @@ The loop pattern
 acceptance criteria (image width, placeholder detection, price tolerance …)
 without modifying the loop mechanics.
 
-Built-in predicates
--------------------
-
-``MinWidthPredicate``
-    Accepts a JPEG or PNG only if its pixel width meets a minimum.
-    Uses header-only parsing — no external library required.
-
 ADR: ADR-013
 """
 
@@ -214,59 +207,3 @@ class MultiSourceSink:
             )
 
         return best_data, best_source
-
-
-# ---------------------------------------------------------------------------
-# Built-in predicates
-# ---------------------------------------------------------------------------
-
-
-class MinWidthPredicate:
-    """Accept a JPEG or PNG image only if its pixel width meets a minimum.
-
-    Uses header-only parsing (JPEG SOF / PNG IHDR) — no external library
-    required. Returns ``True`` (acceptable) when the measured width is >=
-    *min_px*. A *min_px* of 0 always returns ``True`` (disables the check).
-    """
-
-    def __init__(self, min_px: int) -> None:
-        self._min_px = min_px
-
-    def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
-        if not self._min_px:
-            return True
-        return image_width(data) >= self._min_px
-
-
-# ---------------------------------------------------------------------------
-# Image header parsing
-# ---------------------------------------------------------------------------
-
-
-def image_width(data: bytes) -> int:
-    """Return the pixel width of a JPEG or PNG from its header bytes.
-
-    Reads only the first few hundred bytes — no external library required.
-    Returns 0 if the format is unrecognised or the header is truncated.
-
-    Supports:
-    - PNG: reads width from the IHDR chunk (bytes 16–19).
-    - JPEG: scans forward for a SOF0 / SOF1 / SOF2 marker, skipping
-      variable-length APP segments (including multi-segment EXIF headers).
-    """
-    if len(data) >= 24 and data[:8] == b"\x89PNG\r\n\x1a\n":
-        # PNG: IHDR chunk starts at byte 8; width is at bytes 16–19.
-        return int.from_bytes(data[16:20], "big")
-    if len(data) >= 4 and data[:2] == b"\xff\xd8":
-        # JPEG: scan forward for a SOF0 / SOF1 / SOF2 marker.
-        i = 2
-        while i + 8 < len(data):
-            if data[i] != 0xFF:
-                break
-            marker = data[i + 1]
-            seg_len = int.from_bytes(data[i + 2 : i + 4], "big")
-            if marker in (0xC0, 0xC1, 0xC2):  # SOF0 / SOF1 / SOF2
-                # Segment layout: FF Cx LL LL PP HH HH WW WW …
-                return int.from_bytes(data[i + 7 : i + 9], "big")
-            i += 2 + seg_len
-    return 0

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -1,0 +1,258 @@
+"""Multi-source resolution utilities for Ladon Sink implementations.
+
+Provides the ``FetchPredicate`` protocol and ``MultiSourceSink`` base class,
+which together encode the *try-until-accepted* resolution loop used by any
+Sink that resolves a record field from multiple ranked sources.
+
+The loop pattern
+----------------
+
+::
+
+    for source in sources (ordered best-first):
+        if not _should_try_source(source, ref):   # tier-skip, guards
+            continue
+        data = _fetch_from_source(source, ref, client)
+        if data is None:
+            continue                               # source returned nothing
+        if _is_better_candidate(data, ...):        # update best-seen fallback
+            best = (data, source)
+        if all predicates pass:
+            return (data, source)                  # accepted — stop
+    return best                                    # best-seen fallback
+
+``FetchPredicate`` is the extension point: adapters inject domain-specific
+acceptance criteria (image width, placeholder detection, price tolerance …)
+without modifying the loop mechanics.
+
+Built-in predicates
+-------------------
+
+``MinWidthPredicate``
+    Accepts a JPEG or PNG only if its pixel width meets a minimum.
+    Uses header-only parsing — no external library required.
+
+ADR: ADR-013
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol, Sequence
+
+from ..networking.client import HttpClient
+from .models import Ref
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class FetchPredicate(Protocol):
+    """Acceptance criterion on a raw fetch result.
+
+    Returns ``True`` if *data* is good enough to stop the resolution loop.
+    Returns ``False`` to keep *data* as a fallback candidate and continue to
+    the next source in search of a better result.
+    """
+
+    def accepts(self, data: bytes, ref: Ref) -> bool:
+        """Return True if this result is acceptable."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+
+class MultiSourceSink:
+    """Base for Sink implementations that resolve from multiple ranked sources.
+
+    Subclasses must override :meth:`_fetch_from_source` to adapt their
+    specific source interface. Three optional hooks control loop behaviour:
+
+    ``_should_try_source(source, ref) → bool``
+        Pre-fetch guard. Default: always try. Override to skip sources whose
+        tier cannot improve on the existing record, or to enforce rate limits.
+
+    ``_is_better_candidate(data, source, best_data, best_source, ref) → bool``
+        Fallback selection. Default: first non-None result wins. Override for
+        domain-specific ranking (e.g., prefer wider images when multiple
+        below-threshold results exist).
+
+    ``_fetch_from_source(source, ref, client) → bytes | None``
+        Calls the source's native interface. Must be overridden; there is no
+        default implementation because source interfaces vary per adapter.
+
+    The main entry point is :meth:`_resolve_multi`, which runs the loop and
+    returns ``(data, source)`` for the best accepted result, or the best
+    fallback if no result passed all predicates.
+    """
+
+    def __init__(
+        self,
+        sources: list[Any],
+        predicates: Sequence[FetchPredicate] = (),
+    ) -> None:
+        self._ms_sources: list[Any] = list(sources)
+        self._ms_predicates: list[FetchPredicate] = list(predicates)
+
+    # ------------------------------------------------------------------
+    # Hooks — override in subclasses
+    # ------------------------------------------------------------------
+
+    def _fetch_from_source(
+        self, _source: Any, _ref: Ref, _client: HttpClient
+    ) -> bytes | None:
+        """Fetch raw bytes from *_source* for *_ref*. Must be overridden."""
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement _fetch_from_source"
+        )
+
+    def _should_try_source(self, _source: Any, _ref: Ref) -> bool:
+        """Return True if *_source* should be attempted for *_ref*.
+
+        Default: always try. Override to implement tier-skip, cooldown
+        guards, or any other pre-fetch filtering.
+        """
+        return True
+
+    def _is_better_candidate(
+        self,
+        _data: bytes,
+        _source: Any,
+        _best_data: bytes | None,
+        best_source: Any | None,
+        _ref: Ref,
+    ) -> bool:
+        """Return True if *(_data, _source)* should replace the current best.
+
+        Default: first non-None result wins (``best_source is None``).
+        Override for domain-specific fallback ranking.
+        """
+        return best_source is None
+
+    # ------------------------------------------------------------------
+    # Loop
+    # ------------------------------------------------------------------
+
+    def _all_predicates_pass(self, data: bytes, ref: Ref) -> bool:
+        """Return True if *data* satisfies every registered predicate."""
+        return all(p.accepts(data, ref) for p in self._ms_predicates)
+
+    def resolve_multi(
+        self, ref: Ref, client: HttpClient
+    ) -> tuple[bytes | None, Any | None]:
+        """Try sources in priority order; return the best accepted result.
+
+        Returns ``(data, source)`` for the first result that passes all
+        predicates, or the best fallback seen if no result was accepted.
+        Returns ``(None, None)`` if no source produced any result.
+        """
+        best_data: bytes | None = None
+        best_source: Any | None = None
+
+        for source in self._ms_sources:
+            if not self._should_try_source(source, ref):
+                logger.debug(
+                    "resolution: skipping source %r for %s",
+                    getattr(source, "name", source),
+                    ref.url,
+                )
+                continue
+
+            data = self._fetch_from_source(source, ref, client)
+            if data is None:
+                logger.debug(
+                    "resolution: %r returned no data for %s",
+                    getattr(source, "name", source),
+                    ref.url,
+                )
+                continue
+
+            if self._is_better_candidate(
+                data, source, best_data, best_source, ref
+            ):
+                best_data = data
+                best_source = source
+                logger.debug(
+                    "resolution: %r is new best candidate for %s",
+                    getattr(source, "name", source),
+                    ref.url,
+                )
+
+            if not self._ms_predicates or self._all_predicates_pass(data, ref):
+                logger.debug(
+                    "resolution: accepted result from %r for %s",
+                    getattr(source, "name", source),
+                    ref.url,
+                )
+                return data, source
+
+            logger.debug(
+                "resolution: %r did not pass all predicates for %s; trying next",
+                getattr(source, "name", source),
+                ref.url,
+            )
+
+        return best_data, best_source
+
+
+# ---------------------------------------------------------------------------
+# Built-in predicates
+# ---------------------------------------------------------------------------
+
+
+class MinWidthPredicate:
+    """Accept a JPEG or PNG image only if its pixel width meets a minimum.
+
+    Uses header-only parsing (JPEG SOF / PNG IHDR) — no external library
+    required. Returns ``True`` (acceptable) when the measured width is >=
+    *min_px*. A *min_px* of 0 always returns ``True`` (disables the check).
+    """
+
+    def __init__(self, min_px: int) -> None:
+        self._min_px = min_px
+
+    def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+        if not self._min_px:
+            return True
+        return image_width(data) >= self._min_px
+
+
+# ---------------------------------------------------------------------------
+# Image header parsing
+# ---------------------------------------------------------------------------
+
+
+def image_width(data: bytes) -> int:
+    """Return the pixel width of a JPEG or PNG from its header bytes.
+
+    Reads only the first few hundred bytes — no external library required.
+    Returns 0 if the format is unrecognised or the header is truncated.
+
+    Supports:
+    - PNG: reads width from the IHDR chunk (bytes 16–19).
+    - JPEG: scans forward for a SOF0 / SOF1 / SOF2 marker, skipping
+      variable-length APP segments (including multi-segment EXIF headers).
+    """
+    if len(data) >= 24 and data[:8] == b"\x89PNG\r\n\x1a\n":
+        # PNG: IHDR chunk starts at byte 8; width is at bytes 16–19.
+        return int.from_bytes(data[16:20], "big")
+    if len(data) >= 4 and data[:2] == b"\xff\xd8":
+        # JPEG: scan forward for a SOF0 / SOF1 / SOF2 marker.
+        i = 2
+        while i + 8 < len(data):
+            if data[i] != 0xFF:
+                break
+            marker = data[i + 1]
+            seg_len = int.from_bytes(data[i + 2 : i + 4], "big")
+            if marker in (0xC0, 0xC1, 0xC2):  # SOF0 / SOF1 / SOF2
+                # Segment layout: FF Cx LL LL PP HH HH WW WW …
+                return int.from_bytes(data[i + 7 : i + 9], "big")
+            i += 2 + seg_len
+    return 0

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -38,7 +38,7 @@ ADR: ADR-013
 from __future__ import annotations
 
 import logging
-from typing import Any, Protocol, Sequence
+from typing import Any, Protocol, Sequence, runtime_checkable
 
 from ..networking.client import HttpClient
 from .models import Ref
@@ -51,6 +51,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+@runtime_checkable
 class FetchPredicate(Protocol):
     """Acceptance criterion on a raw fetch result.
 
@@ -88,7 +89,7 @@ class MultiSourceSink:
         Calls the source's native interface. Must be overridden; there is no
         default implementation because source interfaces vary per adapter.
 
-    The main entry point is :meth:`_resolve_multi`, which runs the loop and
+    The main entry point is :meth:`resolve_multi`, which runs the loop and
     returns ``(data, source)`` for the best accepted result, or the best
     fallback if no result passed all predicates.
     """

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -103,6 +103,15 @@ class MultiSourceSink:
         self._ms_predicates: list[FetchPredicate] = list(predicates)
 
     # ------------------------------------------------------------------
+    # Public accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def sources(self) -> list[Any]:
+        """Priority-ordered source list (read-only copy)."""
+        return list(self._ms_sources)
+
+    # ------------------------------------------------------------------
     # Hooks — override in subclasses
     # ------------------------------------------------------------------
 
@@ -175,6 +184,10 @@ class MultiSourceSink:
                 )
                 continue
 
+            # Update the best-seen fallback before checking predicates.
+            # If predicates pass we return data/source directly (not best_data),
+            # so the update is a no-op in that path. If predicates fail, the
+            # updated best_data becomes the last-resort fallback after the loop.
             if self._is_better_candidate(
                 data, source, best_data, best_source, ref
             ):

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -121,6 +121,24 @@ class TestMultiSourceSinkLoop:
         assert data == b"DATA_B"
         assert src is s2
 
+    def test_skips_empty_bytes_and_tries_next(self) -> None:
+        """b'' is treated identically to None — not a valid result."""
+        s1 = _SimpleSource("a", b"")
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data == b"DATA_B"
+        assert src is s2
+
+    def test_all_empty_bytes_returns_none_none(self) -> None:
+        """All sources returning b'' is equivalent to all returning None."""
+        s1 = _SimpleSource("a", b"")
+        s2 = _SimpleSource("b", b"")
+        sink = _SimpleSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data is None
+        assert src is None
+
     def test_should_try_source_false_skips_source(self) -> None:
         class _SkippingSink(_SimpleSink):
             def _should_try_source(
@@ -182,32 +200,35 @@ class TestMultiSourceSinkPredicates:
         assert s2.calls == 0
 
     def test_multiple_predicates_all_must_pass(self) -> None:
-        """Loop continues to next source until ALL predicates pass.
+        """Loop continues until BOTH predicates pass — partial pass is not enough.
 
-        Source A passes _MinLengthPredicate but fails _PassOnlyB.
-        Source B passes both — it must be the accepted result, proving that
-        a partial predicate pass is not enough to stop the loop.
+        Source A: 8 bytes — passes _MinLengthPredicate(5) but fails _PassOnlyB.
+        Source B: 8 bytes — passes both predicates.
+
+        If the loop stopped on the first predicate passing, source A would be
+        accepted (MinLength passes).  The correct behaviour is to continue to
+        source B where ALL predicates pass.
         """
 
         class _PassOnlyB:
             def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
                 return data == b"source_b"
 
-        s1 = _SimpleSource("a", b"source_a")
-        s2 = _SimpleSource("b", b"source_b")
+        s1 = _SimpleSource(
+            "a", b"source_a"
+        )  # 8 bytes — passes MinLength, fails PassOnlyB
+        s2 = _SimpleSource("b", b"source_b")  # 8 bytes — passes both
         sink = _SimpleSink(
             sources=[s1, s2],
-            predicates=[_PassOnlyB()],
+            predicates=[_MinLengthPredicate(5), _PassOnlyB()],
         )
         data, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s2
         assert data == b"source_b"
         assert (
             s1.calls == 1
-        )  # source A was tried (predicate failed — loop continued)
-        assert (
-            s2.calls == 1
-        )  # source B accepted (predicate passed — loop stopped)
+        )  # tried — MinLength passed, PassOnlyB failed → continued
+        assert s2.calls == 1  # tried — both predicates passed → accepted
 
     def test_no_predicates_stops_at_first_result(self) -> None:
         s1 = _SimpleSource("a", b"DATA_A")

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -342,6 +342,19 @@ class TestMultiSourceSinkContract:
         sink.resolve_multi(_ref(), MagicMock())
         assert s_late.calls == 0  # never tried — mutation happened after copy
 
+    def test_sources_property_returns_copy(self) -> None:
+        """sources property reflects the configured list; mutations don't affect the sink."""
+        s1 = _SimpleSource("a", b"DATA_A")
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])
+
+        exposed = sink.sources
+        assert exposed == [s1, s2]
+
+        # Mutating the returned list must not affect the sink's internal list.
+        exposed.clear()
+        assert sink.sources == [s1, s2]
+
 
 # ---------------------------------------------------------------------------
 # FetchPredicate — structural subtyping and runtime check

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -1,0 +1,311 @@
+"""Tests for ladon.plugins.resolution — MultiSourceSink and FetchPredicate."""
+
+from __future__ import annotations
+
+import struct
+from unittest.mock import MagicMock
+
+from ladon.plugins.models import Ref
+from ladon.plugins.resolution import (
+    FetchPredicate,
+    MinWidthPredicate,
+    MultiSourceSink,
+    image_width,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal synthetic image bytes (no external library required)
+# ---------------------------------------------------------------------------
+
+
+def _make_png(width: int, height: int) -> bytes:
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr_data = struct.pack(">II", width, height) + b"\x08\x02\x00\x00\x00"
+    ihdr_len = struct.pack(">I", len(ihdr_data))
+    return sig + ihdr_len + b"IHDR" + ihdr_data
+
+
+def _make_jpeg(width: int, height: int) -> bytes:
+    soi = b"\xff\xd8"
+    app0 = (
+        b"\xff\xe0"
+        + b"\x00\x10"
+        + b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    )
+    sof0 = (
+        b"\xff\xc0"
+        + struct.pack(">H", 17)
+        + b"\x08"
+        + struct.pack(">HH", height, width)
+        + b"\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
+    )
+    return soi + app0 + sof0
+
+
+def _make_jpeg_with_exif(width: int, height: int) -> bytes:
+    soi = b"\xff\xd8"
+    app0 = (
+        b"\xff\xe0"
+        + b"\x00\x10"
+        + b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    )
+    exif_payload = b"Exif\x00\x00" + b"\x00" * 14
+    app1 = b"\xff\xe1" + struct.pack(">H", 2 + len(exif_payload)) + exif_payload
+    sof0 = (
+        b"\xff\xc0"
+        + struct.pack(">H", 17)
+        + b"\x08"
+        + struct.pack(">HH", height, width)
+        + b"\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
+    )
+    return soi + app0 + app1 + sof0
+
+
+def _ref(url: str = "https://example.com/1") -> Ref:
+    return Ref(url=url)
+
+
+# ---------------------------------------------------------------------------
+# image_width
+# ---------------------------------------------------------------------------
+
+
+class TestImageWidth:
+    def test_jpeg_width_parsed(self) -> None:
+        assert image_width(_make_jpeg(380, 500)) == 380
+
+    def test_png_width_parsed(self) -> None:
+        assert image_width(_make_png(1200, 1600)) == 1200
+
+    def test_unknown_format_returns_zero(self) -> None:
+        assert image_width(b"NOTANIMAGE") == 0
+
+    def test_truncated_data_returns_zero(self) -> None:
+        assert image_width(b"\xff\xd8\xff") == 0
+
+    def test_png_too_short_returns_zero(self) -> None:
+        assert image_width(b"\x89PNG\r\n\x1a\n\x00\x00") == 0
+
+    def test_jpeg_with_multiple_app_segments(self) -> None:
+        assert image_width(_make_jpeg_with_exif(1024, 768)) == 1024
+
+
+# ---------------------------------------------------------------------------
+# MinWidthPredicate
+# ---------------------------------------------------------------------------
+
+
+class TestMinWidthPredicate:
+    def test_accepts_image_at_threshold(self) -> None:
+        p = MinWidthPredicate(300)
+        assert p.accepts(_make_jpeg(300, 400), _ref()) is True
+
+    def test_accepts_image_above_threshold(self) -> None:
+        p = MinWidthPredicate(300)
+        assert p.accepts(_make_jpeg(600, 800), _ref()) is True
+
+    def test_rejects_image_below_threshold(self) -> None:
+        p = MinWidthPredicate(300)
+        assert p.accepts(_make_jpeg(250, 350), _ref()) is False
+
+    def test_zero_min_always_accepts(self) -> None:
+        p = MinWidthPredicate(0)
+        assert p.accepts(b"anything", _ref()) is True
+
+    def test_ref_is_not_required_for_decision(self) -> None:
+        """The predicate ignores the ref — only data matters."""
+        p = MinWidthPredicate(100)
+        assert (
+            p.accepts(_make_jpeg(200, 300), _ref("https://irrelevant.com"))
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Concrete MultiSourceSink for testing
+# ---------------------------------------------------------------------------
+
+
+class _SimpleSource:
+    """Minimal source stub: returns fixed bytes or None."""
+
+    def __init__(self, name: str, data: bytes | None) -> None:
+        self.name = name
+        self._data = data
+        self.calls: int = 0
+
+    def fetch(self) -> bytes | None:
+        self.calls += 1
+        return self._data
+
+
+class _SimpleSink(MultiSourceSink):
+    """Concrete MultiSourceSink for tests — sources have a plain .fetch() interface."""
+
+    def _fetch_from_source(
+        self, source: _SimpleSource, ref: Ref, client: object  # noqa: ARG002
+    ) -> bytes | None:
+        return source.fetch()
+
+
+class _WidthRankingSink(MultiSourceSink):
+    """Sink that prefers wider images as fallback."""
+
+    def __init__(self, sources: list[_SimpleSource], min_px: int) -> None:
+        super().__init__(sources, [MinWidthPredicate(min_px)])
+        self._min_px = min_px
+
+    def _fetch_from_source(
+        self, source: _SimpleSource, ref: Ref, client: object  # noqa: ARG002
+    ) -> bytes | None:
+        return source.fetch()
+
+    def _is_better_candidate(
+        self,
+        data: bytes,
+        source: _SimpleSource,
+        best_data: bytes | None,
+        best_source: _SimpleSource | None,
+        ref: Ref,  # noqa: ARG002
+    ) -> bool:
+        if best_source is None:
+            return True
+        return image_width(data) > image_width(best_data or b"")
+
+
+# ---------------------------------------------------------------------------
+# MultiSourceSink — loop mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSourceSinkLoop:
+    def test_returns_none_none_when_no_sources(self) -> None:
+        sink = _SimpleSink(sources=[], predicates=[])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data is None
+        assert src is None
+
+    def test_returns_none_none_when_all_sources_fail(self) -> None:
+        sources = [_SimpleSource("a", None), _SimpleSource("b", None)]
+        sink = _SimpleSink(sources=sources)
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data is None
+        assert src is None
+
+    def test_returns_first_result_when_no_predicates(self) -> None:
+        s1 = _SimpleSource("a", b"DATA_A")
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data == b"DATA_A"
+        assert src is s1
+        assert s2.calls == 0  # stopped at first
+
+    def test_skips_none_results_and_tries_next(self) -> None:
+        s1 = _SimpleSource("a", None)
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data == b"DATA_B"
+        assert src is s2
+
+    def test_should_try_source_false_skips_source(self) -> None:
+        class _SkippingSink(_SimpleSink):
+            def _should_try_source(
+                self, source: _SimpleSource, ref: Ref  # noqa: ARG002
+            ) -> bool:
+                return source.name != "skip_me"
+
+        s1 = _SimpleSource("skip_me", b"SKIPPED")
+        s2 = _SimpleSource("keep_me", b"KEPT")
+        sink = _SkippingSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data == b"KEPT"
+        assert src is s2
+        assert s1.calls == 0
+
+    def test_fetch_not_called_on_skipped_source(self) -> None:
+        class _AllSkip(_SimpleSink):
+            def _should_try_source(
+                self, source: _SimpleSource, ref: Ref  # noqa: ARG002
+            ) -> bool:
+                return False
+
+        s = _SimpleSource("a", b"DATA")
+        sink = _AllSkip(sources=[s])
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is None
+        assert s.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# MultiSourceSink — predicate integration
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSourceSinkPredicates:
+    def test_stops_when_predicate_passes(self) -> None:
+        s1 = _SimpleSource("narrow", _make_jpeg(250, 350))
+        s2 = _SimpleSource("wide", _make_jpeg(600, 800))
+        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s2
+        assert image_width(data or b"") == 600
+
+    def test_falls_back_to_best_when_no_source_passes(self) -> None:
+        """Both sources below threshold — best (widest) fallback returned."""
+        s1 = _SimpleSource("a", _make_jpeg(200, 300))
+        s2 = _SimpleSource("b", _make_jpeg(280, 400))
+        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s2
+        assert image_width(data or b"") == 280
+
+    def test_accepts_first_source_when_it_clears_threshold(self) -> None:
+        s1 = _SimpleSource("a", _make_jpeg(400, 600))
+        s2 = _SimpleSource("b", _make_jpeg(600, 800))
+        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s1  # stopped at first accepted
+        assert s2.calls == 0
+
+    def test_multiple_predicates_all_must_pass(self) -> None:
+        class _AlwaysFail:
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                return False
+
+        s = _SimpleSource("a", _make_jpeg(600, 800))
+        sink = _SimpleSink(
+            sources=[s],
+            predicates=[MinWidthPredicate(300), _AlwaysFail()],
+        )
+        # MinWidthPredicate passes but _AlwaysFail blocks — result kept as fallback
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s
+
+    def test_no_predicates_stops_at_first_result(self) -> None:
+        s1 = _SimpleSource("a", _make_jpeg(100, 150))
+        s2 = _SimpleSource("b", _make_jpeg(600, 800))
+        sink = _SimpleSink(sources=[s1, s2], predicates=[])
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s1
+        assert s2.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# FetchPredicate — structural subtyping check
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPredicateProtocol:
+    def test_min_width_predicate_satisfies_protocol(self) -> None:
+        p: FetchPredicate = MinWidthPredicate(300)
+        assert p.accepts(_make_jpeg(400, 500), _ref()) is True
+
+    def test_custom_predicate_satisfies_protocol(self) -> None:
+        class _Always:
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                return True
+
+        p: FetchPredicate = _Always()
+        assert p.accepts(b"anything", _ref()) is True

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -1,9 +1,13 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+# pyright: reportUnknownArgumentType=false, reportArgumentType=false
 """Tests for ladon.plugins.resolution — MultiSourceSink and FetchPredicate."""
 
 from __future__ import annotations
 
 import struct
 from unittest.mock import MagicMock
+
+import pytest
 
 from ladon.plugins.models import Ref
 from ladon.plugins.resolution import (
@@ -270,18 +274,32 @@ class TestMultiSourceSinkPredicates:
         assert s2.calls == 0
 
     def test_multiple_predicates_all_must_pass(self) -> None:
-        class _AlwaysFail:
-            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
-                return False
+        """Loop continues to next source until ALL predicates pass.
 
-        s = _SimpleSource("a", _make_jpeg(600, 800))
+        Source A passes MinWidthPredicate but fails _PassOnlyB.
+        Source B passes both — it must be the accepted result, proving that
+        a partial predicate pass is not enough to stop the loop.
+        """
+
+        class _PassOnlyB:
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                return data == b"source_b"
+
+        s1 = _SimpleSource("a", b"source_a")
+        s2 = _SimpleSource("b", b"source_b")
         sink = _SimpleSink(
-            sources=[s],
-            predicates=[MinWidthPredicate(300), _AlwaysFail()],
+            sources=[s1, s2],
+            predicates=[_PassOnlyB()],
         )
-        # MinWidthPredicate passes but _AlwaysFail blocks — result kept as fallback
-        _, src = sink.resolve_multi(_ref(), MagicMock())
-        assert src is s
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s2
+        assert data == b"source_b"
+        assert (
+            s1.calls == 1
+        )  # source A was tried (predicate failed — loop continued)
+        assert (
+            s2.calls == 1
+        )  # source B accepted (predicate passed — loop stopped)
 
     def test_no_predicates_stops_at_first_result(self) -> None:
         s1 = _SimpleSource("a", _make_jpeg(100, 150))
@@ -293,7 +311,40 @@ class TestMultiSourceSinkPredicates:
 
 
 # ---------------------------------------------------------------------------
-# FetchPredicate — structural subtyping check
+# MultiSourceSink — abstract method contract
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSourceSinkContract:
+    def test_fetch_from_source_raises_not_implemented(self) -> None:
+        """Bare MultiSourceSink raises NotImplementedError — subclasses must override."""
+        sink = MultiSourceSink(sources=[_SimpleSource("a", b"DATA")])
+        with pytest.raises(
+            NotImplementedError, match="must implement _fetch_from_source"
+        ):
+            sink.resolve_multi(_ref(), MagicMock())
+
+    def test_default_no_predicates_stops_at_first_result(self) -> None:
+        """When no predicates are configured the loop stops at the first result."""
+        s1 = _SimpleSource("a", b"DATA_A")
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])  # no predicates= arg
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s1
+        assert s2.calls == 0
+
+    def test_sources_copied_not_aliased(self) -> None:
+        """Mutating the source list after construction must not affect the sink."""
+        s_late = _SimpleSource("late", b"X")
+        src_list: list[_SimpleSource] = []
+        sink = _SimpleSink(sources=src_list)
+        src_list.append(s_late)
+        sink.resolve_multi(_ref(), MagicMock())
+        assert s_late.calls == 0  # never tried — mutation happened after copy
+
+
+# ---------------------------------------------------------------------------
+# FetchPredicate — structural subtyping and runtime check
 # ---------------------------------------------------------------------------
 
 
@@ -309,3 +360,12 @@ class TestFetchPredicateProtocol:
 
         p: FetchPredicate = _Always()
         assert p.accepts(b"anything", _ref()) is True
+
+    def test_runtime_checkable_isinstance(self) -> None:
+        """FetchPredicate is @runtime_checkable — isinstance works on instances."""
+        p = MinWidthPredicate(300)
+        assert isinstance(p, FetchPredicate)
+
+    def test_runtime_checkable_rejects_non_protocol(self) -> None:
+        assert not isinstance("not a predicate", FetchPredicate)
+        assert not isinstance(42, FetchPredicate)

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import struct
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,57 +11,8 @@ import pytest
 from ladon.plugins.models import Ref
 from ladon.plugins.resolution import (
     FetchPredicate,
-    MinWidthPredicate,
     MultiSourceSink,
-    image_width,
 )
-
-# ---------------------------------------------------------------------------
-# Minimal synthetic image bytes (no external library required)
-# ---------------------------------------------------------------------------
-
-
-def _make_png(width: int, height: int) -> bytes:
-    sig = b"\x89PNG\r\n\x1a\n"
-    ihdr_data = struct.pack(">II", width, height) + b"\x08\x02\x00\x00\x00"
-    ihdr_len = struct.pack(">I", len(ihdr_data))
-    return sig + ihdr_len + b"IHDR" + ihdr_data
-
-
-def _make_jpeg(width: int, height: int) -> bytes:
-    soi = b"\xff\xd8"
-    app0 = (
-        b"\xff\xe0"
-        + b"\x00\x10"
-        + b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
-    )
-    sof0 = (
-        b"\xff\xc0"
-        + struct.pack(">H", 17)
-        + b"\x08"
-        + struct.pack(">HH", height, width)
-        + b"\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
-    )
-    return soi + app0 + sof0
-
-
-def _make_jpeg_with_exif(width: int, height: int) -> bytes:
-    soi = b"\xff\xd8"
-    app0 = (
-        b"\xff\xe0"
-        + b"\x00\x10"
-        + b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
-    )
-    exif_payload = b"Exif\x00\x00" + b"\x00" * 14
-    app1 = b"\xff\xe1" + struct.pack(">H", 2 + len(exif_payload)) + exif_payload
-    sof0 = (
-        b"\xff\xc0"
-        + struct.pack(">H", 17)
-        + b"\x08"
-        + struct.pack(">HH", height, width)
-        + b"\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
-    )
-    return soi + app0 + app1 + sof0
 
 
 def _ref(url: str = "https://example.com/1") -> Ref:
@@ -70,59 +20,18 @@ def _ref(url: str = "https://example.com/1") -> Ref:
 
 
 # ---------------------------------------------------------------------------
-# image_width
+# Domain-agnostic predicate for tests (avoids image-specific imports)
 # ---------------------------------------------------------------------------
 
 
-class TestImageWidth:
-    def test_jpeg_width_parsed(self) -> None:
-        assert image_width(_make_jpeg(380, 500)) == 380
+class _MinLengthPredicate:
+    """Accept data only if its byte length meets a minimum."""
 
-    def test_png_width_parsed(self) -> None:
-        assert image_width(_make_png(1200, 1600)) == 1200
+    def __init__(self, min_len: int) -> None:
+        self._min_len = min_len
 
-    def test_unknown_format_returns_zero(self) -> None:
-        assert image_width(b"NOTANIMAGE") == 0
-
-    def test_truncated_data_returns_zero(self) -> None:
-        assert image_width(b"\xff\xd8\xff") == 0
-
-    def test_png_too_short_returns_zero(self) -> None:
-        assert image_width(b"\x89PNG\r\n\x1a\n\x00\x00") == 0
-
-    def test_jpeg_with_multiple_app_segments(self) -> None:
-        assert image_width(_make_jpeg_with_exif(1024, 768)) == 1024
-
-
-# ---------------------------------------------------------------------------
-# MinWidthPredicate
-# ---------------------------------------------------------------------------
-
-
-class TestMinWidthPredicate:
-    def test_accepts_image_at_threshold(self) -> None:
-        p = MinWidthPredicate(300)
-        assert p.accepts(_make_jpeg(300, 400), _ref()) is True
-
-    def test_accepts_image_above_threshold(self) -> None:
-        p = MinWidthPredicate(300)
-        assert p.accepts(_make_jpeg(600, 800), _ref()) is True
-
-    def test_rejects_image_below_threshold(self) -> None:
-        p = MinWidthPredicate(300)
-        assert p.accepts(_make_jpeg(250, 350), _ref()) is False
-
-    def test_zero_min_always_accepts(self) -> None:
-        p = MinWidthPredicate(0)
-        assert p.accepts(b"anything", _ref()) is True
-
-    def test_ref_is_not_required_for_decision(self) -> None:
-        """The predicate ignores the ref — only data matters."""
-        p = MinWidthPredicate(100)
-        assert (
-            p.accepts(_make_jpeg(200, 300), _ref("https://irrelevant.com"))
-            is True
-        )
+    def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+        return len(data) >= self._min_len
 
 
 # ---------------------------------------------------------------------------
@@ -152,12 +61,11 @@ class _SimpleSink(MultiSourceSink):
         return source.fetch()
 
 
-class _WidthRankingSink(MultiSourceSink):
-    """Sink that prefers wider images as fallback."""
+class _LengthRankingSink(MultiSourceSink):
+    """Sink that prefers longer payloads as fallback (domain-agnostic)."""
 
-    def __init__(self, sources: list[_SimpleSource], min_px: int) -> None:
-        super().__init__(sources, [MinWidthPredicate(min_px)])
-        self._min_px = min_px
+    def __init__(self, sources: list[_SimpleSource], min_len: int) -> None:
+        super().__init__(sources, [_MinLengthPredicate(min_len)])
 
     def _fetch_from_source(
         self, source: _SimpleSource, ref: Ref, client: object  # noqa: ARG002
@@ -174,7 +82,7 @@ class _WidthRankingSink(MultiSourceSink):
     ) -> bool:
         if best_source is None:
             return True
-        return image_width(data) > image_width(best_data or b"")
+        return len(data) > len(best_data or b"")
 
 
 # ---------------------------------------------------------------------------
@@ -249,26 +157,26 @@ class TestMultiSourceSinkLoop:
 
 class TestMultiSourceSinkPredicates:
     def test_stops_when_predicate_passes(self) -> None:
-        s1 = _SimpleSource("narrow", _make_jpeg(250, 350))
-        s2 = _SimpleSource("wide", _make_jpeg(600, 800))
-        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        s1 = _SimpleSource("short", b"x" * 5)
+        s2 = _SimpleSource("long", b"x" * 20)
+        sink = _LengthRankingSink(sources=[s1, s2], min_len=10)
         data, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s2
-        assert image_width(data or b"") == 600
+        assert len(data or b"") == 20
 
     def test_falls_back_to_best_when_no_source_passes(self) -> None:
-        """Both sources below threshold — best (widest) fallback returned."""
-        s1 = _SimpleSource("a", _make_jpeg(200, 300))
-        s2 = _SimpleSource("b", _make_jpeg(280, 400))
-        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        """Both sources below threshold — best (longest) fallback returned."""
+        s1 = _SimpleSource("a", b"x" * 4)
+        s2 = _SimpleSource("b", b"x" * 7)
+        sink = _LengthRankingSink(sources=[s1, s2], min_len=10)
         data, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s2
-        assert image_width(data or b"") == 280
+        assert len(data or b"") == 7
 
     def test_accepts_first_source_when_it_clears_threshold(self) -> None:
-        s1 = _SimpleSource("a", _make_jpeg(400, 600))
-        s2 = _SimpleSource("b", _make_jpeg(600, 800))
-        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        s1 = _SimpleSource("a", b"x" * 15)
+        s2 = _SimpleSource("b", b"x" * 20)
+        sink = _LengthRankingSink(sources=[s1, s2], min_len=10)
         _, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s1  # stopped at first accepted
         assert s2.calls == 0
@@ -276,7 +184,7 @@ class TestMultiSourceSinkPredicates:
     def test_multiple_predicates_all_must_pass(self) -> None:
         """Loop continues to next source until ALL predicates pass.
 
-        Source A passes MinWidthPredicate but fails _PassOnlyB.
+        Source A passes _MinLengthPredicate but fails _PassOnlyB.
         Source B passes both — it must be the accepted result, proving that
         a partial predicate pass is not enough to stop the loop.
         """
@@ -302,8 +210,8 @@ class TestMultiSourceSinkPredicates:
         )  # source B accepted (predicate passed — loop stopped)
 
     def test_no_predicates_stops_at_first_result(self) -> None:
-        s1 = _SimpleSource("a", _make_jpeg(100, 150))
-        s2 = _SimpleSource("b", _make_jpeg(600, 800))
+        s1 = _SimpleSource("a", b"DATA_A")
+        s2 = _SimpleSource("b", b"DATA_B")
         sink = _SimpleSink(sources=[s1, s2], predicates=[])
         _, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s1
@@ -362,10 +270,6 @@ class TestMultiSourceSinkContract:
 
 
 class TestFetchPredicateProtocol:
-    def test_min_width_predicate_satisfies_protocol(self) -> None:
-        p: FetchPredicate = MinWidthPredicate(300)
-        assert p.accepts(_make_jpeg(400, 500), _ref()) is True
-
     def test_custom_predicate_satisfies_protocol(self) -> None:
         class _Always:
             def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
@@ -374,9 +278,13 @@ class TestFetchPredicateProtocol:
         p: FetchPredicate = _Always()
         assert p.accepts(b"anything", _ref()) is True
 
+    def test_min_length_predicate_satisfies_protocol(self) -> None:
+        p: FetchPredicate = _MinLengthPredicate(5)
+        assert p.accepts(b"x" * 10, _ref()) is True
+
     def test_runtime_checkable_isinstance(self) -> None:
         """FetchPredicate is @runtime_checkable — isinstance works on instances."""
-        p = MinWidthPredicate(300)
+        p = _MinLengthPredicate(5)
         assert isinstance(p, FetchPredicate)
 
     def test_runtime_checkable_rejects_non_protocol(self) -> None:


### PR DESCRIPTION
## Summary

Implements ADR-013: the `MultiSourceSink` base class and `FetchPredicate` protocol, providing a reusable *try-until-accepted* resolution loop for Sink implementations that resolve a record field from multiple ranked sources.

Key changes:
- `src/ladon/plugins/resolution.py`: `FetchPredicate` protocol (`@runtime_checkable`), `MultiSourceSink` with `resolve_multi()` loop, three override hooks (`_should_try_source`, `_is_better_candidate`, `_fetch_from_source`)
- `src/ladon/__init__.py`: top-level re-exports for `FetchPredicate` and `MultiSourceSink`
- `src/ladon/plugins/__init__.py`: re-exports from resolution module
- `tests/plugins/test_resolution.py`: comprehensive unit tests covering loop mechanics, predicate integration, and protocol conformance
- `MinWidthPredicate` / `image_width` moved to `ladon-dylan-dog` (domain-specific, not framework)
- Review findings addressed: `if not data:` guard (catches `b''`), `_is_better_candidate` always-False warning, `sources` property copy, docstring improvements

## Test plan

- [ ] `pytest -q` — all tests pass
- [ ] `pyright` — no type errors
- [ ] `ruff` + `black` + `isort` — clean