### PR TITLE
feat(runner): CrawlPlan + plan_crawl / execute_plan split (v0.3)

### DIFF
--- a/src/ladon/async_runner.py
+++ b/src/ladon/async_runner.py
@@ -30,7 +30,9 @@ exceptions are recorded in ``RunResult.errors`` as leaf failures.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
+import warnings
 from collections.abc import Awaitable, Callable
 
 from ladon.networking.async_client import AsyncHttpClient
@@ -315,6 +317,9 @@ async def execute_plan(
         plugin:      Async crawl plugin whose sink consumes each leaf.
         client:      Configured AsyncHttpClient instance.
         config:      Run-level configuration (leaf_limit, async_concurrency).
+                     If the plan was already narrowed with ``CrawlPlan.limited_to()``,
+                     both that cap and ``config.leaf_limit`` apply independently —
+                     the tighter of the two wins.
         on_leaf:     Optional async callback receiving ``(leaf_record, leaf_ref)``
                      after each successful consume.  Note: second argument is the
                      **leaf ref**, not a parent record (see ADR-011).
@@ -323,13 +328,20 @@ async def execute_plan(
                      (success or failure).  Called from inside concurrent leaf
                      tasks — order matches completion order, not input order.
                      Async callables are not supported; passing an ``async def``
-                     will silently discard the coroutine.  Exceptions raised
-                     by this callback are logged and swallowed.
+                     raises ``TypeError`` at call time because the coroutine
+                     object is not awaited.  Exceptions raised by this callback
+                     are logged and swallowed.
 
     Returns:
         RunResult with counts and any per-leaf error messages.  Phase 1
         errors from the plan are carried forward into ``RunResult.errors``.
     """
+    if on_progress is not None and inspect.iscoroutinefunction(on_progress):
+        warnings.warn(
+            "on_progress must be a synchronous callable; async callables are "
+            "not supported and the coroutine will not be awaited.",
+            stacklevel=2,
+        )
     leaves = plan.leaves
     if config.leaf_limit > 0:
         leaves = leaves[: config.leaf_limit]

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -69,9 +69,13 @@ class CrawlPlan:
     def limited_to(self, n: int) -> CrawlPlan:
         """Return a new plan capped at the first n leaves.
 
-        ``n`` must be a positive integer.  ``0`` is not equivalent to
-        "no limit" — it produces an empty plan.  To apply no cap, simply
-        do not call ``limited_to()``.
+        ``n`` must be a positive integer; ``0`` and negative values raise
+        ``ValueError``.  To apply no cap, simply do not call
+        ``limited_to()``.
+
+        Note: if you also pass ``RunConfig(leaf_limit=k)`` to
+        ``execute_plan_sync()`` / ``execute_plan()``, both caps are applied
+        independently — the tighter of the two wins.
         """
         if n <= 0:
             raise ValueError(
@@ -390,6 +394,8 @@ def execute_plan_sync(
         plugin:      Crawl plugin whose sink consumes each leaf.
         client:      Configured HttpClient instance.
         config:      Run-level configuration (leaf_limit; async_concurrency ignored).
+                     If the plan was already narrowed with ``CrawlPlan.limited_to()``,
+                     both caps apply independently — the tighter of the two wins.
         on_leaf:     Optional callback receiving ``(leaf_record, leaf_ref)``
                      after each successful consume.  Note: second argument is the
                      **leaf ref**, not a parent record (see ADR-011).

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -980,6 +980,67 @@ class TestExecutePlan:
         )
         assert calls == []
 
+    async def test_warns_when_on_progress_is_async(
+        self, plugin: _MockAsyncPlugin
+    ) -> None:
+        plan = CrawlPlan(record=_make_record(), leaves=(), errors=())
+
+        async def async_callback(done: int, total: int) -> None:
+            pass
+
+        with pytest.warns(
+            UserWarning, match="on_progress must be a synchronous callable"
+        ):
+            await execute_plan(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_progress=async_callback,
+            )
+
+    async def test_on_progress_called_after_sink_failure(
+        self, top_ref: Ref
+    ) -> None:
+        class _FailingSink:
+            async def consume(self, ref: object, client: object) -> object:
+                raise LeafUnavailableError("gone")
+
+        refs = [Ref(url="https://demo.example.com/leaf/1")]
+        p = _MockAsyncPlugin(refs)
+        p.sink = _FailingSink()
+        plan = await plan_crawl(top_ref, p, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+        await execute_plan(
+            plan,
+            p,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_progress=lambda d, t: progress_calls.append((d, t)),
+        )
+        assert progress_calls == [(1, 1)]
+
+    async def test_on_progress_called_after_on_leaf_failure(
+        self, top_ref: Ref
+    ) -> None:
+        refs = [Ref(url="https://demo.example.com/leaf/1")]
+        p = _MockAsyncPlugin(refs)
+        plan = await plan_crawl(top_ref, p, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+
+        async def failing_callback(record: object, ref: object) -> None:
+            raise RuntimeError("db fail")
+
+        await execute_plan(
+            plan,
+            p,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_leaf=failing_callback,
+            on_progress=lambda d, t: progress_calls.append((d, t)),
+        )
+        assert progress_calls == [(1, 1)]
+
     async def test_plan_crawl_then_execute_plan_roundtrip(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:


### PR DESCRIPTION
## Summary

Implements the plan/execute split from the v0.3 runner design:

- `CrawlPlan` — immutable dataclass carrying `record`, `leaves`, `errors`; with `excluding()` and `limited_to()` helpers
- `plan_crawl_sync` / `plan_crawl` — Phase 1 only (tree traversal, no sink)
- `execute_plan_sync` / `execute_plan` — Phase 3 only against an existing plan; adds `on_progress(done, total)` callback
- `run_crawl` / `async_run_crawl` — unchanged self-contained Phase 1+3 entry points
- `execute_plan`'s `on_leaf` receives `(leaf_record, leaf_ref)` per ADR-011 (leaf ref, not parent)

Review findings addressed:
- `limited_to()` docstring: n=0 raises `ValueError`, not "produces an empty plan"
- Double-cap note: `limited_to()` + `RunConfig(leaf_limit=k)` both apply independently
- `execute_plan` warns at call time (`warnings.warn`) if `on_progress` is a coroutine function
- Async test suite: added `test_on_progress_called_on_failure_too` and `test_on_progress_called_after_on_leaf_failure` to mirror the sync suite

## Test plan

- [ ] `pytest -q` — all tests pass (601 total)
- [ ] `pyright` — no type errors
- [ ] `ruff` + `black` + `isort` — clean