### PR TITLE
fix(plugins): apply review findings to MultiSourceSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`CrawlPlan`** — immutable Phase 1 output carrying `record`, `leaves`,
+  and `errors`.  Filter with `excluding(predicate)` or `limited_to(n)`
+  before passing to `execute_plan_sync` / `execute_plan`.
+- **`plan_crawl_sync` / `plan_crawl`** — Phase 1 only: traverse all
+  expanders and return a `CrawlPlan` without calling the sink.
+- **`execute_plan_sync` / `execute_plan`** — Phase 3 only: consume an
+  existing plan against the sink.  `on_leaf` receives
+  `(leaf_record, leaf_ref)` — the leaf ref, **not** a parent record
+  (ADR-011).  Optional `on_progress(done, total)` callback for real-time
+  progress reporting.
+
 ### Fixed
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ladon-crawl"
-version = "0.3.1"
+version = "0.3.2"
 description = "A structured, resumable web crawling framework for AI-ready datasets."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from .async_runner import async_run_crawl
+from .async_runner import async_run_crawl, execute_plan, plan_crawl
 from .mcp import LadonMCPAdapter
 from .networking import make_async_http_client, make_http_client
 from .networking.async_client import AsyncHttpClient
@@ -40,7 +40,14 @@ from .plugins import (
     Sink,
     Source,
 )
-from .runner import RunConfig, RunResult, run_crawl
+from .runner import (
+    CrawlPlan,
+    RunConfig,
+    RunResult,
+    execute_plan_sync,
+    plan_crawl_sync,
+    run_crawl,
+)
 from .storage import (
     LocalFileStorage,
     Storage,
@@ -59,11 +66,17 @@ except PackageNotFoundError:
 
 
 __all__ = [
-    # Runner
+    # Runner — sync
     "run_crawl",
-    "async_run_crawl",
+    "plan_crawl_sync",
+    "execute_plan_sync",
     "RunConfig",
     "RunResult",
+    "CrawlPlan",
+    # Runner — async
+    "async_run_crawl",
+    "plan_crawl",
+    "execute_plan",
     # Sync plugin protocols
     "CrawlPlugin",
     "Source",

--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -61,7 +61,7 @@ try:
     __version__ = version("ladon-crawl")
 except PackageNotFoundError:
     __version__ = (
-        "0.3.1"  # editable install without metadata — bump with every release
+        "0.3.2"  # editable install without metadata — bump with every release
     )
 
 

--- a/src/ladon/async_runner.py
+++ b/src/ladon/async_runner.py
@@ -323,7 +323,8 @@ async def execute_plan(
                      (success or failure).  Called from inside concurrent leaf
                      tasks — order matches completion order, not input order.
                      Async callables are not supported; passing an ``async def``
-                     will silently discard the coroutine.
+                     will silently discard the coroutine.  Exceptions raised
+                     by this callback are logged and swallowed.
 
     Returns:
         RunResult with counts and any per-leaf error messages.  Phase 1
@@ -337,7 +338,7 @@ async def execute_plan(
 
     logger.info(
         "execute_plan started",
-        extra={"plugin": plugin.name, "total_leaves": total},
+        extra={"plugin": plugin.name, "leaf_count": total},
     )
 
     errors: list[str] = list(plan.errors)
@@ -354,6 +355,19 @@ async def execute_plan(
         leaf_errors    holds at most one error string.
         """
         nonlocal done_count
+
+        def _fire_progress() -> None:
+            if on_progress is not None:
+                try:
+                    on_progress(done_count, total)
+                except Exception as _exc:
+                    logger.warning(
+                        "on_progress callback raised — ref[%d]: %s",
+                        i,
+                        _exc,
+                        extra={"plugin": plugin.name, "ref_index": i},
+                    )
+
         async with semaphore:
             try:
                 leaf_record = await plugin.sink.consume(leaf_ref, client)
@@ -369,16 +383,14 @@ async def execute_plan(
                     },
                 )
                 done_count += 1
-                if on_progress is not None:
-                    on_progress(done_count, total)
+                _fire_progress()
                 return (False, False, [f"ref[{i}] consume failed: {exc}"])
 
             if on_leaf is not None:
                 try:
                     await on_leaf(leaf_record, leaf_ref)
                     done_count += 1
-                    if on_progress is not None:
-                        on_progress(done_count, total)
+                    _fire_progress()
                     return (True, True, [])
                 except Exception as exc:
                     logger.warning(
@@ -392,13 +404,11 @@ async def execute_plan(
                         },
                     )
                     done_count += 1
-                    if on_progress is not None:
-                        on_progress(done_count, total)
+                    _fire_progress()
                     return (True, False, [f"ref[{i}] callback failed: {exc}"])
 
             done_count += 1
-            if on_progress is not None:
-                on_progress(done_count, total)
+            _fire_progress()
             return (True, True, [])
 
     outcomes = await asyncio.gather(
@@ -422,7 +432,15 @@ async def execute_plan(
             )
             if on_progress is not None:
                 done_count += 1
-                on_progress(done_count, total)
+                try:
+                    on_progress(done_count, total)
+                except Exception as _exc:
+                    logger.warning(
+                        "on_progress callback raised — ref[%d]: %s",
+                        i,
+                        _exc,
+                        extra={"plugin": plugin.name, "ref_index": i},
+                    )
         else:
             consumed, persisted, leaf_errors = outcome
             if consumed:

--- a/src/ladon/async_runner.py
+++ b/src/ladon/async_runner.py
@@ -7,6 +7,14 @@ asyncio:
      ``asyncio.Semaphore(config.async_concurrency)`` to bound the number of
      in-flight requests.
 
+The plan/execute split (v0.3):
+  ``plan_crawl`` runs Phase 1 only and returns a ``CrawlPlan``.
+  ``execute_plan`` runs Phase 3 against an existing plan.
+  ``async_run_crawl`` remains a self-contained Phase 1+3 entry point with the
+  original ``on_leaf(leaf_record, parent_record)`` contract.
+  ``execute_plan``'s ``on_leaf`` receives ``(leaf_record, leaf_ref)``
+  per ADR-011 — different from ``async_run_crawl``'s contract.
+
 ``ExpansionNotReadyError`` retains the same globally-fatal semantics as in
 the sync runner: when any expander raises it, the coroutine raises immediately
 and the caller must schedule a retry.
@@ -33,7 +41,7 @@ from ladon.plugins.errors import (
     LeafUnavailableError,
     PartialExpansionError,
 )
-from ladon.runner import RunConfig, RunResult
+from ladon.runner import CrawlPlan, RunConfig, RunResult
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +223,197 @@ async def async_run_crawl(
 
     return RunResult(
         record=top_record,
+        leaves_consumed=leaves_consumed,
+        leaves_persisted=leaves_persisted,
+        leaves_failed=leaves_failed,
+        errors=tuple(errors),
+    )
+
+
+async def plan_crawl(
+    top_ref: object,
+    plugin: AsyncCrawlPlugin,
+    client: AsyncHttpClient,
+) -> CrawlPlan:
+    """Run Phase 1 (tree traversal) asynchronously and return a CrawlPlan.
+
+    Traverses all expanders in order and collects every leaf ref.  Does not
+    call the sink.  Branch failures are recorded in ``CrawlPlan.errors``.
+
+    Raises:
+        ExpansionNotReadyError:     Any expander raised this — run is globally
+                                    premature; caller should retry later.
+        PartialExpansionError:      Raised only from the first expander.
+        ChildListUnavailableError:  Raised only from the first expander.
+        ValueError:                 Plugin has no expanders configured.
+    """
+    if not plugin.expanders:
+        raise ValueError(
+            f"AsyncCrawlPlugin '{plugin.name}' has no expanders configured"
+        )
+
+    errors: list[str] = []
+
+    first_expansion = await plugin.expanders[0].expand(top_ref, client)
+    top_record: object = first_expansion.record
+    current_refs: list[object] = list(first_expansion.child_refs)
+
+    for expander in plugin.expanders[1:]:
+        next_refs: list[object] = []
+        for ref in current_refs:
+            try:
+                expansion = await expander.expand(ref, client)
+            except ExpansionNotReadyError:
+                raise
+            except (PartialExpansionError, ChildListUnavailableError) as exc:
+                errors.append(f"expander branch '{ref}': {exc}")
+                logger.warning(
+                    "expander branch failed",
+                    extra={
+                        "ref": str(ref),
+                        "error": str(exc),
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                continue
+            next_refs.extend(expansion.child_refs)
+        current_refs = next_refs
+
+    logger.info(
+        "plan_crawl finished",
+        extra={"plugin": plugin.name, "leaf_count": len(current_refs)},
+    )
+    return CrawlPlan(
+        record=top_record,
+        leaves=tuple(current_refs),
+        errors=tuple(errors),
+    )
+
+
+async def execute_plan(
+    plan: CrawlPlan,
+    plugin: AsyncCrawlPlugin,
+    client: AsyncHttpClient,
+    config: RunConfig,
+    on_leaf: Callable[[object, object], Awaitable[None]] | None = None,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> RunResult:
+    """Run Phase 3 (leaf fetching) asynchronously against an existing CrawlPlan.
+
+    Args:
+        plan:        Plan produced by ``plan_crawl()``.
+        plugin:      Async crawl plugin whose sink consumes each leaf.
+        client:      Configured AsyncHttpClient instance.
+        config:      Run-level configuration (leaf_limit, async_concurrency).
+        on_leaf:     Optional async callback receiving ``(leaf_record, leaf_ref)``
+                     after each successful consume.  Note: second argument is the
+                     **leaf ref**, not a parent record (see ADR-011).
+        on_progress: Optional callback receiving ``(leaves_done, total_leaves)``
+                     after each leaf attempt (success or failure).  Called from
+                     inside the concurrent leaf tasks — order matches completion
+                     order, not input order.
+
+    Returns:
+        RunResult with counts and any per-leaf error messages.  Phase 1
+        errors from the plan are carried forward into ``RunResult.errors``.
+    """
+    leaves = plan.leaves
+    if config.leaf_limit > 0:
+        leaves = leaves[: config.leaf_limit]
+
+    total = len(leaves)
+    errors: list[str] = list(plan.errors)
+    semaphore = asyncio.Semaphore(config.async_concurrency)
+    done_count = 0
+
+    async def _process_leaf(
+        i: int, leaf_ref: object
+    ) -> tuple[bool, bool, list[str]]:
+        """Returns (consumed, persisted, leaf_errors).
+
+        consumed=True  when sink.consume() succeeded.
+        persisted=True when consumed AND on_leaf succeeded (or no callback).
+        leaf_errors    holds at most one error string.
+        """
+        nonlocal done_count
+        async with semaphore:
+            try:
+                leaf_record = await plugin.sink.consume(leaf_ref, client)
+            except LeafUnavailableError as exc:
+                logger.warning(
+                    "leaf unavailable — ref[%d] error=%s",
+                    i,
+                    exc,
+                    extra={"ref_index": i, "error": str(exc)},
+                )
+                done_count += 1
+                if on_progress is not None:
+                    on_progress(done_count, total)
+                return (False, False, [f"ref[{i}] consume failed: {exc}"])
+
+            if on_leaf is not None:
+                try:
+                    await on_leaf(leaf_record, leaf_ref)
+                    done_count += 1
+                    if on_progress is not None:
+                        on_progress(done_count, total)
+                    return (True, True, [])
+                except Exception as exc:
+                    logger.warning(
+                        "on_leaf callback failed — ref[%d] error=%s",
+                        i,
+                        exc,
+                        extra={"ref_index": i, "error": str(exc)},
+                    )
+                    done_count += 1
+                    if on_progress is not None:
+                        on_progress(done_count, total)
+                    return (True, False, [f"ref[{i}] callback failed: {exc}"])
+
+            done_count += 1
+            if on_progress is not None:
+                on_progress(done_count, total)
+            return (True, True, [])
+
+    outcomes = await asyncio.gather(
+        *[_process_leaf(i, leaf_ref) for i, leaf_ref in enumerate(leaves)],
+        return_exceptions=True,
+    )
+
+    leaves_consumed = 0
+    leaves_persisted = 0
+    leaves_failed = 0
+
+    for i, outcome in enumerate(outcomes):
+        if isinstance(outcome, BaseException):
+            leaves_failed += 1
+            errors.append(f"ref[{i}]: unexpected error: {outcome}")
+            logger.error(
+                "unexpected leaf error — ref[%d]: %s",
+                i,
+                outcome,
+                extra={"ref_index": i},
+            )
+        else:
+            consumed, persisted, leaf_errors = outcome
+            if consumed:
+                leaves_consumed += 1
+            else:
+                leaves_failed += 1
+            if persisted:
+                leaves_persisted += 1
+            errors.extend(leaf_errors)
+
+    logger.info(
+        "execute_plan finished",
+        extra={
+            "leaves_consumed": leaves_consumed,
+            "leaves_persisted": leaves_persisted,
+            "leaves_failed": leaves_failed,
+        },
+    )
+    return RunResult(
+        record=plan.record,
         leaves_consumed=leaves_consumed,
         leaves_persisted=leaves_persisted,
         leaves_failed=leaves_failed,

--- a/src/ladon/async_runner.py
+++ b/src/ladon/async_runner.py
@@ -240,6 +240,10 @@ async def plan_crawl(
     Traverses all expanders in order and collects every leaf ref.  Does not
     call the sink.  Branch failures are recorded in ``CrawlPlan.errors``.
 
+    Note: unlike ``async_run_crawl``, this function does not accept a
+    ``config`` argument — Phase 1 (tree traversal) has no configurable
+    parameters.
+
     Raises:
         ExpansionNotReadyError:     Any expander raised this — run is globally
                                     premature; caller should retry later.
@@ -417,7 +421,8 @@ async def execute_plan(
                 extra={"plugin": plugin.name, "ref_index": i},
             )
             if on_progress is not None:
-                on_progress(leaves_consumed + leaves_failed, total)
+                done_count += 1
+                on_progress(done_count, total)
         else:
             consumed, persisted, leaf_errors = outcome
             if consumed:

--- a/src/ladon/async_runner.py
+++ b/src/ladon/async_runner.py
@@ -252,6 +252,11 @@ async def plan_crawl(
             f"AsyncCrawlPlugin '{plugin.name}' has no expanders configured"
         )
 
+    logger.info(
+        "plan_crawl started",
+        extra={"plugin": plugin.name, "ref": str(top_ref)},
+    )
+
     errors: list[str] = []
 
     first_expansion = await plugin.expanders[0].expand(top_ref, client)
@@ -270,6 +275,7 @@ async def plan_crawl(
                 logger.warning(
                     "expander branch failed",
                     extra={
+                        "plugin": plugin.name,
                         "ref": str(ref),
                         "error": str(exc),
                         "error_type": type(exc).__name__,
@@ -308,10 +314,12 @@ async def execute_plan(
         on_leaf:     Optional async callback receiving ``(leaf_record, leaf_ref)``
                      after each successful consume.  Note: second argument is the
                      **leaf ref**, not a parent record (see ADR-011).
-        on_progress: Optional callback receiving ``(leaves_done, total_leaves)``
-                     after each leaf attempt (success or failure).  Called from
-                     inside the concurrent leaf tasks — order matches completion
-                     order, not input order.
+        on_progress: Optional **synchronous** callback receiving
+                     ``(leaves_done, total_leaves)`` after each leaf attempt
+                     (success or failure).  Called from inside concurrent leaf
+                     tasks — order matches completion order, not input order.
+                     Async callables are not supported; passing an ``async def``
+                     will silently discard the coroutine.
 
     Returns:
         RunResult with counts and any per-leaf error messages.  Phase 1
@@ -322,6 +330,12 @@ async def execute_plan(
         leaves = leaves[: config.leaf_limit]
 
     total = len(leaves)
+
+    logger.info(
+        "execute_plan started",
+        extra={"plugin": plugin.name, "total_leaves": total},
+    )
+
     errors: list[str] = list(plan.errors)
     semaphore = asyncio.Semaphore(config.async_concurrency)
     done_count = 0
@@ -344,7 +358,11 @@ async def execute_plan(
                     "leaf unavailable — ref[%d] error=%s",
                     i,
                     exc,
-                    extra={"ref_index": i, "error": str(exc)},
+                    extra={
+                        "plugin": plugin.name,
+                        "ref_index": i,
+                        "error": str(exc),
+                    },
                 )
                 done_count += 1
                 if on_progress is not None:
@@ -363,7 +381,11 @@ async def execute_plan(
                         "on_leaf callback failed — ref[%d] error=%s",
                         i,
                         exc,
-                        extra={"ref_index": i, "error": str(exc)},
+                        extra={
+                            "plugin": plugin.name,
+                            "ref_index": i,
+                            "error": str(exc),
+                        },
                     )
                     done_count += 1
                     if on_progress is not None:
@@ -392,8 +414,10 @@ async def execute_plan(
                 "unexpected leaf error — ref[%d]: %s",
                 i,
                 outcome,
-                extra={"ref_index": i},
+                extra={"plugin": plugin.name, "ref_index": i},
             )
+            if on_progress is not None:
+                on_progress(leaves_consumed + leaves_failed, total)
         else:
             consumed, persisted, leaf_errors = outcome
             if consumed:
@@ -407,6 +431,7 @@ async def execute_plan(
     logger.info(
         "execute_plan finished",
         extra={
+            "plugin": plugin.name,
             "leaves_consumed": leaves_consumed,
             "leaves_persisted": leaves_persisted,
             "leaves_failed": leaves_failed,

--- a/src/ladon/mcp/adapter.py
+++ b/src/ladon/mcp/adapter.py
@@ -32,7 +32,8 @@ class LadonMCPAdapter(ABC):
     @property
     @abstractmethod
     def adapter_name(self) -> str:
-        """Short identifier used in tool name prefixes: ``mimir``, ``hermes``."""
+        """Short identifier used in log messages and reserved for future
+        tool-name prefixing: ``mimir``, ``hermes``."""
         ...
 
     @abstractmethod
@@ -42,6 +43,10 @@ class LadonMCPAdapter(ABC):
         Each callable must have a descriptive docstring (used as the tool
         description) and type-annotated parameters (used to build the JSON
         schema). All database access **must** use ``read_only=True``.
+
+        On ``duckdb.Error``, return a structured ``{"error": "..."}`` payload
+        (or ``[{"error": "..."}]`` for list-returning tools) rather than
+        raising — MCP clients may not handle exceptions gracefully.
         """
         ...
 

--- a/src/ladon/plugins/__init__.py
+++ b/src/ladon/plugins/__init__.py
@@ -22,7 +22,12 @@ from .errors import (
 )
 from .models import Expansion, Ref
 from .protocol import CrawlPlugin, Expander, Sink, Source
-from .resolution import FetchPredicate, MinWidthPredicate, MultiSourceSink
+from .resolution import (
+    FetchPredicate,
+    MinWidthPredicate,
+    MultiSourceSink,
+    image_width,
+)
 
 __all__ = [
     # Sync protocols
@@ -42,6 +47,7 @@ __all__ = [
     "FetchPredicate",
     "MultiSourceSink",
     "MinWidthPredicate",
+    "image_width",
     # Errors
     "PluginError",
     "ExpansionNotReadyError",

--- a/src/ladon/plugins/__init__.py
+++ b/src/ladon/plugins/__init__.py
@@ -24,9 +24,7 @@ from .models import Expansion, Ref
 from .protocol import CrawlPlugin, Expander, Sink, Source
 from .resolution import (
     FetchPredicate,
-    MinWidthPredicate,
     MultiSourceSink,
-    image_width,
 )
 
 __all__ = [
@@ -46,8 +44,6 @@ __all__ = [
     # Resolution
     "FetchPredicate",
     "MultiSourceSink",
-    "MinWidthPredicate",
-    "image_width",
     # Errors
     "PluginError",
     "ExpansionNotReadyError",

--- a/src/ladon/plugins/__init__.py
+++ b/src/ladon/plugins/__init__.py
@@ -22,6 +22,7 @@ from .errors import (
 )
 from .models import Expansion, Ref
 from .protocol import CrawlPlugin, Expander, Sink, Source
+from .resolution import FetchPredicate, MinWidthPredicate, MultiSourceSink
 
 __all__ = [
     # Sync protocols
@@ -37,6 +38,10 @@ __all__ = [
     # Models
     "Ref",
     "Expansion",
+    # Resolution
+    "FetchPredicate",
+    "MultiSourceSink",
+    "MinWidthPredicate",
     # Errors
     "PluginError",
     "ExpansionNotReadyError",

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -13,13 +13,13 @@ The loop pattern
         if not _should_try_source(source, ref):   # tier-skip, guards
             continue
         data = _fetch_from_source(source, ref, client)
-        if data is None:
-            continue                               # source returned nothing
+        if not data:
+            continue                               # source returned nothing / empty bytes
         if _is_better_candidate(data, ...):        # update best-seen fallback
             best = (data, source)
-        if all predicates pass:
+        if not predicates or all predicates pass:
             return (data, source)                  # accepted — stop
-    return best                                    # best-seen fallback
+    return best                                    # best-seen fallback (may be None)
 
 ``FetchPredicate`` is the extension point: adapters inject domain-specific
 acceptance criteria (image width, placeholder detection, price tolerance …)
@@ -51,6 +51,12 @@ class FetchPredicate(Protocol):
     Returns ``True`` if *data* is good enough to stop the resolution loop.
     Returns ``False`` to keep *data* as a fallback candidate and continue to
     the next source in search of a better result.
+
+    .. note::
+        ``isinstance(obj, FetchPredicate)`` only checks that an ``accepts``
+        attribute *exists* — it does not verify callability or signature.
+        Passing a mis-shaped object will raise ``TypeError`` at call time
+        inside :meth:`MultiSourceSink.resolve_multi`, not at construction.
     """
 
     def accepts(self, data: bytes, ref: Ref) -> bool:
@@ -74,7 +80,7 @@ class MultiSourceSink:
         tier cannot improve on the existing record, or to enforce rate limits.
 
     ``_is_better_candidate(data, source, best_data, best_source, ref) → bool``
-        Fallback selection. Default: first non-None result wins. Override for
+        Fallback selection. Default: first non-empty result wins. Override for
         domain-specific ranking (e.g., prefer wider images when multiple
         below-threshold results exist).
 
@@ -111,13 +117,13 @@ class MultiSourceSink:
     def _fetch_from_source(
         self, _source: Any, _ref: Ref, _client: HttpClient
     ) -> bytes | None:
-        """Fetch raw bytes from *_source* for *_ref*. Must be overridden."""
+        """Fetch raw bytes from *source* for *ref*. Must be overridden."""
         raise NotImplementedError(
             f"{type(self).__name__} must implement _fetch_from_source"
         )
 
     def _should_try_source(self, _source: Any, _ref: Ref) -> bool:
-        """Return True if *_source* should be attempted for *_ref*.
+        """Return True if *source* should be attempted for *ref*.
 
         Default: always try. Override to implement tier-skip, cooldown
         guards, or any other pre-fetch filtering.
@@ -132,10 +138,17 @@ class MultiSourceSink:
         best_source: Any | None,
         _ref: Ref,
     ) -> bool:
-        """Return True if *(_data, _source)* should replace the current best.
+        """Return True if *(data, source)* should replace the current best.
 
-        Default: first non-None result wins (``best_source is None``).
+        Default: first non-empty result wins (``best_source is None``).
         Override for domain-specific fallback ranking.
+
+        .. warning::
+            If a subclass overrides this to always return ``False`` (e.g. due
+            to a bug in the ranking logic), ``best_data`` is never updated and
+            :meth:`resolve_multi` returns ``(None, None)`` even when sources
+            produce data.  The caller cannot distinguish this from "no sources
+            returned data" without inspecting logs.
         """
         return best_source is None
 
@@ -169,7 +182,7 @@ class MultiSourceSink:
                 continue
 
             data = self._fetch_from_source(source, ref, client)
-            if data is None:
+            if not data:
                 logger.debug(
                     "resolution: %r returned no data for %s",
                     getattr(source, "name", source),

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -25,13 +25,6 @@ The loop pattern
 acceptance criteria (image width, placeholder detection, price tolerance …)
 without modifying the loop mechanics.
 
-Built-in predicates
--------------------
-
-``MinWidthPredicate``
-    Accepts a JPEG or PNG only if its pixel width meets a minimum.
-    Uses header-only parsing — no external library required.
-
 ADR: ADR-013
 """
 
@@ -214,59 +207,3 @@ class MultiSourceSink:
             )
 
         return best_data, best_source
-
-
-# ---------------------------------------------------------------------------
-# Built-in predicates
-# ---------------------------------------------------------------------------
-
-
-class MinWidthPredicate:
-    """Accept a JPEG or PNG image only if its pixel width meets a minimum.
-
-    Uses header-only parsing (JPEG SOF / PNG IHDR) — no external library
-    required. Returns ``True`` (acceptable) when the measured width is >=
-    *min_px*. A *min_px* of 0 always returns ``True`` (disables the check).
-    """
-
-    def __init__(self, min_px: int) -> None:
-        self._min_px = min_px
-
-    def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
-        if not self._min_px:
-            return True
-        return image_width(data) >= self._min_px
-
-
-# ---------------------------------------------------------------------------
-# Image header parsing
-# ---------------------------------------------------------------------------
-
-
-def image_width(data: bytes) -> int:
-    """Return the pixel width of a JPEG or PNG from its header bytes.
-
-    Reads only the first few hundred bytes — no external library required.
-    Returns 0 if the format is unrecognised or the header is truncated.
-
-    Supports:
-    - PNG: reads width from the IHDR chunk (bytes 16–19).
-    - JPEG: scans forward for a SOF0 / SOF1 / SOF2 marker, skipping
-      variable-length APP segments (including multi-segment EXIF headers).
-    """
-    if len(data) >= 24 and data[:8] == b"\x89PNG\r\n\x1a\n":
-        # PNG: IHDR chunk starts at byte 8; width is at bytes 16–19.
-        return int.from_bytes(data[16:20], "big")
-    if len(data) >= 4 and data[:2] == b"\xff\xd8":
-        # JPEG: scan forward for a SOF0 / SOF1 / SOF2 marker.
-        i = 2
-        while i + 8 < len(data):
-            if data[i] != 0xFF:
-                break
-            marker = data[i + 1]
-            seg_len = int.from_bytes(data[i + 2 : i + 4], "big")
-            if marker in (0xC0, 0xC1, 0xC2):  # SOF0 / SOF1 / SOF2
-                # Segment layout: FF Cx LL LL PP HH HH WW WW …
-                return int.from_bytes(data[i + 7 : i + 9], "big")
-            i += 2 + seg_len
-    return 0

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -1,0 +1,258 @@
+"""Multi-source resolution utilities for Ladon Sink implementations.
+
+Provides the ``FetchPredicate`` protocol and ``MultiSourceSink`` base class,
+which together encode the *try-until-accepted* resolution loop used by any
+Sink that resolves a record field from multiple ranked sources.
+
+The loop pattern
+----------------
+
+::
+
+    for source in sources (ordered best-first):
+        if not _should_try_source(source, ref):   # tier-skip, guards
+            continue
+        data = _fetch_from_source(source, ref, client)
+        if data is None:
+            continue                               # source returned nothing
+        if _is_better_candidate(data, ...):        # update best-seen fallback
+            best = (data, source)
+        if all predicates pass:
+            return (data, source)                  # accepted — stop
+    return best                                    # best-seen fallback
+
+``FetchPredicate`` is the extension point: adapters inject domain-specific
+acceptance criteria (image width, placeholder detection, price tolerance …)
+without modifying the loop mechanics.
+
+Built-in predicates
+-------------------
+
+``MinWidthPredicate``
+    Accepts a JPEG or PNG only if its pixel width meets a minimum.
+    Uses header-only parsing — no external library required.
+
+ADR: ADR-013
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol, Sequence
+
+from ..networking.client import HttpClient
+from .models import Ref
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class FetchPredicate(Protocol):
+    """Acceptance criterion on a raw fetch result.
+
+    Returns ``True`` if *data* is good enough to stop the resolution loop.
+    Returns ``False`` to keep *data* as a fallback candidate and continue to
+    the next source in search of a better result.
+    """
+
+    def accepts(self, data: bytes, ref: Ref) -> bool:
+        """Return True if this result is acceptable."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+
+class MultiSourceSink:
+    """Base for Sink implementations that resolve from multiple ranked sources.
+
+    Subclasses must override :meth:`_fetch_from_source` to adapt their
+    specific source interface. Three optional hooks control loop behaviour:
+
+    ``_should_try_source(source, ref) → bool``
+        Pre-fetch guard. Default: always try. Override to skip sources whose
+        tier cannot improve on the existing record, or to enforce rate limits.
+
+    ``_is_better_candidate(data, source, best_data, best_source, ref) → bool``
+        Fallback selection. Default: first non-None result wins. Override for
+        domain-specific ranking (e.g., prefer wider images when multiple
+        below-threshold results exist).
+
+    ``_fetch_from_source(source, ref, client) → bytes | None``
+        Calls the source's native interface. Must be overridden; there is no
+        default implementation because source interfaces vary per adapter.
+
+    The main entry point is :meth:`_resolve_multi`, which runs the loop and
+    returns ``(data, source)`` for the best accepted result, or the best
+    fallback if no result passed all predicates.
+    """
+
+    def __init__(
+        self,
+        sources: list[Any],
+        predicates: Sequence[FetchPredicate] = (),
+    ) -> None:
+        self._ms_sources: list[Any] = list(sources)
+        self._ms_predicates: list[FetchPredicate] = list(predicates)
+
+    # ------------------------------------------------------------------
+    # Hooks — override in subclasses
+    # ------------------------------------------------------------------
+
+    def _fetch_from_source(
+        self, _source: Any, _ref: Ref, _client: HttpClient
+    ) -> bytes | None:
+        """Fetch raw bytes from *_source* for *_ref*. Must be overridden."""
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement _fetch_from_source"
+        )
+
+    def _should_try_source(self, _source: Any, _ref: Ref) -> bool:
+        """Return True if *_source* should be attempted for *_ref*.
+
+        Default: always try. Override to implement tier-skip, cooldown
+        guards, or any other pre-fetch filtering.
+        """
+        return True
+
+    def _is_better_candidate(
+        self,
+        _data: bytes,
+        _source: Any,
+        _best_data: bytes | None,
+        best_source: Any | None,
+        _ref: Ref,
+    ) -> bool:
+        """Return True if *(_data, _source)* should replace the current best.
+
+        Default: first non-None result wins (``best_source is None``).
+        Override for domain-specific fallback ranking.
+        """
+        return best_source is None
+
+    # ------------------------------------------------------------------
+    # Loop
+    # ------------------------------------------------------------------
+
+    def _all_predicates_pass(self, data: bytes, ref: Ref) -> bool:
+        """Return True if *data* satisfies every registered predicate."""
+        return all(p.accepts(data, ref) for p in self._ms_predicates)
+
+    def resolve_multi(
+        self, ref: Ref, client: HttpClient
+    ) -> tuple[bytes | None, Any | None]:
+        """Try sources in priority order; return the best accepted result.
+
+        Returns ``(data, source)`` for the first result that passes all
+        predicates, or the best fallback seen if no result was accepted.
+        Returns ``(None, None)`` if no source produced any result.
+        """
+        best_data: bytes | None = None
+        best_source: Any | None = None
+
+        for source in self._ms_sources:
+            if not self._should_try_source(source, ref):
+                logger.debug(
+                    "resolution: skipping source %r for %s",
+                    getattr(source, "name", source),
+                    ref.url,
+                )
+                continue
+
+            data = self._fetch_from_source(source, ref, client)
+            if data is None:
+                logger.debug(
+                    "resolution: %r returned no data for %s",
+                    getattr(source, "name", source),
+                    ref.url,
+                )
+                continue
+
+            if self._is_better_candidate(
+                data, source, best_data, best_source, ref
+            ):
+                best_data = data
+                best_source = source
+                logger.debug(
+                    "resolution: %r is new best candidate for %s",
+                    getattr(source, "name", source),
+                    ref.url,
+                )
+
+            if not self._ms_predicates or self._all_predicates_pass(data, ref):
+                logger.debug(
+                    "resolution: accepted result from %r for %s",
+                    getattr(source, "name", source),
+                    ref.url,
+                )
+                return data, source
+
+            logger.debug(
+                "resolution: %r did not pass all predicates for %s; trying next",
+                getattr(source, "name", source),
+                ref.url,
+            )
+
+        return best_data, best_source
+
+
+# ---------------------------------------------------------------------------
+# Built-in predicates
+# ---------------------------------------------------------------------------
+
+
+class MinWidthPredicate:
+    """Accept a JPEG or PNG image only if its pixel width meets a minimum.
+
+    Uses header-only parsing (JPEG SOF / PNG IHDR) — no external library
+    required. Returns ``True`` (acceptable) when the measured width is >=
+    *min_px*. A *min_px* of 0 always returns ``True`` (disables the check).
+    """
+
+    def __init__(self, min_px: int) -> None:
+        self._min_px = min_px
+
+    def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+        if not self._min_px:
+            return True
+        return image_width(data) >= self._min_px
+
+
+# ---------------------------------------------------------------------------
+# Image header parsing
+# ---------------------------------------------------------------------------
+
+
+def image_width(data: bytes) -> int:
+    """Return the pixel width of a JPEG or PNG from its header bytes.
+
+    Reads only the first few hundred bytes — no external library required.
+    Returns 0 if the format is unrecognised or the header is truncated.
+
+    Supports:
+    - PNG: reads width from the IHDR chunk (bytes 16–19).
+    - JPEG: scans forward for a SOF0 / SOF1 / SOF2 marker, skipping
+      variable-length APP segments (including multi-segment EXIF headers).
+    """
+    if len(data) >= 24 and data[:8] == b"\x89PNG\r\n\x1a\n":
+        # PNG: IHDR chunk starts at byte 8; width is at bytes 16–19.
+        return int.from_bytes(data[16:20], "big")
+    if len(data) >= 4 and data[:2] == b"\xff\xd8":
+        # JPEG: scan forward for a SOF0 / SOF1 / SOF2 marker.
+        i = 2
+        while i + 8 < len(data):
+            if data[i] != 0xFF:
+                break
+            marker = data[i + 1]
+            seg_len = int.from_bytes(data[i + 2 : i + 4], "big")
+            if marker in (0xC0, 0xC1, 0xC2):  # SOF0 / SOF1 / SOF2
+                # Segment layout: FF Cx LL LL PP HH HH WW WW …
+                return int.from_bytes(data[i + 7 : i + 9], "big")
+            i += 2 + seg_len
+    return 0

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -38,7 +38,7 @@ ADR: ADR-013
 from __future__ import annotations
 
 import logging
-from typing import Any, Protocol, Sequence
+from typing import Any, Protocol, Sequence, runtime_checkable
 
 from ..networking.client import HttpClient
 from .models import Ref
@@ -51,6 +51,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+@runtime_checkable
 class FetchPredicate(Protocol):
     """Acceptance criterion on a raw fetch result.
 
@@ -88,7 +89,7 @@ class MultiSourceSink:
         Calls the source's native interface. Must be overridden; there is no
         default implementation because source interfaces vary per adapter.
 
-    The main entry point is :meth:`_resolve_multi`, which runs the loop and
+    The main entry point is :meth:`resolve_multi`, which runs the loop and
     returns ``(data, source)`` for the best accepted result, or the best
     fallback if no result passed all predicates.
     """

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -103,6 +103,15 @@ class MultiSourceSink:
         self._ms_predicates: list[FetchPredicate] = list(predicates)
 
     # ------------------------------------------------------------------
+    # Public accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def sources(self) -> list[Any]:
+        """Priority-ordered source list (read-only copy)."""
+        return list(self._ms_sources)
+
+    # ------------------------------------------------------------------
     # Hooks — override in subclasses
     # ------------------------------------------------------------------
 
@@ -175,6 +184,10 @@ class MultiSourceSink:
                 )
                 continue
 
+            # Update the best-seen fallback before checking predicates.
+            # If predicates pass we return data/source directly (not best_data),
+            # so the update is a no-op in that path. If predicates fail, the
+            # updated best_data becomes the last-resort fallback after the loop.
             if self._is_better_candidate(
                 data, source, best_data, best_source, ref
             ):

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -394,7 +394,8 @@ def execute_plan_sync(
                      after each successful consume.  Note: second argument is the
                      **leaf ref**, not a parent record (see ADR-011).
         on_progress: Optional callback receiving ``(leaves_done, total_leaves)``
-                     after each leaf attempt (success or failure).
+                     after each leaf attempt (success or failure).  Exceptions
+                     raised by this callback are logged and swallowed.
 
     Returns:
         RunResult with counts and any per-leaf error messages.  Phase 1
@@ -408,7 +409,7 @@ def execute_plan_sync(
 
     logger.info(
         "execute_plan_sync started",
-        extra={"plugin": plugin.name, "total_leaves": total},
+        extra={"plugin": plugin.name, "leaf_count": total},
     )
 
     leaves_consumed = 0
@@ -433,7 +434,15 @@ def execute_plan_sync(
                 },
             )
             if on_progress is not None:
-                on_progress(leaves_consumed + leaves_failed, total)
+                try:
+                    on_progress(leaves_consumed + leaves_failed, total)
+                except Exception as _exc:
+                    logger.warning(
+                        "on_progress callback raised — ref[%d]: %s",
+                        i,
+                        _exc,
+                        extra={"plugin": plugin.name, "ref_index": i},
+                    )
             continue
 
         leaves_consumed += 1
@@ -458,7 +467,15 @@ def execute_plan_sync(
             leaves_persisted += 1
 
         if on_progress is not None:
-            on_progress(leaves_consumed + leaves_failed, total)
+            try:
+                on_progress(leaves_consumed + leaves_failed, total)
+            except Exception as _exc:
+                logger.warning(
+                    "on_progress callback raised — ref[%d]: %s",
+                    i,
+                    _exc,
+                    extra={"plugin": plugin.name, "ref_index": i},
+                )
 
     logger.info(
         "execute_plan_sync finished",

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -16,6 +16,14 @@ condition: when any expander raises it, the run is aborted immediately
 and the exception propagates to the caller. The caller must treat it as
 "not yet ready" and schedule a retry on the next run — it is never
 silently swallowed or converted into a partial result.
+
+The plan/execute split (v0.3):
+  ``plan_crawl_sync`` runs Phase 1 only and returns a ``CrawlPlan``.
+  ``execute_plan_sync`` runs Phase 3 against an existing plan.
+  ``run_crawl`` remains a self-contained Phase 1+3 entry point with the
+  original ``on_leaf(leaf_record, parent_record)`` contract.
+  ``execute_plan_sync``'s ``on_leaf`` receives ``(leaf_record, leaf_ref)``
+  per ADR-011 — different from ``run_crawl``'s contract.
 """
 
 from __future__ import annotations
@@ -34,6 +42,37 @@ from ladon.plugins.errors import (
 from ladon.plugins.protocol import CrawlPlugin
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CrawlPlan:
+    """Immutable output of ``plan_crawl_sync()`` / ``plan_crawl()``.
+
+    Carries the top-level record, all leaf refs collected during Phase 1
+    tree traversal, and any branch errors that occurred.  Use
+    ``excluding()`` and ``limited_to()`` to derive filtered variants
+    before passing to ``execute_plan_sync()`` / ``execute_plan()``.
+    """
+
+    record: object
+    leaves: tuple[object, ...]
+    errors: tuple[str, ...]
+
+    def excluding(self, predicate: Callable[[object], bool]) -> CrawlPlan:
+        """Return a new plan with leaves for which predicate is True removed."""
+        return CrawlPlan(
+            record=self.record,
+            leaves=tuple(ref for ref in self.leaves if not predicate(ref)),
+            errors=self.errors,
+        )
+
+    def limited_to(self, n: int) -> CrawlPlan:
+        """Return a new plan capped at the first n leaves."""
+        return CrawlPlan(
+            record=self.record,
+            leaves=self.leaves[:n],
+            errors=self.errors,
+        )
 
 
 @dataclass(frozen=True)
@@ -250,6 +289,154 @@ def run_crawl(
 
     return RunResult(
         record=top_record,
+        leaves_consumed=leaves_consumed,
+        leaves_persisted=leaves_persisted,
+        leaves_failed=leaves_failed,
+        errors=tuple(errors),
+    )
+
+
+def plan_crawl_sync(
+    top_ref: object,
+    plugin: CrawlPlugin,
+    client: HttpClient,
+) -> CrawlPlan:
+    """Run Phase 1 (tree traversal) synchronously and return a CrawlPlan.
+
+    Traverses all expanders in order and collects every leaf ref.  Does not
+    call the sink.  Branch failures are recorded in ``CrawlPlan.errors``.
+
+    Raises:
+        ExpansionNotReadyError:     Any expander raised this — run is globally
+                                    premature; caller should retry later.
+        PartialExpansionError:      Raised only from the first expander.
+        ChildListUnavailableError:  Raised only from the first expander.
+        ValueError:                 Plugin has no expanders configured.
+    """
+    if not plugin.expanders:
+        raise ValueError(
+            f"CrawlPlugin '{plugin.name}' has no expanders configured"
+        )
+
+    errors: list[str] = []
+
+    first_expansion = plugin.expanders[0].expand(top_ref, client)
+    top_record: object = first_expansion.record
+    current_refs: list[object] = list(first_expansion.child_refs)
+
+    for expander in plugin.expanders[1:]:
+        next_refs: list[object] = []
+        for ref in current_refs:
+            try:
+                expansion = expander.expand(ref, client)
+            except ExpansionNotReadyError:
+                raise
+            except (PartialExpansionError, ChildListUnavailableError) as exc:
+                errors.append(f"expander branch '{ref}': {exc}")
+                logger.warning(
+                    "expander branch failed",
+                    extra={
+                        "ref": str(ref),
+                        "error": str(exc),
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                continue
+            next_refs.extend(expansion.child_refs)
+        current_refs = next_refs
+
+    logger.info(
+        "plan_crawl_sync finished",
+        extra={"plugin": plugin.name, "leaf_count": len(current_refs)},
+    )
+    return CrawlPlan(
+        record=top_record,
+        leaves=tuple(current_refs),
+        errors=tuple(errors),
+    )
+
+
+def execute_plan_sync(
+    plan: CrawlPlan,
+    plugin: CrawlPlugin,
+    client: HttpClient,
+    config: RunConfig,
+    on_leaf: Callable[[object, object], None] | None = None,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> RunResult:
+    """Run Phase 3 (leaf fetching) against an existing CrawlPlan.
+
+    Args:
+        plan:        Plan produced by ``plan_crawl_sync()``.
+        plugin:      Crawl plugin whose sink consumes each leaf.
+        client:      Configured HttpClient instance.
+        config:      Run-level configuration (leaf_limit; async_concurrency ignored).
+        on_leaf:     Optional callback receiving ``(leaf_record, leaf_ref)``
+                     after each successful consume.  Note: second argument is the
+                     **leaf ref**, not a parent record (see ADR-011).
+        on_progress: Optional callback receiving ``(leaves_done, total_leaves)``
+                     after each leaf attempt (success or failure).
+
+    Returns:
+        RunResult with counts and any per-leaf error messages.  Phase 1
+        errors from the plan are carried forward into ``RunResult.errors``.
+    """
+    leaves = plan.leaves
+    if config.leaf_limit > 0:
+        leaves = leaves[: config.leaf_limit]
+
+    total = len(leaves)
+    leaves_consumed = 0
+    leaves_persisted = 0
+    leaves_failed = 0
+    errors: list[str] = list(plan.errors)
+
+    for i, leaf_ref in enumerate(leaves):
+        try:
+            leaf_record = plugin.sink.consume(leaf_ref, client)
+        except LeafUnavailableError as exc:
+            leaves_failed += 1
+            errors.append(f"ref[{i}] consume failed: {exc}")
+            logger.warning(
+                "leaf unavailable — ref[%d] error=%s",
+                i,
+                exc,
+                extra={"ref_index": i, "error": str(exc)},
+            )
+            if on_progress is not None:
+                on_progress(leaves_consumed + leaves_failed, total)
+            continue
+
+        leaves_consumed += 1
+
+        if on_leaf is not None:
+            try:
+                on_leaf(leaf_record, leaf_ref)
+                leaves_persisted += 1
+            except Exception as exc:
+                errors.append(f"ref[{i}] callback failed: {exc}")
+                logger.warning(
+                    "on_leaf callback failed — ref[%d] error=%s",
+                    i,
+                    exc,
+                    extra={"ref_index": i, "error": str(exc)},
+                )
+        else:
+            leaves_persisted += 1
+
+        if on_progress is not None:
+            on_progress(leaves_consumed + leaves_failed, total)
+
+    logger.info(
+        "execute_plan_sync finished",
+        extra={
+            "leaves_consumed": leaves_consumed,
+            "leaves_persisted": leaves_persisted,
+            "leaves_failed": leaves_failed,
+        },
+    )
+    return RunResult(
+        record=plan.record,
         leaves_consumed=leaves_consumed,
         leaves_persisted=leaves_persisted,
         leaves_failed=leaves_failed,

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -67,7 +67,17 @@ class CrawlPlan:
         )
 
     def limited_to(self, n: int) -> CrawlPlan:
-        """Return a new plan capped at the first n leaves."""
+        """Return a new plan capped at the first n leaves.
+
+        ``n`` must be a positive integer.  ``0`` is not equivalent to
+        "no limit" — it produces an empty plan.  To apply no cap, simply
+        do not call ``limited_to()``.
+        """
+        if n <= 0:
+            raise ValueError(
+                f"limited_to() requires a positive integer; got {n}. "
+                "To apply no cap, don't call limited_to()."
+            )
         return CrawlPlan(
             record=self.record,
             leaves=self.leaves[:n],
@@ -318,6 +328,11 @@ def plan_crawl_sync(
             f"CrawlPlugin '{plugin.name}' has no expanders configured"
         )
 
+    logger.info(
+        "plan_crawl_sync started",
+        extra={"plugin": plugin.name, "ref": str(top_ref)},
+    )
+
     errors: list[str] = []
 
     first_expansion = plugin.expanders[0].expand(top_ref, client)
@@ -336,6 +351,7 @@ def plan_crawl_sync(
                 logger.warning(
                     "expander branch failed",
                     extra={
+                        "plugin": plugin.name,
                         "ref": str(ref),
                         "error": str(exc),
                         "error_type": type(exc).__name__,
@@ -386,6 +402,12 @@ def execute_plan_sync(
         leaves = leaves[: config.leaf_limit]
 
     total = len(leaves)
+
+    logger.info(
+        "execute_plan_sync started",
+        extra={"plugin": plugin.name, "total_leaves": total},
+    )
+
     leaves_consumed = 0
     leaves_persisted = 0
     leaves_failed = 0
@@ -401,7 +423,11 @@ def execute_plan_sync(
                 "leaf unavailable — ref[%d] error=%s",
                 i,
                 exc,
-                extra={"ref_index": i, "error": str(exc)},
+                extra={
+                    "plugin": plugin.name,
+                    "ref_index": i,
+                    "error": str(exc),
+                },
             )
             if on_progress is not None:
                 on_progress(leaves_consumed + leaves_failed, total)
@@ -419,7 +445,11 @@ def execute_plan_sync(
                     "on_leaf callback failed — ref[%d] error=%s",
                     i,
                     exc,
-                    extra={"ref_index": i, "error": str(exc)},
+                    extra={
+                        "plugin": plugin.name,
+                        "ref_index": i,
+                        "error": str(exc),
+                    },
                 )
         else:
             leaves_persisted += 1
@@ -430,6 +460,7 @@ def execute_plan_sync(
     logger.info(
         "execute_plan_sync finished",
         extra={
+            "plugin": plugin.name,
             "leaves_consumed": leaves_consumed,
             "leaves_persisted": leaves_persisted,
             "leaves_failed": leaves_failed,

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -108,7 +108,7 @@ class RunConfig:
 
 @dataclass(frozen=True)
 class RunResult:
-    """Outcome of a single run_crawl() call.
+    """Outcome of a crawl run — returned by run_crawl(), execute_plan_sync(), and execute_plan().
 
     ``leaves_consumed`` counts leaves for which ``sink.consume()`` succeeded,
     regardless of whether the ``on_leaf`` callback also succeeded.
@@ -315,6 +315,9 @@ def plan_crawl_sync(
 
     Traverses all expanders in order and collects every leaf ref.  Does not
     call the sink.  Branch failures are recorded in ``CrawlPlan.errors``.
+
+    Note: unlike ``run_crawl``, this function does not accept a ``config``
+    argument — Phase 1 (tree traversal) has no configurable parameters.
 
     Raises:
         ExpansionNotReadyError:     Any expander raised this — run is globally

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -121,6 +121,24 @@ class TestMultiSourceSinkLoop:
         assert data == b"DATA_B"
         assert src is s2
 
+    def test_skips_empty_bytes_and_tries_next(self) -> None:
+        """b'' is treated identically to None — not a valid result."""
+        s1 = _SimpleSource("a", b"")
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data == b"DATA_B"
+        assert src is s2
+
+    def test_all_empty_bytes_returns_none_none(self) -> None:
+        """All sources returning b'' is equivalent to all returning None."""
+        s1 = _SimpleSource("a", b"")
+        s2 = _SimpleSource("b", b"")
+        sink = _SimpleSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data is None
+        assert src is None
+
     def test_should_try_source_false_skips_source(self) -> None:
         class _SkippingSink(_SimpleSink):
             def _should_try_source(
@@ -182,32 +200,35 @@ class TestMultiSourceSinkPredicates:
         assert s2.calls == 0
 
     def test_multiple_predicates_all_must_pass(self) -> None:
-        """Loop continues to next source until ALL predicates pass.
+        """Loop continues until BOTH predicates pass — partial pass is not enough.
 
-        Source A passes _MinLengthPredicate but fails _PassOnlyB.
-        Source B passes both — it must be the accepted result, proving that
-        a partial predicate pass is not enough to stop the loop.
+        Source A: 8 bytes — passes _MinLengthPredicate(5) but fails _PassOnlyB.
+        Source B: 8 bytes — passes both predicates.
+
+        If the loop stopped on the first predicate passing, source A would be
+        accepted (MinLength passes).  The correct behaviour is to continue to
+        source B where ALL predicates pass.
         """
 
         class _PassOnlyB:
             def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
                 return data == b"source_b"
 
-        s1 = _SimpleSource("a", b"source_a")
-        s2 = _SimpleSource("b", b"source_b")
+        s1 = _SimpleSource(
+            "a", b"source_a"
+        )  # 8 bytes — passes MinLength, fails PassOnlyB
+        s2 = _SimpleSource("b", b"source_b")  # 8 bytes — passes both
         sink = _SimpleSink(
             sources=[s1, s2],
-            predicates=[_PassOnlyB()],
+            predicates=[_MinLengthPredicate(5), _PassOnlyB()],
         )
         data, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s2
         assert data == b"source_b"
         assert (
             s1.calls == 1
-        )  # source A was tried (predicate failed — loop continued)
-        assert (
-            s2.calls == 1
-        )  # source B accepted (predicate passed — loop stopped)
+        )  # tried — MinLength passed, PassOnlyB failed → continued
+        assert s2.calls == 1  # tried — both predicates passed → accepted
 
     def test_no_predicates_stops_at_first_result(self) -> None:
         s1 = _SimpleSource("a", b"DATA_A")
@@ -262,6 +283,33 @@ class TestMultiSourceSinkContract:
         # Mutating the returned list must not affect the sink's internal list.
         exposed.clear()
         assert sink.sources == [s1, s2]
+
+    def test_is_better_candidate_always_false_returns_none_none(self) -> None:
+        """_is_better_candidate returning False forever prevents best-seen update.
+
+        Documented in the _is_better_candidate docstring warning: the caller
+        cannot distinguish this from all sources returning no data.
+        """
+
+        class _NeverBetterSink(_SimpleSink):
+            def _is_better_candidate(
+                self,
+                data: bytes,  # noqa: ARG002
+                source: _SimpleSource,  # noqa: ARG002
+                best_data: bytes | None,  # noqa: ARG002
+                best_source: _SimpleSource | None,  # noqa: ARG002
+                ref: Ref,  # noqa: ARG002
+            ) -> bool:
+                return False
+
+        s1 = _SimpleSource("a", b"DATA_A")
+        sink = _NeverBetterSink(
+            sources=[s1],
+            predicates=[_MinLengthPredicate(999)],  # forces fallback path
+        )
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data is None  # best never updated despite source producing data
+        assert src is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -342,6 +342,19 @@ class TestMultiSourceSinkContract:
         sink.resolve_multi(_ref(), MagicMock())
         assert s_late.calls == 0  # never tried — mutation happened after copy
 
+    def test_sources_property_returns_copy(self) -> None:
+        """sources property reflects the configured list; mutations don't affect the sink."""
+        s1 = _SimpleSource("a", b"DATA_A")
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])
+
+        exposed = sink.sources
+        assert exposed == [s1, s2]
+
+        # Mutating the returned list must not affect the sink's internal list.
+        exposed.clear()
+        assert sink.sources == [s1, s2]
+
 
 # ---------------------------------------------------------------------------
 # FetchPredicate — structural subtyping and runtime check

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -1,0 +1,311 @@
+"""Tests for ladon.plugins.resolution — MultiSourceSink and FetchPredicate."""
+
+from __future__ import annotations
+
+import struct
+from unittest.mock import MagicMock
+
+from ladon.plugins.models import Ref
+from ladon.plugins.resolution import (
+    FetchPredicate,
+    MinWidthPredicate,
+    MultiSourceSink,
+    image_width,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal synthetic image bytes (no external library required)
+# ---------------------------------------------------------------------------
+
+
+def _make_png(width: int, height: int) -> bytes:
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr_data = struct.pack(">II", width, height) + b"\x08\x02\x00\x00\x00"
+    ihdr_len = struct.pack(">I", len(ihdr_data))
+    return sig + ihdr_len + b"IHDR" + ihdr_data
+
+
+def _make_jpeg(width: int, height: int) -> bytes:
+    soi = b"\xff\xd8"
+    app0 = (
+        b"\xff\xe0"
+        + b"\x00\x10"
+        + b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    )
+    sof0 = (
+        b"\xff\xc0"
+        + struct.pack(">H", 17)
+        + b"\x08"
+        + struct.pack(">HH", height, width)
+        + b"\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
+    )
+    return soi + app0 + sof0
+
+
+def _make_jpeg_with_exif(width: int, height: int) -> bytes:
+    soi = b"\xff\xd8"
+    app0 = (
+        b"\xff\xe0"
+        + b"\x00\x10"
+        + b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    )
+    exif_payload = b"Exif\x00\x00" + b"\x00" * 14
+    app1 = b"\xff\xe1" + struct.pack(">H", 2 + len(exif_payload)) + exif_payload
+    sof0 = (
+        b"\xff\xc0"
+        + struct.pack(">H", 17)
+        + b"\x08"
+        + struct.pack(">HH", height, width)
+        + b"\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
+    )
+    return soi + app0 + app1 + sof0
+
+
+def _ref(url: str = "https://example.com/1") -> Ref:
+    return Ref(url=url)
+
+
+# ---------------------------------------------------------------------------
+# image_width
+# ---------------------------------------------------------------------------
+
+
+class TestImageWidth:
+    def test_jpeg_width_parsed(self) -> None:
+        assert image_width(_make_jpeg(380, 500)) == 380
+
+    def test_png_width_parsed(self) -> None:
+        assert image_width(_make_png(1200, 1600)) == 1200
+
+    def test_unknown_format_returns_zero(self) -> None:
+        assert image_width(b"NOTANIMAGE") == 0
+
+    def test_truncated_data_returns_zero(self) -> None:
+        assert image_width(b"\xff\xd8\xff") == 0
+
+    def test_png_too_short_returns_zero(self) -> None:
+        assert image_width(b"\x89PNG\r\n\x1a\n\x00\x00") == 0
+
+    def test_jpeg_with_multiple_app_segments(self) -> None:
+        assert image_width(_make_jpeg_with_exif(1024, 768)) == 1024
+
+
+# ---------------------------------------------------------------------------
+# MinWidthPredicate
+# ---------------------------------------------------------------------------
+
+
+class TestMinWidthPredicate:
+    def test_accepts_image_at_threshold(self) -> None:
+        p = MinWidthPredicate(300)
+        assert p.accepts(_make_jpeg(300, 400), _ref()) is True
+
+    def test_accepts_image_above_threshold(self) -> None:
+        p = MinWidthPredicate(300)
+        assert p.accepts(_make_jpeg(600, 800), _ref()) is True
+
+    def test_rejects_image_below_threshold(self) -> None:
+        p = MinWidthPredicate(300)
+        assert p.accepts(_make_jpeg(250, 350), _ref()) is False
+
+    def test_zero_min_always_accepts(self) -> None:
+        p = MinWidthPredicate(0)
+        assert p.accepts(b"anything", _ref()) is True
+
+    def test_ref_is_not_required_for_decision(self) -> None:
+        """The predicate ignores the ref — only data matters."""
+        p = MinWidthPredicate(100)
+        assert (
+            p.accepts(_make_jpeg(200, 300), _ref("https://irrelevant.com"))
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Concrete MultiSourceSink for testing
+# ---------------------------------------------------------------------------
+
+
+class _SimpleSource:
+    """Minimal source stub: returns fixed bytes or None."""
+
+    def __init__(self, name: str, data: bytes | None) -> None:
+        self.name = name
+        self._data = data
+        self.calls: int = 0
+
+    def fetch(self) -> bytes | None:
+        self.calls += 1
+        return self._data
+
+
+class _SimpleSink(MultiSourceSink):
+    """Concrete MultiSourceSink for tests — sources have a plain .fetch() interface."""
+
+    def _fetch_from_source(
+        self, source: _SimpleSource, ref: Ref, client: object  # noqa: ARG002
+    ) -> bytes | None:
+        return source.fetch()
+
+
+class _WidthRankingSink(MultiSourceSink):
+    """Sink that prefers wider images as fallback."""
+
+    def __init__(self, sources: list[_SimpleSource], min_px: int) -> None:
+        super().__init__(sources, [MinWidthPredicate(min_px)])
+        self._min_px = min_px
+
+    def _fetch_from_source(
+        self, source: _SimpleSource, ref: Ref, client: object  # noqa: ARG002
+    ) -> bytes | None:
+        return source.fetch()
+
+    def _is_better_candidate(
+        self,
+        data: bytes,
+        source: _SimpleSource,
+        best_data: bytes | None,
+        best_source: _SimpleSource | None,
+        ref: Ref,  # noqa: ARG002
+    ) -> bool:
+        if best_source is None:
+            return True
+        return image_width(data) > image_width(best_data or b"")
+
+
+# ---------------------------------------------------------------------------
+# MultiSourceSink — loop mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSourceSinkLoop:
+    def test_returns_none_none_when_no_sources(self) -> None:
+        sink = _SimpleSink(sources=[], predicates=[])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data is None
+        assert src is None
+
+    def test_returns_none_none_when_all_sources_fail(self) -> None:
+        sources = [_SimpleSource("a", None), _SimpleSource("b", None)]
+        sink = _SimpleSink(sources=sources)
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data is None
+        assert src is None
+
+    def test_returns_first_result_when_no_predicates(self) -> None:
+        s1 = _SimpleSource("a", b"DATA_A")
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data == b"DATA_A"
+        assert src is s1
+        assert s2.calls == 0  # stopped at first
+
+    def test_skips_none_results_and_tries_next(self) -> None:
+        s1 = _SimpleSource("a", None)
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data == b"DATA_B"
+        assert src is s2
+
+    def test_should_try_source_false_skips_source(self) -> None:
+        class _SkippingSink(_SimpleSink):
+            def _should_try_source(
+                self, source: _SimpleSource, ref: Ref  # noqa: ARG002
+            ) -> bool:
+                return source.name != "skip_me"
+
+        s1 = _SimpleSource("skip_me", b"SKIPPED")
+        s2 = _SimpleSource("keep_me", b"KEPT")
+        sink = _SkippingSink(sources=[s1, s2])
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert data == b"KEPT"
+        assert src is s2
+        assert s1.calls == 0
+
+    def test_fetch_not_called_on_skipped_source(self) -> None:
+        class _AllSkip(_SimpleSink):
+            def _should_try_source(
+                self, source: _SimpleSource, ref: Ref  # noqa: ARG002
+            ) -> bool:
+                return False
+
+        s = _SimpleSource("a", b"DATA")
+        sink = _AllSkip(sources=[s])
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is None
+        assert s.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# MultiSourceSink — predicate integration
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSourceSinkPredicates:
+    def test_stops_when_predicate_passes(self) -> None:
+        s1 = _SimpleSource("narrow", _make_jpeg(250, 350))
+        s2 = _SimpleSource("wide", _make_jpeg(600, 800))
+        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s2
+        assert image_width(data or b"") == 600
+
+    def test_falls_back_to_best_when_no_source_passes(self) -> None:
+        """Both sources below threshold — best (widest) fallback returned."""
+        s1 = _SimpleSource("a", _make_jpeg(200, 300))
+        s2 = _SimpleSource("b", _make_jpeg(280, 400))
+        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s2
+        assert image_width(data or b"") == 280
+
+    def test_accepts_first_source_when_it_clears_threshold(self) -> None:
+        s1 = _SimpleSource("a", _make_jpeg(400, 600))
+        s2 = _SimpleSource("b", _make_jpeg(600, 800))
+        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s1  # stopped at first accepted
+        assert s2.calls == 0
+
+    def test_multiple_predicates_all_must_pass(self) -> None:
+        class _AlwaysFail:
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                return False
+
+        s = _SimpleSource("a", _make_jpeg(600, 800))
+        sink = _SimpleSink(
+            sources=[s],
+            predicates=[MinWidthPredicate(300), _AlwaysFail()],
+        )
+        # MinWidthPredicate passes but _AlwaysFail blocks — result kept as fallback
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s
+
+    def test_no_predicates_stops_at_first_result(self) -> None:
+        s1 = _SimpleSource("a", _make_jpeg(100, 150))
+        s2 = _SimpleSource("b", _make_jpeg(600, 800))
+        sink = _SimpleSink(sources=[s1, s2], predicates=[])
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s1
+        assert s2.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# FetchPredicate — structural subtyping check
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPredicateProtocol:
+    def test_min_width_predicate_satisfies_protocol(self) -> None:
+        p: FetchPredicate = MinWidthPredicate(300)
+        assert p.accepts(_make_jpeg(400, 500), _ref()) is True
+
+    def test_custom_predicate_satisfies_protocol(self) -> None:
+        class _Always:
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                return True
+
+        p: FetchPredicate = _Always()
+        assert p.accepts(b"anything", _ref()) is True

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -1,9 +1,13 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+# pyright: reportUnknownArgumentType=false, reportArgumentType=false
 """Tests for ladon.plugins.resolution — MultiSourceSink and FetchPredicate."""
 
 from __future__ import annotations
 
 import struct
 from unittest.mock import MagicMock
+
+import pytest
 
 from ladon.plugins.models import Ref
 from ladon.plugins.resolution import (
@@ -270,18 +274,32 @@ class TestMultiSourceSinkPredicates:
         assert s2.calls == 0
 
     def test_multiple_predicates_all_must_pass(self) -> None:
-        class _AlwaysFail:
-            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
-                return False
+        """Loop continues to next source until ALL predicates pass.
 
-        s = _SimpleSource("a", _make_jpeg(600, 800))
+        Source A passes MinWidthPredicate but fails _PassOnlyB.
+        Source B passes both — it must be the accepted result, proving that
+        a partial predicate pass is not enough to stop the loop.
+        """
+
+        class _PassOnlyB:
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                return data == b"source_b"
+
+        s1 = _SimpleSource("a", b"source_a")
+        s2 = _SimpleSource("b", b"source_b")
         sink = _SimpleSink(
-            sources=[s],
-            predicates=[MinWidthPredicate(300), _AlwaysFail()],
+            sources=[s1, s2],
+            predicates=[_PassOnlyB()],
         )
-        # MinWidthPredicate passes but _AlwaysFail blocks — result kept as fallback
-        _, src = sink.resolve_multi(_ref(), MagicMock())
-        assert src is s
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s2
+        assert data == b"source_b"
+        assert (
+            s1.calls == 1
+        )  # source A was tried (predicate failed — loop continued)
+        assert (
+            s2.calls == 1
+        )  # source B accepted (predicate passed — loop stopped)
 
     def test_no_predicates_stops_at_first_result(self) -> None:
         s1 = _SimpleSource("a", _make_jpeg(100, 150))
@@ -293,7 +311,40 @@ class TestMultiSourceSinkPredicates:
 
 
 # ---------------------------------------------------------------------------
-# FetchPredicate — structural subtyping check
+# MultiSourceSink — abstract method contract
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSourceSinkContract:
+    def test_fetch_from_source_raises_not_implemented(self) -> None:
+        """Bare MultiSourceSink raises NotImplementedError — subclasses must override."""
+        sink = MultiSourceSink(sources=[_SimpleSource("a", b"DATA")])
+        with pytest.raises(
+            NotImplementedError, match="must implement _fetch_from_source"
+        ):
+            sink.resolve_multi(_ref(), MagicMock())
+
+    def test_default_no_predicates_stops_at_first_result(self) -> None:
+        """When no predicates are configured the loop stops at the first result."""
+        s1 = _SimpleSource("a", b"DATA_A")
+        s2 = _SimpleSource("b", b"DATA_B")
+        sink = _SimpleSink(sources=[s1, s2])  # no predicates= arg
+        _, src = sink.resolve_multi(_ref(), MagicMock())
+        assert src is s1
+        assert s2.calls == 0
+
+    def test_sources_copied_not_aliased(self) -> None:
+        """Mutating the source list after construction must not affect the sink."""
+        s_late = _SimpleSource("late", b"X")
+        src_list: list[_SimpleSource] = []
+        sink = _SimpleSink(sources=src_list)
+        src_list.append(s_late)
+        sink.resolve_multi(_ref(), MagicMock())
+        assert s_late.calls == 0  # never tried — mutation happened after copy
+
+
+# ---------------------------------------------------------------------------
+# FetchPredicate — structural subtyping and runtime check
 # ---------------------------------------------------------------------------
 
 
@@ -309,3 +360,12 @@ class TestFetchPredicateProtocol:
 
         p: FetchPredicate = _Always()
         assert p.accepts(b"anything", _ref()) is True
+
+    def test_runtime_checkable_isinstance(self) -> None:
+        """FetchPredicate is @runtime_checkable — isinstance works on instances."""
+        p = MinWidthPredicate(300)
+        assert isinstance(p, FetchPredicate)
+
+    def test_runtime_checkable_rejects_non_protocol(self) -> None:
+        assert not isinstance("not a predicate", FetchPredicate)
+        assert not isinstance(42, FetchPredicate)

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import struct
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,57 +11,8 @@ import pytest
 from ladon.plugins.models import Ref
 from ladon.plugins.resolution import (
     FetchPredicate,
-    MinWidthPredicate,
     MultiSourceSink,
-    image_width,
 )
-
-# ---------------------------------------------------------------------------
-# Minimal synthetic image bytes (no external library required)
-# ---------------------------------------------------------------------------
-
-
-def _make_png(width: int, height: int) -> bytes:
-    sig = b"\x89PNG\r\n\x1a\n"
-    ihdr_data = struct.pack(">II", width, height) + b"\x08\x02\x00\x00\x00"
-    ihdr_len = struct.pack(">I", len(ihdr_data))
-    return sig + ihdr_len + b"IHDR" + ihdr_data
-
-
-def _make_jpeg(width: int, height: int) -> bytes:
-    soi = b"\xff\xd8"
-    app0 = (
-        b"\xff\xe0"
-        + b"\x00\x10"
-        + b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
-    )
-    sof0 = (
-        b"\xff\xc0"
-        + struct.pack(">H", 17)
-        + b"\x08"
-        + struct.pack(">HH", height, width)
-        + b"\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
-    )
-    return soi + app0 + sof0
-
-
-def _make_jpeg_with_exif(width: int, height: int) -> bytes:
-    soi = b"\xff\xd8"
-    app0 = (
-        b"\xff\xe0"
-        + b"\x00\x10"
-        + b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
-    )
-    exif_payload = b"Exif\x00\x00" + b"\x00" * 14
-    app1 = b"\xff\xe1" + struct.pack(">H", 2 + len(exif_payload)) + exif_payload
-    sof0 = (
-        b"\xff\xc0"
-        + struct.pack(">H", 17)
-        + b"\x08"
-        + struct.pack(">HH", height, width)
-        + b"\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
-    )
-    return soi + app0 + app1 + sof0
 
 
 def _ref(url: str = "https://example.com/1") -> Ref:
@@ -70,59 +20,18 @@ def _ref(url: str = "https://example.com/1") -> Ref:
 
 
 # ---------------------------------------------------------------------------
-# image_width
+# Domain-agnostic predicate for tests (avoids image-specific imports)
 # ---------------------------------------------------------------------------
 
 
-class TestImageWidth:
-    def test_jpeg_width_parsed(self) -> None:
-        assert image_width(_make_jpeg(380, 500)) == 380
+class _MinLengthPredicate:
+    """Accept data only if its byte length meets a minimum."""
 
-    def test_png_width_parsed(self) -> None:
-        assert image_width(_make_png(1200, 1600)) == 1200
+    def __init__(self, min_len: int) -> None:
+        self._min_len = min_len
 
-    def test_unknown_format_returns_zero(self) -> None:
-        assert image_width(b"NOTANIMAGE") == 0
-
-    def test_truncated_data_returns_zero(self) -> None:
-        assert image_width(b"\xff\xd8\xff") == 0
-
-    def test_png_too_short_returns_zero(self) -> None:
-        assert image_width(b"\x89PNG\r\n\x1a\n\x00\x00") == 0
-
-    def test_jpeg_with_multiple_app_segments(self) -> None:
-        assert image_width(_make_jpeg_with_exif(1024, 768)) == 1024
-
-
-# ---------------------------------------------------------------------------
-# MinWidthPredicate
-# ---------------------------------------------------------------------------
-
-
-class TestMinWidthPredicate:
-    def test_accepts_image_at_threshold(self) -> None:
-        p = MinWidthPredicate(300)
-        assert p.accepts(_make_jpeg(300, 400), _ref()) is True
-
-    def test_accepts_image_above_threshold(self) -> None:
-        p = MinWidthPredicate(300)
-        assert p.accepts(_make_jpeg(600, 800), _ref()) is True
-
-    def test_rejects_image_below_threshold(self) -> None:
-        p = MinWidthPredicate(300)
-        assert p.accepts(_make_jpeg(250, 350), _ref()) is False
-
-    def test_zero_min_always_accepts(self) -> None:
-        p = MinWidthPredicate(0)
-        assert p.accepts(b"anything", _ref()) is True
-
-    def test_ref_is_not_required_for_decision(self) -> None:
-        """The predicate ignores the ref — only data matters."""
-        p = MinWidthPredicate(100)
-        assert (
-            p.accepts(_make_jpeg(200, 300), _ref("https://irrelevant.com"))
-            is True
-        )
+    def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+        return len(data) >= self._min_len
 
 
 # ---------------------------------------------------------------------------
@@ -152,12 +61,11 @@ class _SimpleSink(MultiSourceSink):
         return source.fetch()
 
 
-class _WidthRankingSink(MultiSourceSink):
-    """Sink that prefers wider images as fallback."""
+class _LengthRankingSink(MultiSourceSink):
+    """Sink that prefers longer payloads as fallback (domain-agnostic)."""
 
-    def __init__(self, sources: list[_SimpleSource], min_px: int) -> None:
-        super().__init__(sources, [MinWidthPredicate(min_px)])
-        self._min_px = min_px
+    def __init__(self, sources: list[_SimpleSource], min_len: int) -> None:
+        super().__init__(sources, [_MinLengthPredicate(min_len)])
 
     def _fetch_from_source(
         self, source: _SimpleSource, ref: Ref, client: object  # noqa: ARG002
@@ -174,7 +82,7 @@ class _WidthRankingSink(MultiSourceSink):
     ) -> bool:
         if best_source is None:
             return True
-        return image_width(data) > image_width(best_data or b"")
+        return len(data) > len(best_data or b"")
 
 
 # ---------------------------------------------------------------------------
@@ -249,26 +157,26 @@ class TestMultiSourceSinkLoop:
 
 class TestMultiSourceSinkPredicates:
     def test_stops_when_predicate_passes(self) -> None:
-        s1 = _SimpleSource("narrow", _make_jpeg(250, 350))
-        s2 = _SimpleSource("wide", _make_jpeg(600, 800))
-        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        s1 = _SimpleSource("short", b"x" * 5)
+        s2 = _SimpleSource("long", b"x" * 20)
+        sink = _LengthRankingSink(sources=[s1, s2], min_len=10)
         data, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s2
-        assert image_width(data or b"") == 600
+        assert len(data or b"") == 20
 
     def test_falls_back_to_best_when_no_source_passes(self) -> None:
-        """Both sources below threshold — best (widest) fallback returned."""
-        s1 = _SimpleSource("a", _make_jpeg(200, 300))
-        s2 = _SimpleSource("b", _make_jpeg(280, 400))
-        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        """Both sources below threshold — best (longest) fallback returned."""
+        s1 = _SimpleSource("a", b"x" * 4)
+        s2 = _SimpleSource("b", b"x" * 7)
+        sink = _LengthRankingSink(sources=[s1, s2], min_len=10)
         data, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s2
-        assert image_width(data or b"") == 280
+        assert len(data or b"") == 7
 
     def test_accepts_first_source_when_it_clears_threshold(self) -> None:
-        s1 = _SimpleSource("a", _make_jpeg(400, 600))
-        s2 = _SimpleSource("b", _make_jpeg(600, 800))
-        sink = _WidthRankingSink(sources=[s1, s2], min_px=300)
+        s1 = _SimpleSource("a", b"x" * 15)
+        s2 = _SimpleSource("b", b"x" * 20)
+        sink = _LengthRankingSink(sources=[s1, s2], min_len=10)
         _, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s1  # stopped at first accepted
         assert s2.calls == 0
@@ -276,7 +184,7 @@ class TestMultiSourceSinkPredicates:
     def test_multiple_predicates_all_must_pass(self) -> None:
         """Loop continues to next source until ALL predicates pass.
 
-        Source A passes MinWidthPredicate but fails _PassOnlyB.
+        Source A passes _MinLengthPredicate but fails _PassOnlyB.
         Source B passes both — it must be the accepted result, proving that
         a partial predicate pass is not enough to stop the loop.
         """
@@ -302,8 +210,8 @@ class TestMultiSourceSinkPredicates:
         )  # source B accepted (predicate passed — loop stopped)
 
     def test_no_predicates_stops_at_first_result(self) -> None:
-        s1 = _SimpleSource("a", _make_jpeg(100, 150))
-        s2 = _SimpleSource("b", _make_jpeg(600, 800))
+        s1 = _SimpleSource("a", b"DATA_A")
+        s2 = _SimpleSource("b", b"DATA_B")
         sink = _SimpleSink(sources=[s1, s2], predicates=[])
         _, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s1
@@ -362,10 +270,6 @@ class TestMultiSourceSinkContract:
 
 
 class TestFetchPredicateProtocol:
-    def test_min_width_predicate_satisfies_protocol(self) -> None:
-        p: FetchPredicate = MinWidthPredicate(300)
-        assert p.accepts(_make_jpeg(400, 500), _ref()) is True
-
     def test_custom_predicate_satisfies_protocol(self) -> None:
         class _Always:
             def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
@@ -374,9 +278,13 @@ class TestFetchPredicateProtocol:
         p: FetchPredicate = _Always()
         assert p.accepts(b"anything", _ref()) is True
 
+    def test_min_length_predicate_satisfies_protocol(self) -> None:
+        p: FetchPredicate = _MinLengthPredicate(5)
+        assert p.accepts(b"x" * 10, _ref()) is True
+
     def test_runtime_checkable_isinstance(self) -> None:
         """FetchPredicate is @runtime_checkable — isinstance works on instances."""
-        p = MinWidthPredicate(300)
+        p = _MinLengthPredicate(5)
         assert isinstance(p, FetchPredicate)
 
     def test_runtime_checkable_rejects_non_protocol(self) -> None:

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -991,6 +991,40 @@ class TestExecutePlan:
         result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
         assert result.leaves_persisted == result.leaves_consumed
 
+    async def test_empty_plan_returns_zero_result(
+        self, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan
+        from ladon.runner import CrawlPlan
+
+        plan = CrawlPlan(
+            record=_make_record(),
+            leaves=(),
+            errors=("branch err",),
+        )
+        result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert result.leaves_consumed == 0
+        assert result.leaves_persisted == 0
+        assert result.leaves_failed == 0
+        assert result.errors == ("branch err",)
+
+    async def test_empty_plan_on_progress_never_called(
+        self, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan
+        from ladon.runner import CrawlPlan
+
+        plan = CrawlPlan(record=_make_record(), leaves=(), errors=())
+        calls: list[object] = []
+        await execute_plan(
+            plan,
+            plugin,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_progress=lambda d, t: calls.append((d, t)),
+        )
+        assert calls == []
+
     async def test_plan_crawl_then_execute_plan_roundtrip(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import pytest
 
-from ladon.async_runner import async_run_crawl
+from ladon.async_runner import async_run_crawl, execute_plan, plan_crawl
 from ladon.plugins.errors import (
     ChildListUnavailableError,
     ExpansionNotReadyError,
@@ -29,7 +29,7 @@ from ladon.plugins.errors import (
     PartialExpansionError,
 )
 from ladon.plugins.models import Expansion, Ref
-from ladon.runner import RunConfig, RunResult
+from ladon.runner import CrawlPlan, RunConfig, RunResult
 
 # ---------------------------------------------------------------------------
 # Domain-neutral test types
@@ -741,49 +741,36 @@ class TestPlanCrawl:
     async def test_returns_crawl_plan(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import plan_crawl
-        from ladon.runner import CrawlPlan
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         assert isinstance(plan, CrawlPlan)
 
     async def test_leaf_count_matches_expander_output(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         assert len(plan.leaves) == 3
 
     async def test_record_set_from_first_expander(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         assert isinstance(plan.record, _DemoRecord)
 
     async def test_no_errors_on_clean_run(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         assert plan.errors == ()
 
     async def test_empty_plugin_raises_value_error(
         self, top_ref: Ref, child_refs: list[Ref]
     ) -> None:
-        from ladon.async_runner import plan_crawl
-
         p = _MockAsyncPlugin(child_refs)
         p.expanders = []
         with pytest.raises(ValueError, match="no expanders configured"):
             await plan_crawl(top_ref, p, None)  # type: ignore[arg-type]
 
     async def test_expansion_not_ready_propagates(self, top_ref: Ref) -> None:
-        from ladon.async_runner import plan_crawl
-
         class _NotReadyExpander:
             async def expand(self, ref: object, client: object) -> Expansion:
                 raise ExpansionNotReadyError("not ready")
@@ -796,8 +783,6 @@ class TestPlanCrawl:
     async def test_branch_error_on_non_first_expander_is_isolated(
         self, top_ref: Ref
     ) -> None:
-        from ladon.async_runner import plan_crawl
-
         parent_refs = [
             Ref(url="https://demo.example.com/parent/1"),
             Ref(url="https://demo.example.com/parent/2"),
@@ -821,8 +806,6 @@ class TestPlanCrawl:
         assert "branch" in plan.errors[0]
 
     async def test_multi_expander_chain_leaf_count(self, top_ref: Ref) -> None:
-        from ladon.async_runner import plan_crawl
-
         parent_refs = [
             Ref(url="https://demo.example.com/parent/1"),
             Ref(url="https://demo.example.com/parent/2"),
@@ -850,8 +833,6 @@ class TestExecutePlan:
     async def test_returns_run_result(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
         assert isinstance(result, RunResult)
@@ -859,8 +840,6 @@ class TestExecutePlan:
     async def test_all_leaves_consumed(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
         assert result.leaves_consumed == 3
@@ -870,8 +849,6 @@ class TestExecutePlan:
     async def test_record_carried_from_plan(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
         assert result.record is plan.record
@@ -879,8 +856,6 @@ class TestExecutePlan:
     async def test_on_leaf_receives_leaf_record_and_leaf_ref(
         self, top_ref: Ref, plugin: _MockAsyncPlugin, child_refs: list[Ref]
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         calls: list[tuple[object, object]] = []
 
@@ -898,8 +873,6 @@ class TestExecutePlan:
     async def test_leaf_unavailable_counted_as_failed(
         self, top_ref: Ref
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         refs = [
             Ref(url="https://demo.example.com/leaf/1"),
             Ref(url="https://demo.example.com/leaf/2"),
@@ -924,8 +897,6 @@ class TestExecutePlan:
     async def test_on_leaf_callback_failure_counted(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
 
         async def bad_callback(record: object, ref: object) -> None:
@@ -942,8 +913,6 @@ class TestExecutePlan:
     async def test_leaf_limit_applied(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         result = await execute_plan(plan, plugin, None, RunConfig(leaf_limit=2))  # type: ignore[arg-type]
         assert result.leaves_consumed == 2
@@ -951,9 +920,6 @@ class TestExecutePlan:
     async def test_plan_errors_carried_into_result(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan
-        from ladon.runner import CrawlPlan
-
         plan = CrawlPlan(
             record=_make_record(),
             leaves=(Ref(url="https://demo.example.com/leaf/1"),),
@@ -965,8 +931,6 @@ class TestExecutePlan:
     async def test_on_progress_called_after_each_leaf(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         progress_calls: list[tuple[int, int]] = []
 
@@ -984,8 +948,6 @@ class TestExecutePlan:
     async def test_no_on_leaf_leaves_persisted_equals_consumed(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
         assert result.leaves_persisted == result.leaves_consumed
@@ -993,9 +955,6 @@ class TestExecutePlan:
     async def test_empty_plan_returns_zero_result(
         self, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan
-        from ladon.runner import CrawlPlan
-
         plan = CrawlPlan(
             record=_make_record(),
             leaves=(),
@@ -1010,9 +969,6 @@ class TestExecutePlan:
     async def test_empty_plan_on_progress_never_called(
         self, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan
-        from ladon.runner import CrawlPlan
-
         plan = CrawlPlan(record=_make_record(), leaves=(), errors=())
         calls: list[object] = []
         await execute_plan(
@@ -1027,8 +983,6 @@ class TestExecutePlan:
     async def test_plan_crawl_then_execute_plan_roundtrip(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
-        from ladon.async_runner import execute_plan, plan_crawl
-
         plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
         filtered = plan.excluding(lambda r: r.url.endswith("/2"))  # type: ignore[union-attr]
         result = await execute_plan(filtered, plugin, None, RunConfig())  # type: ignore[arg-type]
@@ -1038,8 +992,6 @@ class TestExecutePlan:
         self, top_ref: Ref
     ) -> None:
         """BaseException escaping _process_leaf must still trigger on_progress."""
-        from ladon.async_runner import execute_plan
-        from ladon.runner import CrawlPlan
 
         class _ExplodingSink:
             async def consume(self, ref: object, client: object) -> object:
@@ -1067,10 +1019,22 @@ class TestExecutePlan:
         assert len(progress_calls) == 1
         assert progress_calls[0] == (1, 1)
 
+    async def test_on_progress_exception_is_swallowed(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+
+        def exploding_progress(done: int, total: int) -> None:
+            raise RuntimeError("progress bar closed")
+
+        result = await execute_plan(
+            plan, plugin, None, RunConfig(), on_progress=exploding_progress  # type: ignore[arg-type]
+        )
+        assert result.leaves_consumed == 3
+
     async def test_plan_importable_from_ladon(self) -> None:
         from ladon import execute_plan as _ep
         from ladon import plan_crawl as _pc
-        from ladon.async_runner import execute_plan, plan_crawl
 
         assert _pc is plan_crawl
         assert _ep is execute_plan

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -1,7 +1,6 @@
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
 # pyright: reportUnknownArgumentType=false, reportArgumentType=false
 # pyright: reportUnknownParameterType=false, reportMissingParameterType=false
-# pyright: reportArgumentType=false
 """Contract tests for async_run_crawl().
 
 Async mocks are plain classes with async methods — no inheritance from

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -1001,6 +1001,39 @@ class TestExecutePlan:
         result = await execute_plan(filtered, plugin, None, RunConfig())  # type: ignore[arg-type]
         assert result.leaves_consumed == 2
 
+    async def test_on_progress_fired_for_base_exception_leaves(
+        self, top_ref: Ref
+    ) -> None:
+        """BaseException escaping _process_leaf must still trigger on_progress."""
+        from ladon.async_runner import execute_plan
+        from ladon.runner import CrawlPlan
+
+        class _ExplodingSink:
+            async def consume(self, ref: object, client: object) -> object:
+                raise RuntimeError("unexpected kaboom")
+
+        p = _MockAsyncPlugin([Ref(url="https://demo.example.com/leaf/1")])
+        p.sink = _ExplodingSink()
+        plan = CrawlPlan(
+            record=_make_record(),
+            leaves=(Ref(url="https://demo.example.com/leaf/1"),),
+            errors=(),
+        )
+        progress_calls: list[tuple[int, int]] = []
+        result = await execute_plan(
+            plan,
+            p,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_progress=lambda d, t: progress_calls.append((d, t)),
+        )
+        # The RuntimeError is not LeafUnavailableError, so it escapes
+        # _process_leaf and is caught by gather(return_exceptions=True).
+        # on_progress must still fire so callers can reach total.
+        assert result.leaves_failed == 1
+        assert len(progress_calls) == 1
+        assert progress_calls[0] == (1, 1)
+
     async def test_plan_importable_from_ladon(self) -> None:
         from ladon import execute_plan as _ep
         from ladon import plan_crawl as _pc

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -731,3 +731,280 @@ class TestTopLevelExports:
         from ladon.networking.async_client import AsyncHttpClient as _AHC
 
         assert AsyncHttpClient is _AHC
+
+
+# ---------------------------------------------------------------------------
+# plan_crawl — Phase 1 only (async)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanCrawl:
+    async def test_returns_crawl_plan(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import plan_crawl
+        from ladon.runner import CrawlPlan
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        assert isinstance(plan, CrawlPlan)
+
+    async def test_leaf_count_matches_expander_output(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        assert len(plan.leaves) == 3
+
+    async def test_record_set_from_first_expander(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        assert isinstance(plan.record, _DemoRecord)
+
+    async def test_no_errors_on_clean_run(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        assert plan.errors == ()
+
+    async def test_empty_plugin_raises_value_error(
+        self, top_ref: Ref, child_refs: list[Ref]
+    ) -> None:
+        from ladon.async_runner import plan_crawl
+
+        p = _MockAsyncPlugin(child_refs)
+        p.expanders = []
+        with pytest.raises(ValueError, match="no expanders configured"):
+            await plan_crawl(top_ref, p, None)  # type: ignore[arg-type]
+
+    async def test_expansion_not_ready_propagates(self, top_ref: Ref) -> None:
+        from ladon.async_runner import plan_crawl
+
+        class _NotReadyExpander:
+            async def expand(self, ref: object, client: object) -> Expansion:
+                raise ExpansionNotReadyError("not ready")
+
+        p = _MockAsyncPlugin([])
+        p.expanders = [_NotReadyExpander()]
+        with pytest.raises(ExpansionNotReadyError):
+            await plan_crawl(top_ref, p, None)  # type: ignore[arg-type]
+
+    async def test_branch_error_on_non_first_expander_is_isolated(
+        self, top_ref: Ref
+    ) -> None:
+        from ladon.async_runner import plan_crawl
+
+        parent_refs = [
+            Ref(url="https://demo.example.com/parent/1"),
+            Ref(url="https://demo.example.com/parent/2"),
+        ]
+        first_expander = _MockAsyncExpander(parent_refs)
+
+        class _BranchErrorExpander:
+            async def expand(self, ref: object, client: object) -> Expansion:
+                if "parent/1" in str(ref):
+                    raise PartialExpansionError("branch failed")
+                return Expansion(
+                    record=_make_record(),
+                    child_refs=[Ref(url="https://demo.example.com/leaf/ok")],
+                )
+
+        p = _MockAsyncPlugin([])
+        p.expanders = [first_expander, _BranchErrorExpander()]
+        plan = await plan_crawl(top_ref, p, None)  # type: ignore[arg-type]
+        assert len(plan.leaves) == 1
+        assert len(plan.errors) == 1
+        assert "branch" in plan.errors[0]
+
+    async def test_multi_expander_chain_leaf_count(self, top_ref: Ref) -> None:
+        from ladon.async_runner import plan_crawl
+
+        parent_refs = [
+            Ref(url="https://demo.example.com/parent/1"),
+            Ref(url="https://demo.example.com/parent/2"),
+        ]
+        child_refs = [
+            Ref(url="https://demo.example.com/child/a"),
+            Ref(url="https://demo.example.com/child/b"),
+        ]
+        p = _MockAsyncPlugin([])
+        p.expanders = [
+            _MockAsyncExpander(parent_refs),
+            _MockAsyncExpander(child_refs),
+        ]
+        plan = await plan_crawl(top_ref, p, None)  # type: ignore[arg-type]
+        # 2 parents × 2 children each = 4 total leaves
+        assert len(plan.leaves) == 4
+
+
+# ---------------------------------------------------------------------------
+# execute_plan — Phase 3 only (async)
+# ---------------------------------------------------------------------------
+
+
+class TestExecutePlan:
+    async def test_returns_run_result(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert isinstance(result, RunResult)
+
+    async def test_all_leaves_consumed(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert result.leaves_consumed == 3
+        assert result.leaves_persisted == 3
+        assert result.leaves_failed == 0
+
+    async def test_record_carried_from_plan(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert result.record is plan.record
+
+    async def test_on_leaf_receives_leaf_record_and_leaf_ref(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin, child_refs: list[Ref]
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        calls: list[tuple[object, object]] = []
+
+        async def on_leaf(record: object, ref: object) -> None:
+            calls.append((record, ref))
+
+        await execute_plan(plan, plugin, None, RunConfig(), on_leaf=on_leaf)  # type: ignore[arg-type]
+        assert len(calls) == 3
+        for _, ref in calls:
+            assert isinstance(ref, Ref)
+        received_urls = {ref.url for _, ref in calls}  # type: ignore[union-attr]
+        expected_urls = {r.url for r in child_refs}
+        assert received_urls == expected_urls
+
+    async def test_leaf_unavailable_counted_as_failed(
+        self, top_ref: Ref
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        refs = [
+            Ref(url="https://demo.example.com/leaf/1"),
+            Ref(url="https://demo.example.com/leaf/2"),
+            Ref(url="https://demo.example.com/leaf/3"),
+        ]
+
+        class _PartialAsyncSink:
+            async def consume(self, ref: object, client: object) -> object:
+                r = ref if isinstance(ref, Ref) else Ref(url=str(ref))
+                if r.url.endswith("/2"):
+                    raise LeafUnavailableError("missing")
+                return _make_leaf(leaf_id=r.url.split("/")[-1], url=r.url)
+
+        p = _MockAsyncPlugin(refs)
+        p.sink = _PartialAsyncSink()
+        plan = await plan_crawl(top_ref, p, None)  # type: ignore[arg-type]
+        result = await execute_plan(plan, p, None, RunConfig())  # type: ignore[arg-type]
+        assert result.leaves_consumed == 2
+        assert result.leaves_failed == 1
+        assert result.leaves_consumed + result.leaves_failed == 3
+
+    async def test_on_leaf_callback_failure_counted(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+
+        async def bad_callback(record: object, ref: object) -> None:
+            raise RuntimeError("db exploded")
+
+        result = await execute_plan(
+            plan, plugin, None, RunConfig(), on_leaf=bad_callback  # type: ignore[arg-type]
+        )
+        assert result.leaves_consumed == 3
+        assert result.leaves_persisted == 0
+        assert result.leaves_failed == 0
+        assert len(result.errors) == 3
+
+    async def test_leaf_limit_applied(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = await execute_plan(plan, plugin, None, RunConfig(leaf_limit=2))  # type: ignore[arg-type]
+        assert result.leaves_consumed == 2
+
+    async def test_plan_errors_carried_into_result(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan
+        from ladon.runner import CrawlPlan
+
+        plan = CrawlPlan(
+            record=_make_record(),
+            leaves=(Ref(url="https://demo.example.com/leaf/1"),),
+            errors=("expander branch 'x': failed",),
+        )
+        result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert any("expander branch" in e for e in result.errors)
+
+    async def test_on_progress_called_after_each_leaf(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+
+        def on_progress(done: int, total: int) -> None:
+            progress_calls.append((done, total))
+
+        await execute_plan(
+            plan, plugin, None, RunConfig(), on_progress=on_progress  # type: ignore[arg-type]
+        )
+        assert len(progress_calls) == 3
+        # Each call increments done; final total is always 3
+        assert all(t == 3 for _, t in progress_calls)
+        assert sorted(d for d, _ in progress_calls) == [1, 2, 3]
+
+    async def test_no_on_leaf_leaves_persisted_equals_consumed(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert result.leaves_persisted == result.leaves_consumed
+
+    async def test_plan_crawl_then_execute_plan_roundtrip(
+        self, top_ref: Ref, plugin: _MockAsyncPlugin
+    ) -> None:
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        filtered = plan.excluding(lambda r: r.url.endswith("/2"))  # type: ignore[union-attr]
+        result = await execute_plan(filtered, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert result.leaves_consumed == 2
+
+    async def test_plan_importable_from_ladon(self) -> None:
+        from ladon import execute_plan as _ep
+        from ladon import plan_crawl as _pc
+        from ladon.async_runner import execute_plan, plan_crawl
+
+        assert _pc is plan_crawl
+        assert _ep is execute_plan

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -170,6 +170,16 @@ class TestCrawlPlan:
         filtered = plan.excluding(lambda _: True)
         assert filtered.record is original_record
 
+    def test_limited_to_zero_raises(self) -> None:
+        plan = CrawlPlan(record=_DemoRecord(), leaves=(), errors=())
+        with pytest.raises(ValueError, match="positive integer"):
+            plan.limited_to(0)
+
+    def test_limited_to_negative_raises(self) -> None:
+        plan = CrawlPlan(record=_DemoRecord(), leaves=(), errors=())
+        with pytest.raises(ValueError, match="positive integer"):
+            plan.limited_to(-1)
+
 
 # ---------------------------------------------------------------------------
 # plan_crawl_sync — happy path

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,473 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+# pyright: reportUnknownArgumentType=false, reportArgumentType=false
+# pyright: reportUnknownParameterType=false, reportMissingParameterType=false
+"""Contract tests for CrawlPlan, plan_crawl_sync, and execute_plan_sync.
+
+The ``client`` parameter is ``None`` throughout — mock expanders and sinks
+never use it; the runner passes it through without inspecting it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from ladon.plugins.errors import (
+    ChildListUnavailableError,
+    ExpansionNotReadyError,
+    LeafUnavailableError,
+    PartialExpansionError,
+)
+from ladon.plugins.models import Expansion, Ref
+from ladon.runner import (
+    CrawlPlan,
+    RunConfig,
+    RunResult,
+    execute_plan_sync,
+    plan_crawl_sync,
+)
+
+# ---------------------------------------------------------------------------
+# Domain-neutral test types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DemoRecord:
+    name: str = "demo"
+
+
+@dataclass(frozen=True)
+class _DemoLeafRecord:
+    leaf_id: str
+    url: str
+
+
+# ---------------------------------------------------------------------------
+# Mock plugin helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockExpander:
+    def __init__(self, child_refs: list[Ref]) -> None:
+        self._child_refs = child_refs
+
+    def expand(self, ref: object, client: object) -> Expansion:
+        return Expansion(record=_DemoRecord(), child_refs=self._child_refs)
+
+
+class _MockSink:
+    def consume(self, ref: object, client: object) -> _DemoLeafRecord:
+        r = ref if isinstance(ref, Ref) else Ref(url=str(ref))
+        return _DemoLeafRecord(leaf_id=r.url.split("/")[-1], url=r.url)
+
+
+class _MockPlugin:
+    def __init__(self, child_refs: list[Ref]) -> None:
+        self.expanders: list[Any] = [_MockExpander(child_refs)]
+        self.sink: Any = _MockSink()
+
+    @property
+    def name(self) -> str:
+        return "mock_plugin"
+
+    @property
+    def source(self) -> object:
+        return object()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def child_refs() -> list[Ref]:
+    return [
+        Ref(url="https://demo.example.com/leaf/1"),
+        Ref(url="https://demo.example.com/leaf/2"),
+        Ref(url="https://demo.example.com/leaf/3"),
+    ]
+
+
+@pytest.fixture()
+def plugin(child_refs: list[Ref]) -> _MockPlugin:
+    return _MockPlugin(child_refs)
+
+
+@pytest.fixture()
+def top_ref() -> Ref:
+    return Ref(url="https://demo.example.com/top/1")
+
+
+# ---------------------------------------------------------------------------
+# CrawlPlan — value semantics
+# ---------------------------------------------------------------------------
+
+
+class TestCrawlPlan:
+    def test_frozen(self) -> None:
+        plan = CrawlPlan(record=_DemoRecord(), leaves=(), errors=())
+        with pytest.raises(AttributeError):
+            plan.leaves = ()  # type: ignore[misc]
+
+    def test_excluding_removes_matching_leaves(self) -> None:
+        refs = [Ref(url=f"https://x.example.com/{i}") for i in range(4)]
+        plan = CrawlPlan(record=_DemoRecord(), leaves=tuple(refs), errors=())
+        filtered = plan.excluding(lambda r: r.url.endswith("/1") or r.url.endswith("/3"))  # type: ignore[union-attr]
+        assert len(filtered.leaves) == 2
+        remaining_urls = {r.url for r in filtered.leaves}  # type: ignore[union-attr]
+        assert "https://x.example.com/0" in remaining_urls
+        assert "https://x.example.com/2" in remaining_urls
+
+    def test_excluding_preserves_errors(self) -> None:
+        refs = [Ref(url="https://x.example.com/1")]
+        plan = CrawlPlan(
+            record=_DemoRecord(),
+            leaves=tuple(refs),
+            errors=("branch 'x': failed",),
+        )
+        filtered = plan.excluding(lambda _: True)
+        assert filtered.errors == ("branch 'x': failed",)
+        assert len(filtered.leaves) == 0
+
+    def test_excluding_nothing_returns_same_count(self) -> None:
+        refs = [Ref(url=f"https://x.example.com/{i}") for i in range(3)]
+        plan = CrawlPlan(record=_DemoRecord(), leaves=tuple(refs), errors=())
+        filtered = plan.excluding(lambda _: False)
+        assert len(filtered.leaves) == 3
+
+    def test_limited_to_caps_leaves(self) -> None:
+        refs = [Ref(url=f"https://x.example.com/{i}") for i in range(5)]
+        plan = CrawlPlan(record=_DemoRecord(), leaves=tuple(refs), errors=())
+        capped = plan.limited_to(3)
+        assert len(capped.leaves) == 3
+        assert capped.leaves[0].url == "https://x.example.com/0"  # type: ignore[union-attr]
+        assert capped.leaves[2].url == "https://x.example.com/2"  # type: ignore[union-attr]
+
+    def test_limited_to_larger_than_count_is_noop(self) -> None:
+        refs = [Ref(url=f"https://x.example.com/{i}") for i in range(2)]
+        plan = CrawlPlan(record=_DemoRecord(), leaves=tuple(refs), errors=())
+        capped = plan.limited_to(100)
+        assert len(capped.leaves) == 2
+
+    def test_limited_to_preserves_errors(self) -> None:
+        refs = [Ref(url=f"https://x.example.com/{i}") for i in range(3)]
+        plan = CrawlPlan(
+            record=_DemoRecord(),
+            leaves=tuple(refs),
+            errors=("branch error",),
+        )
+        capped = plan.limited_to(1)
+        assert capped.errors == ("branch error",)
+
+    def test_record_preserved_through_filter(self) -> None:
+        original_record = _DemoRecord(name="original")
+        refs = [Ref(url="https://x.example.com/1")]
+        plan = CrawlPlan(record=original_record, leaves=tuple(refs), errors=())
+        filtered = plan.excluding(lambda _: True)
+        assert filtered.record is original_record
+
+
+# ---------------------------------------------------------------------------
+# plan_crawl_sync — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestPlanCrawlSync:
+    def test_returns_crawl_plan(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        assert isinstance(plan, CrawlPlan)
+
+    def test_leaf_count_matches_expander_output(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        assert len(plan.leaves) == 3
+
+    def test_record_set_from_first_expander(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        assert isinstance(plan.record, _DemoRecord)
+
+    def test_no_errors_on_clean_run(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        assert plan.errors == ()
+
+    def test_empty_expander_produces_empty_plan(self, top_ref: Ref) -> None:
+        p = _MockPlugin([])
+        plan = plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+        assert len(plan.leaves) == 0
+        assert plan.errors == ()
+
+    def test_multi_expander_chain(self, top_ref: Ref) -> None:
+        parent_refs = [
+            Ref(url="https://x.example.com/parent/1"),
+            Ref(url="https://x.example.com/parent/2"),
+        ]
+        child_refs = [
+            Ref(url="https://x.example.com/child/a"),
+            Ref(url="https://x.example.com/child/b"),
+        ]
+        first_expander = _MockExpander(parent_refs)
+        second_expander = _MockExpander(child_refs)
+        p = _MockPlugin([])
+        p.expanders = [first_expander, second_expander]
+        plan = plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+        # 2 parents × 2 children each = 4 total leaves
+        assert len(plan.leaves) == 4
+
+    def test_empty_plugin_raises_value_error(
+        self, top_ref: Ref, child_refs: list[Ref]
+    ) -> None:
+        p = _MockPlugin(child_refs)
+        p.expanders = []
+        with pytest.raises(ValueError, match="no expanders configured"):
+            plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+
+    def test_expansion_not_ready_propagates(self, top_ref: Ref) -> None:
+        class _NotReadyExpander:
+            def expand(self, ref: object, client: object) -> Expansion:
+                raise ExpansionNotReadyError("not ready")
+
+        p = _MockPlugin([])
+        p.expanders = [_NotReadyExpander()]
+        with pytest.raises(ExpansionNotReadyError):
+            plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+
+    def test_partial_expansion_propagates_from_first(
+        self, top_ref: Ref
+    ) -> None:
+        class _PartialExpander:
+            def expand(self, ref: object, client: object) -> Expansion:
+                raise PartialExpansionError("partial")
+
+        p = _MockPlugin([])
+        p.expanders = [_PartialExpander()]
+        with pytest.raises(PartialExpansionError):
+            plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+
+    def test_child_list_unavailable_propagates_from_first(
+        self, top_ref: Ref
+    ) -> None:
+        class _UnavailableExpander:
+            def expand(self, ref: object, client: object) -> Expansion:
+                raise ChildListUnavailableError("unavail")
+
+        p = _MockPlugin([])
+        p.expanders = [_UnavailableExpander()]
+        with pytest.raises(ChildListUnavailableError):
+            plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+
+    def test_branch_error_on_non_first_expander_is_isolated(
+        self, top_ref: Ref
+    ) -> None:
+        good_refs = [
+            Ref(url="https://x.example.com/good/1"),
+            Ref(url="https://x.example.com/good/2"),
+        ]
+        first_expander = _MockExpander(good_refs)
+
+        class _BranchErrorExpander:
+            def expand(self, ref: object, client: object) -> Expansion:
+                if "good/1" in str(ref):
+                    raise PartialExpansionError("branch failed")
+                return Expansion(
+                    record=_DemoRecord(),
+                    child_refs=[Ref(url="https://x.example.com/leaf/ok")],
+                )
+
+        p = _MockPlugin([])
+        p.expanders = [first_expander, _BranchErrorExpander()]
+        plan = plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+        assert len(plan.leaves) == 1  # good/2 succeeded; good/1 branch failed
+        assert len(plan.errors) == 1
+        assert "branch" in plan.errors[0]
+
+    def test_expansion_not_ready_from_non_first_expander_propagates(
+        self, top_ref: Ref
+    ) -> None:
+        parent_refs = [Ref(url="https://x.example.com/parent/1")]
+        first_expander = _MockExpander(parent_refs)
+
+        class _NotReadySecondExpander:
+            def expand(self, ref: object, client: object) -> Expansion:
+                raise ExpansionNotReadyError("not ready yet")
+
+        p = _MockPlugin([])
+        p.expanders = [first_expander, _NotReadySecondExpander()]
+        with pytest.raises(ExpansionNotReadyError):
+            plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# execute_plan_sync — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestExecutePlanSync:
+    def test_returns_run_result(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = execute_plan_sync(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert isinstance(result, RunResult)
+
+    def test_all_leaves_consumed(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = execute_plan_sync(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert result.leaves_consumed == 3
+        assert result.leaves_persisted == 3
+        assert result.leaves_failed == 0
+
+    def test_record_carried_from_plan(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = execute_plan_sync(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert result.record is plan.record
+
+    def test_on_leaf_receives_leaf_record_and_leaf_ref(
+        self, top_ref: Ref, plugin: _MockPlugin, child_refs: list[Ref]
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        calls: list[tuple[object, object]] = []
+
+        def on_leaf(record: object, ref: object) -> None:
+            calls.append((record, ref))
+
+        execute_plan_sync(plan, plugin, None, RunConfig(), on_leaf=on_leaf)  # type: ignore[arg-type]
+        assert len(calls) == 3
+        # Second arg must be the leaf ref (a Ref), not a parent record
+        for _, ref in calls:
+            assert isinstance(ref, Ref)
+        received_urls = {ref.url for _, ref in calls}  # type: ignore[union-attr]
+        expected_urls = {r.url for r in child_refs}
+        assert received_urls == expected_urls
+
+    def test_on_leaf_not_called_when_consume_fails(self, top_ref: Ref) -> None:
+        class _FailingSink:
+            def consume(self, ref: object, client: object) -> _DemoLeafRecord:
+                raise LeafUnavailableError("gone")
+
+        p = _MockPlugin([Ref(url="https://x.example.com/leaf/1")])
+        p.sink = _FailingSink()
+        plan = plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+        calls: list[object] = []
+        execute_plan_sync(plan, p, None, RunConfig(), on_leaf=lambda r, ref: calls.append(r))  # type: ignore[arg-type]
+        assert len(calls) == 0
+
+    def test_leaf_unavailable_counted_as_failed(self, top_ref: Ref) -> None:
+        refs = [
+            Ref(url="https://x.example.com/leaf/1"),
+            Ref(url="https://x.example.com/leaf/2"),
+            Ref(url="https://x.example.com/leaf/3"),
+        ]
+
+        class _PartialSink:
+            def consume(self, ref: object, client: object) -> _DemoLeafRecord:
+                r = ref if isinstance(ref, Ref) else Ref(url=str(ref))
+                if r.url.endswith("/2"):
+                    raise LeafUnavailableError("missing")
+                return _DemoLeafRecord(leaf_id=r.url.split("/")[-1], url=r.url)
+
+        p = _MockPlugin(refs)
+        p.sink = _PartialSink()
+        plan = plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+        result = execute_plan_sync(plan, p, None, RunConfig())  # type: ignore[arg-type]
+        assert result.leaves_consumed == 2
+        assert result.leaves_failed == 1
+        assert result.leaves_consumed + result.leaves_failed == 3
+        assert len(result.errors) == 1
+        assert "consume failed" in result.errors[0]
+
+    def test_on_leaf_callback_failure_counted(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+
+        def bad_callback(record: object, ref: object) -> None:
+            raise RuntimeError("db exploded")
+
+        result = execute_plan_sync(plan, plugin, None, RunConfig(), on_leaf=bad_callback)  # type: ignore[arg-type]
+        assert result.leaves_consumed == 3
+        assert result.leaves_persisted == 0
+        assert result.leaves_failed == 0
+        assert len(result.errors) == 3
+        for err in result.errors:
+            assert "callback failed" in err
+
+    def test_leaf_limit_applied(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = execute_plan_sync(plan, plugin, None, RunConfig(leaf_limit=2))  # type: ignore[arg-type]
+        assert result.leaves_consumed == 2
+
+    def test_zero_leaf_limit_means_no_limit(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = execute_plan_sync(plan, plugin, None, RunConfig(leaf_limit=0))  # type: ignore[arg-type]
+        assert result.leaves_consumed == 3
+
+    def test_plan_errors_carried_into_result(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = CrawlPlan(
+            record=_DemoRecord(),
+            leaves=(Ref(url="https://x.example.com/leaf/1"),),
+            errors=("expander branch 'x': failed",),
+        )
+        result = execute_plan_sync(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert any("expander branch" in e for e in result.errors)
+
+    def test_on_progress_called_after_each_leaf(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+
+        def on_progress(done: int, total: int) -> None:
+            progress_calls.append((done, total))
+
+        execute_plan_sync(plan, plugin, None, RunConfig(), on_progress=on_progress)  # type: ignore[arg-type]
+        assert len(progress_calls) == 3
+        assert progress_calls[0] == (1, 3)
+        assert progress_calls[1] == (2, 3)
+        assert progress_calls[2] == (3, 3)
+
+    def test_on_progress_called_on_failure_too(self, top_ref: Ref) -> None:
+        class _FailingSink:
+            def consume(self, ref: object, client: object) -> _DemoLeafRecord:
+                raise LeafUnavailableError("gone")
+
+        refs = [Ref(url="https://x.example.com/leaf/1")]
+        p = _MockPlugin(refs)
+        p.sink = _FailingSink()
+        plan = plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+        execute_plan_sync(
+            plan,
+            p,
+            None,
+            RunConfig(),
+            on_progress=lambda d, t: progress_calls.append((d, t)),  # type: ignore[arg-type]
+        )
+        assert progress_calls == [(1, 1)]
+
+    def test_no_on_leaf_leaves_persisted_equals_consumed(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        result = execute_plan_sync(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert result.leaves_persisted == result.leaves_consumed

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,6 +9,7 @@ never use it; the runner passes it through without inspecting it.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -507,3 +508,95 @@ class TestExecutePlanSync:
             on_progress=lambda d, t: calls.append((d, t)),
         )
         assert calls == []
+
+    def test_on_progress_called_after_on_leaf_failure(
+        self, top_ref: Ref
+    ) -> None:
+        refs = [Ref(url="https://x.example.com/leaf/1")]
+        p = _MockPlugin(refs)
+        plan = plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+
+        def failing_callback(record: object, ref: object) -> None:
+            raise RuntimeError("db fail")
+
+        execute_plan_sync(
+            plan,
+            p,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_leaf=failing_callback,
+            on_progress=lambda d, t: progress_calls.append((d, t)),
+        )
+        assert progress_calls == [(1, 1)]
+
+    def test_on_progress_exception_is_swallowed(
+        self, top_ref: Ref, plugin: _MockPlugin
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+
+        def exploding_progress(done: int, total: int) -> None:
+            raise RuntimeError("progress bar closed")
+
+        result = execute_plan_sync(
+            plan, plugin, None, RunConfig(), on_progress=exploding_progress  # type: ignore[arg-type]
+        )
+        assert result.leaves_consumed == 3
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerLogging:
+    def test_plan_crawl_sync_start_and_finish_logged(
+        self,
+        top_ref: Ref,
+        plugin: _MockPlugin,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.INFO, logger="ladon.runner"):
+            plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        messages = [r.message for r in caplog.records]
+        assert any("plan_crawl_sync started" in m for m in messages)
+        assert any("plan_crawl_sync finished" in m for m in messages)
+
+    def test_plan_crawl_sync_start_has_plugin_and_ref(
+        self,
+        top_ref: Ref,
+        plugin: _MockPlugin,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.INFO, logger="ladon.runner"):
+            plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        start = next(r for r in caplog.records if "started" in r.message)
+        assert start.plugin == "mock_plugin"  # type: ignore[attr-defined]
+        assert start.ref == str(top_ref)  # type: ignore[attr-defined]
+
+    def test_execute_plan_sync_start_and_finish_logged(
+        self,
+        top_ref: Ref,
+        plugin: _MockPlugin,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        with caplog.at_level(logging.INFO, logger="ladon.runner"):
+            execute_plan_sync(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        messages = [r.message for r in caplog.records]
+        assert any("execute_plan_sync started" in m for m in messages)
+        assert any("execute_plan_sync finished" in m for m in messages)
+
+    def test_execute_plan_sync_finish_has_counts(
+        self,
+        top_ref: Ref,
+        plugin: _MockPlugin,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        with caplog.at_level(logging.INFO, logger="ladon.runner"):
+            execute_plan_sync(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        finish = next(r for r in caplog.records if "finished" in r.message)
+        assert finish.leaves_consumed == 3  # type: ignore[attr-defined]
+        assert finish.leaves_persisted == 3  # type: ignore[attr-defined]
+        assert finish.leaves_failed == 0  # type: ignore[attr-defined]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -481,3 +481,29 @@ class TestExecutePlanSync:
         plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
         result = execute_plan_sync(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
         assert result.leaves_persisted == result.leaves_consumed
+
+    def test_empty_plan_returns_zero_result(self, plugin: _MockPlugin) -> None:
+        plan = CrawlPlan(
+            record=_DemoRecord(),
+            leaves=(),
+            errors=("branch err",),
+        )
+        result = execute_plan_sync(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        assert result.leaves_consumed == 0
+        assert result.leaves_persisted == 0
+        assert result.leaves_failed == 0
+        assert result.errors == ("branch err",)
+
+    def test_empty_plan_on_progress_never_called(
+        self, plugin: _MockPlugin
+    ) -> None:
+        plan = CrawlPlan(record=_DemoRecord(), leaves=(), errors=())
+        calls: list[object] = []
+        execute_plan_sync(
+            plan,
+            plugin,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_progress=lambda d, t: calls.append((d, t)),
+        )
+        assert calls == []


### PR DESCRIPTION
## Summary

Post-merge review findings for `MultiSourceSink` / `FetchPredicate` in
`src/ladon/plugins/resolution.py`. These improvements did not make it into the
initial ADR-013 implementation before the branches diverged.

- **Empty-bytes fix**: `if data is None:` → `if not data:` — a source
  returning `b""` is not a valid result and must not stop the loop or update
  the best-seen fallback. Docstring pseudocode synced to match.
- **`FetchPredicate` docstring**: `@runtime_checkable` note — `isinstance`
  only checks attribute presence, not callability or signature.
- **`_is_better_candidate` docstring**: warning for the always-`False`
  subclass edge case where `resolve_multi` silently returns `(None, None)`
  even when sources produce data.
- **Tests**: 3 new tests; `test_multiple_predicates_all_must_pass`
  strengthened to use two predicates so it actually proves ALL must pass.

## Test plan

- [x] `pytest tests/plugins/test_resolution.py` — 22 passed

Fixes: #128