### PR TITLE
chore(release): bump version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.3.2] — 2026-06-08
+
 ### Added
 
 - **`CrawlPlan`** — immutable Phase 1 output carrying `record`, `leaves`,


### PR DESCRIPTION
## Summary

- Moves `[Unreleased]` → `[0.3.2] — 2026-06-08` in CHANGELOG
- Version was already set to `0.3.2` in `pyproject.toml` (bumped on the runner v0.3 branch)
- Releases: `CrawlPlan` / plan+execute split runner API (ADR-011), `DecisionTracker` observability protocol, and `SqliteDecisionTracker` reference backend

Tag `v0.3.2` will be pushed immediately after merge.