### PR TITLE
feat(plugins): add rejection_info() extension point to predicate_rejected events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`rejection_info()`** — optional duck-typed extension point on
+  `FetchPredicate` implementations for adding predicate-specific diagnostics
+  to `predicate_rejected` decision-event metadata.
+
 ---
 
 ## [0.3.2] — 2026-06-08

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -62,6 +62,15 @@ class FetchPredicate(Protocol):
         attribute *exists* — it does not verify callability or signature.
         Passing a mis-shaped object will raise ``TypeError`` at call time
         inside :meth:`MultiSourceSink.resolve_multi`, not at construction.
+
+    Predicates may optionally expose a duck-typed, zero-argument
+    ``rejection_info() -> dict[str, Any]`` method; it is deliberately not a
+    Protocol member, so existing predicates without it continue to work.
+    When a predicate rejects a result, :meth:`MultiSourceSink.resolve_multi`
+    merges the returned mapping into that ``predicate_rejected`` event's
+    metadata. Exceptions from this method are swallowed and logged at DEBUG
+    level. Its ``predicate_name`` value, if any, is always overwritten by the
+    authoritative rejecting predicate name.
     """
 
     def accepts(self, data: bytes, ref: Ref) -> bool:
@@ -316,6 +325,26 @@ class MultiSourceSink:
                 (p for p in self._ms_predicates if not p.accepts(data, ref)),
                 None,
             )
+            predicate_name = (
+                type(failing).__name__
+                if failing is not None
+                else "<subclass-override>"
+            )
+            rejection_meta: dict[str, Any] = {}
+            if failing is not None:
+                _get_info = getattr(failing, "rejection_info", None)
+                if callable(_get_info):
+                    try:
+                        rejection_meta.update(_get_info())  # type: ignore[arg-type]
+                    except Exception as _info_exc:
+                        logger.debug(
+                            "rejection_info() on %r raised %s — ignoring",
+                            predicate_name,
+                            _info_exc,
+                        )
+            # predicate_name is written last so a badly-behaved rejection_info()
+            # cannot overwrite it.
+            rejection_meta["predicate_name"] = predicate_name
             self._tracker.record(
                 DecisionEvent(
                     run_id=_run_id,
@@ -324,13 +353,7 @@ class MultiSourceSink:
                     source=source_name,
                     event="predicate_rejected",
                     reason="one or more predicates rejected the result",
-                    metadata={
-                        "predicate_name": (
-                            type(failing).__name__
-                            if failing is not None
-                            else "<subclass-override>"
-                        ),
-                    },
+                    metadata=rejection_meta,
                 )
             )
             logger.debug(

--- a/tests/plugins/test_resolution_tracker.py
+++ b/tests/plugins/test_resolution_tracker.py
@@ -8,6 +8,7 @@ point, and that metadata fields carry the expected values.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 from ladon.observability import DecisionEvent
@@ -402,3 +403,90 @@ class TestNullTrackerDefault:
         data, src = sink.resolve_multi(_ref(), MagicMock())
         assert data == b"DATA"
         assert src.name == "a"  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# rejection_info() integration — predicate_rejected metadata
+# ---------------------------------------------------------------------------
+
+
+class TestRejectionInfoMetadata:
+    def test_rejection_info_merged_into_predicate_rejected_metadata(
+        self,
+    ) -> None:
+        """When a predicate has rejection_info(), its output is merged into
+        the predicate_rejected event metadata alongside predicate_name."""
+
+        class _DiagnosticPredicate:
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                return False
+
+            def rejection_info(self) -> dict[str, Any]:
+                return {"detail": "too_short", "threshold": 5}
+
+        tracker = _CapturingTracker()
+        sink = _SimpleSink(
+            sources=[_SimpleSource("a", b"x")],
+            predicates=[_DiagnosticPredicate()],
+            tracker=tracker,
+        )
+        sink.resolve_multi(_ref(), MagicMock())
+        ev = tracker.by_event("predicate_rejected")[0]
+        assert ev.metadata["predicate_name"] == "_DiagnosticPredicate"
+        assert ev.metadata["detail"] == "too_short"
+        assert ev.metadata["threshold"] == 5
+
+    def test_predicate_without_rejection_info_still_works(self) -> None:
+        """Predicates without rejection_info() continue to work unchanged."""
+        tracker = _CapturingTracker()
+        sink = _SimpleSink(
+            sources=[_SimpleSource("a", b"x")],
+            predicates=[_MinLengthPredicate(10)],
+            tracker=tracker,
+        )
+        sink.resolve_multi(_ref(), MagicMock())
+        ev = tracker.by_event("predicate_rejected")[0]
+        assert "predicate_name" in ev.metadata
+        assert ev.metadata["predicate_name"] == "_MinLengthPredicate"
+
+    def test_rejection_info_raising_does_not_propagate(self) -> None:
+        """An exception from rejection_info() is swallowed; the event still fires."""
+
+        class _BrokenInfoPredicate:
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                return False
+
+            def rejection_info(self) -> dict[str, Any]:
+                raise RuntimeError("info unavailable")
+
+        tracker = _CapturingTracker()
+        sink = _SimpleSink(
+            sources=[_SimpleSource("a", b"x")],
+            predicates=[_BrokenInfoPredicate()],
+            tracker=tracker,
+        )
+        sink.resolve_multi(_ref(), MagicMock())  # must not raise
+        ev = tracker.by_event("predicate_rejected")[0]
+        assert ev.metadata["predicate_name"] == "_BrokenInfoPredicate"
+
+    def test_rejection_info_cannot_overwrite_predicate_name(self) -> None:
+        """predicate_name in metadata is always authoritative; rejection_info()
+        returning a dict with the same key must not clobber it."""
+
+        class _OverwritingPredicate:
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                return False
+
+            def rejection_info(self) -> dict[str, Any]:
+                return {"predicate_name": "INJECTED", "extra": 42}
+
+        tracker = _CapturingTracker()
+        sink = _SimpleSink(
+            sources=[_SimpleSource("a", b"x")],
+            predicates=[_OverwritingPredicate()],
+            tracker=tracker,
+        )
+        sink.resolve_multi(_ref(), MagicMock())
+        ev = tracker.by_event("predicate_rejected")[0]
+        assert ev.metadata["predicate_name"] == "_OverwritingPredicate"
+        assert ev.metadata["extra"] == 42


### PR DESCRIPTION
## Summary

- `predicate_rejected` DecisionEvent metadata previously carried only `predicate_name`, making it impossible to calibrate predicates (e.g. `NoRistampaBannerPredicate`) from the decisions DB alone — diagnostic values like `hue_stdev`/`fg_fraction` were only visible in DEBUG logs.
- `FetchPredicate` implementations may now optionally expose a zero-argument `rejection_info() -> dict[str, Any]` method. It is deliberately duck-typed, not a `Protocol` member, so existing predicates without it are unaffected.
- `MultiSourceSink.resolve_multi()` merges the returned mapping into that event's metadata. `predicate_name` is written last so a misbehaving `rejection_info()` cannot spoof which predicate actually rejected the result. Exceptions from `rejection_info()` are swallowed and logged at DEBUG rather than propagating and breaking a resolution that otherwise succeeded.

## Verification

- 672 tests pass, including 4 new tests covering: normal merge, predicates without the method, exception-swallowing, and anti-spoofing of `predicate_name`
- `ruff check .` and `pyright` both clean
- `CHANGELOG.md` `[Unreleased]` entry added