### PR TITLE
docs(nav): add ADR-005 to mkdocs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
     - ADR-002 HTTP Result Contract: decisions/adr-002-http-status-result-contract.md
     - ADR-003 Plugin Interface: decisions/adr-003-plugin-adapter-interface.md
     - ADR-004 SES Protocol Design: decisions/adr-004-ses-protocol-design.md
+    - ADR-005 Asset Storage (`ladon.storage`): decisions/adr-005-asset-storage.md
     - ADR-006 Persistence Layer: decisions/adr-006-persistence-layer.md
     - ADR-007 Circuit Breaker: decisions/adr-007-circuit-breaker.md
     - ADR-008 robots.txt: decisions/adr-008-robots-txt.md


### PR DESCRIPTION
## Summary

Closes #142.

`docs/decisions/adr-005-asset-storage.md` existed on disk but was missing from `mkdocs.yml`'s `Decisions:` nav section, which jumped straight from ADR-004 to ADR-006.

Rebased onto `main` after #141 merged, so this now completes the full ADR-001 through ADR-012 sequence in nav with no orphaned decision pages.

## Verification

- `mkdocs build --strict` passes with zero orphaned pages