### PR TITLE
docs(site): surface CHANGELOG.md via mkdocs snippet include

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+--8<-- "CHANGELOG.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,12 +48,15 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
+  - pymdownx.snippets:
+      base_path: ["."]
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
 
 nav:
   - Home: index.md
+  - Changelog: changelog.md
   - Getting Started: getting-started.md
   - Guides:
     - How Ladon Works: guides/how-ladon-works.md


### PR DESCRIPTION
## Summary

Closes #136.

`CHANGELOG.md` existed at the repo root but had no page in the docs site. This adds a `docs/changelog.md` page that transcludes the root file at build time via `pymdownx.snippets` (already a transitive dep of mkdocs-material — no new dependency needed), so the root file stays the single source of truth.

- Added `pymdownx.snippets` (`base_path: ["."]`) to `mkdocs.yml`'s markdown extensions
- Added `Changelog: changelog.md` to nav, near Home
- `docs/changelog.md` is just the snippet include — no local heading, since `CHANGELOG.md` already starts with its own `# Changelog`

## Verification

- `mkdocs build --strict` passes
- Verified the built HTML actually contains rendered changelog content (e.g. "0.3.2") and exactly one `<h1>` — caught and fixed a duplicate-heading bug from an earlier draft before opening this PR