### PR TITLE
test(cookbook): extract cookbook examples into runnable scripts

### DIFF
--- a/docs/guides/cookbook.md
+++ b/docs/guides/cookbook.md
@@ -14,45 +14,7 @@ Have your `Source.discover()` return one `Ref` per page, then call
 listing page; the `page` value is context you can use in logs or persistence.
 
 ```python
-import json
-from collections.abc import Sequence
-from types import SimpleNamespace
-
-from ladon import ChildListUnavailableError, Expansion, HttpClient, HttpClientConfig, LeafUnavailableError, Ref, RunConfig, run_crawl
-
-class GitHubIssuesSource:
-    def discover(self, client) -> Sequence[Ref]:
-        return [
-            Ref(f"https://api.github.com/repos/psf/requests/issues?per_page=5&page={page}", {"page": page})
-            for page in (1, 2)
-        ]
-
-class IssueList:
-    def expand(self, ref, client):
-        response = client.get(ref.url)
-        if not response.ok or response.value is None:
-            raise ChildListUnavailableError(f"listing failed: {response.error}")
-        issues = json.loads(response.value)
-        return Expansion({"page": ref.raw["page"]}, [Ref(issue["url"]) for issue in issues])
-
-class IssueSink:
-    def consume(self, ref, client):
-        response = client.get(ref.url)
-        if not response.ok or response.value is None:
-            raise LeafUnavailableError(f"issue failed: {response.error}")
-        issue = json.loads(response.value)
-        return {"number": issue["number"], "title": issue["title"]}
-
-plugin = SimpleNamespace(
-    name="github-issues",
-    source=GitHubIssuesSource(),
-    expanders=[IssueList()],
-    sink=IssueSink(),
-)
-with HttpClient(HttpClientConfig(user_agent="example-crawler/1.0")) as client:
-    for page_ref in plugin.source.discover(client):
-        result = run_crawl(page_ref, plugin, client, RunConfig())
-        print(result.leaves_consumed, result.errors)
+--8<-- "examples/cookbook/flat_crawl.py:example"
 ```
 
 ## Multi-level tree crawl: Hacker News
@@ -64,23 +26,7 @@ direct comment refs, and `HNSink` fetches each comment. Install it with
 `pip install ladon-hackernews` before running this example.
 
 ```python
-from ladon import ExpansionNotReadyError, HttpClient, HttpClientConfig, RunConfig, run_crawl
-from ladon_hackernews import HNPlugin
-
-plugin = HNPlugin(top=10)
-with HttpClient(HttpClientConfig(user_agent="my-hn-research-bot/1.0")) as client:
-    for story_ref in plugin.source.discover(client):
-        try:
-            result = run_crawl(
-                story_ref,
-                plugin,
-                client,
-                RunConfig(leaf_limit=50),
-                on_leaf=lambda comment, story: print(story.id, comment.id),
-            )
-        except ExpansionNotReadyError:
-            continue  # Rediscover this story on the next scheduled run.
-        print(result.leaves_consumed, result.leaves_failed, result.errors)
+--8<-- "examples/cookbook/tree_crawl_hackernews.py:example"
 ```
 
 The adapter has one configured expander because the source is outside the
@@ -94,27 +40,7 @@ ref rather than requesting the item page again. `Ref` is frozen, so construct
 a new ref with its `raw` mapping in the expander.
 
 ```python
-import json
-
-from ladon import ChildListUnavailableError, Expansion, LeafUnavailableError, Ref
-
-class ProductList:
-    def expand(self, ref, client):
-        response = client.get(ref.url)
-        if not response.ok or response.value is None:
-            raise ChildListUnavailableError(f"listing failed: {response.error}")
-        products = json.loads(response.value)["products"]
-        children = [
-            Ref(product["url"], raw={"sku": product["sku"], "price": product["price"]})
-            for product in products
-        ]
-        return Expansion(record={"category": ref.url}, child_refs=children)
-
-class ProductSink:
-    def consume(self, ref, client):
-        if "sku" not in ref.raw:
-            raise LeafUnavailableError("listing did not provide a SKU")
-        return {"sku": ref.raw["sku"], "price": ref.raw["price"]}
+--8<-- "examples/cookbook/ref_raw_context.py:example"
 ```
 
 This sink deliberately makes no HTTP request: its record is built from data
@@ -130,23 +56,7 @@ at later levels the runner skips only that branch and adds its message to
 `RunResult.errors`.
 
 ```python
-from ladon import ExpansionNotReadyError, PartialExpansionError, RunConfig, run_crawl
-
-def crawl_one(top_ref, plugin, client) -> None:
-    try:
-        result = run_crawl(top_ref, plugin, client, RunConfig())
-    except ExpansionNotReadyError as exc:
-        mark_retry(top_ref, reason=str(exc), when="next scheduled run")
-        return
-    except PartialExpansionError as exc:
-        mark_retry(top_ref, reason=str(exc), when="after the listing is complete")
-        return
-
-    persist_successes(result)
-    branch_errors = [error for error in result.errors if error.startswith("expander branch")]
-    if branch_errors:
-        mark_partial(top_ref, branch_errors)
-        # The next discovery/run revisits the isolated, incomplete branches.
+--8<-- "examples/cookbook/resume_partial_crawl.py:example"
 ```
 
 `LeafUnavailableError` is different: the runner records it in `result.errors`,
@@ -160,26 +70,7 @@ pass an `AsyncHttpClient`. Expanders are awaited in tree order; leaf
 `consume()` calls run concurrently up to `async_concurrency`.
 
 ```python
-import asyncio
-
-from ladon import AsyncHttpClient, HttpClientConfig, RunConfig, async_run_crawl
-
-async def persist(leaf_record, parent_record) -> None:
-    await database.write(leaf_record, parent_record)
-
-async def main() -> None:
-    config = HttpClientConfig(user_agent="my-async-crawler/1.0", retries=2)
-    async with AsyncHttpClient(config) as client:
-        result = await async_run_crawl(
-            top_ref=top_ref,
-            plugin=my_async_plugin,
-            client=client,
-            config=RunConfig(leaf_limit=500, async_concurrency=20),
-            on_leaf=persist,
-        )
-    print(result.leaves_consumed, result.leaves_failed)
-
-asyncio.run(main())
+--8<-- "examples/cookbook/async_crawl.py:example"
 ```
 
 `on_leaf` must be an `async def` callback. Keep its work bounded as well:
@@ -191,22 +82,12 @@ For third-party public sites, enable robots enforcement on the **sync** client
 before discovery. Ladon fetches and caches each origin's `robots.txt`, blocks
 disallowed URLs as `RobotsBlockedError`, and honours `Crawl-delay`.
 
-```python
-from ladon import HttpClient, HttpClientConfig, RobotsBlockedError, RunConfig, run_crawl
+`client.get()` returns a blocked request in `response.error`; plugins must
+check for `RobotsBlockedError` and re-raise it so `run_crawl()` callers can
+handle it. See `PublicPage.expand()` in `examples/cookbook/robots_txt.py`.
 
-config = HttpClientConfig(
-    user_agent="my-research-crawler/1.0 (+https://example.org/contact)",
-    respect_robots_txt=True,
-    min_request_interval_seconds=1.0,
-)
-with HttpClient(config) as client:
-    for top_ref in plugin.source.discover(client):
-        try:
-            result = run_crawl(top_ref, plugin, client, RunConfig(leaf_limit=100))
-        except RobotsBlockedError as exc:
-            record_skipped(top_ref, str(exc))
-            continue
-        save_result(result)
+```python
+--8<-- "examples/cookbook/robots_txt.py:example"
 ```
 
 `AsyncHttpClient` currently raises `NotImplementedError` if

--- a/examples/cookbook/async_crawl.py
+++ b/examples/cookbook/async_crawl.py
@@ -1,0 +1,125 @@
+"""Process locally served leaf pages concurrently with AsyncHttpClient."""
+
+# --8<-- [start:example]
+import asyncio
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import cast
+
+from ladon import (
+    AsyncCrawlPlugin,
+    AsyncHttpClient,
+    Expansion,
+    HttpClientConfig,
+    LeafUnavailableError,
+    Ref,
+    RunConfig,
+    RunResult,
+    async_run_crawl,
+)
+
+
+class AsyncCatalogHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        host, port = cast(tuple[str, int], self.server.server_address)
+        if self.path == "/listing":
+            body = {
+                "items": [
+                    f"http://{host}:{port}/item/{number}" for number in range(3)
+                ]
+            }
+        elif self.path.startswith("/item/"):
+            body = {"id": int(self.path.rsplit("/", 1)[1])}
+        else:
+            self.send_error(404)
+            return
+        encoded = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def build_mock_server() -> tuple[ThreadingHTTPServer, Thread]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), AsyncCatalogHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+class ListingExpander:
+    async def expand(self, ref: Ref, client: AsyncHttpClient) -> Expansion:
+        response = await client.get(ref.url)
+        if not response.ok or response.value is None:
+            raise LeafUnavailableError(f"listing failed: {response.error}")
+        payload = json.loads(response.value)
+        return Expansion(
+            record={"listing": ref.url},
+            child_refs=[Ref(url) for url in payload["items"]],
+        )
+
+
+class ItemSink:
+    async def consume(
+        self, ref: Ref, client: AsyncHttpClient
+    ) -> dict[str, object]:
+        response = await client.get(ref.url)
+        if not response.ok or response.value is None:
+            raise LeafUnavailableError(f"item failed: {response.error}")
+        return json.loads(response.value)
+
+
+class LocalSource:
+    async def discover(self, client: AsyncHttpClient) -> Sequence[Ref]:
+        return ()
+
+
+@dataclass(frozen=True)
+class AsyncCatalogPlugin:
+    name: str = "async-local-catalog"
+    source: LocalSource = LocalSource()
+    expanders: tuple[ListingExpander, ...] = (ListingExpander(),)
+    sink: ItemSink = ItemSink()
+
+
+async def crawl_one(base_url: str) -> RunResult:
+    persisted: list[dict[str, object]] = []
+
+    async def persist(leaf_record: object, parent_record: object) -> None:
+        del parent_record
+        persisted.append(cast(dict[str, object], leaf_record))
+
+    config = HttpClientConfig(user_agent="my-async-crawler/1.0", retries=0)
+    async with AsyncHttpClient(config) as client:
+        result = await async_run_crawl(
+            top_ref=Ref(f"{base_url}/listing"),
+            plugin=cast("AsyncCrawlPlugin", AsyncCatalogPlugin()),
+            client=client,
+            config=RunConfig(leaf_limit=500, async_concurrency=20),
+            on_leaf=persist,
+        )
+    print(result.leaves_consumed, result.leaves_failed, persisted)
+    return result
+
+
+def run_example() -> RunResult:
+    server, thread = build_mock_server()
+    host, port = cast(tuple[str, int], server.server_address)
+    try:
+        return asyncio.run(crawl_one(f"http://{host}:{port}"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+if __name__ == "__main__":
+    run_example()
+# --8<-- [end:example]

--- a/examples/cookbook/flat_crawl.py
+++ b/examples/cookbook/flat_crawl.py
@@ -1,0 +1,80 @@
+"""Crawl two GitHub issue listing pages and print the crawl outcomes."""
+
+# --8<-- [start:example]
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import cast
+
+from ladon import (
+    ChildListUnavailableError,
+    CrawlPlugin,
+    Expansion,
+    HttpClient,
+    HttpClientConfig,
+    LeafUnavailableError,
+    Ref,
+    RunConfig,
+    RunResult,
+    run_crawl,
+)
+
+
+class GitHubIssuesSource:
+    def discover(self, client: HttpClient) -> Sequence[Ref]:
+        return [
+            Ref(
+                "https://api.github.com/repos/psf/requests/issues?per_page=5"
+                f"&page={page}",
+                {"page": page},
+            )
+            for page in (1, 2)
+        ]
+
+
+class IssueList:
+    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+        response = client.get(ref.url)
+        if not response.ok or response.value is None:
+            raise ChildListUnavailableError(f"listing failed: {response.error}")
+        issues = json.loads(response.value)
+        return Expansion(
+            {"page": ref.raw["page"]}, [Ref(issue["url"]) for issue in issues]
+        )
+
+
+class IssueSink:
+    def consume(self, ref: Ref, client: HttpClient) -> dict[str, object]:
+        response = client.get(ref.url)
+        if not response.ok or response.value is None:
+            raise LeafUnavailableError(f"issue failed: {response.error}")
+        issue = json.loads(response.value)
+        return {"number": issue["number"], "title": issue["title"]}
+
+
+@dataclass(frozen=True)
+class GitHubIssuesPlugin:
+    name: str = "github-issues"
+    source: GitHubIssuesSource = GitHubIssuesSource()
+    expanders: Sequence[IssueList] = (IssueList(),)
+    sink: IssueSink = IssueSink()
+
+
+def run_example() -> list[RunResult]:
+    plugin = GitHubIssuesPlugin()
+    results: list[RunResult] = []
+    with HttpClient(
+        HttpClientConfig(user_agent="example-crawler/1.0")
+    ) as client:
+        for page_ref in plugin.source.discover(client):
+            result = run_crawl(
+                page_ref, cast("CrawlPlugin", plugin), client, RunConfig()
+            )
+            results.append(result)
+            print(result.leaves_consumed, result.errors)
+    return results
+
+
+if __name__ == "__main__":
+    run_example()
+# --8<-- [end:example]

--- a/examples/cookbook/ref_raw_context.py
+++ b/examples/cookbook/ref_raw_context.py
@@ -1,0 +1,122 @@
+"""Carry product data from a local listing into leaf refs without refetching."""
+
+# --8<-- [start:example]
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import cast
+
+from ladon import (
+    ChildListUnavailableError,
+    CrawlPlugin,
+    Expansion,
+    HttpClient,
+    HttpClientConfig,
+    LeafUnavailableError,
+    Ref,
+    RunConfig,
+    RunResult,
+    run_crawl,
+)
+
+
+class ProductHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path != "/products":
+            self.send_error(404)
+            return
+        host, port = cast(tuple[str, int], self.server.server_address)
+        products = {
+            "products": [
+                {
+                    "url": f"http://{host}:{port}/product/tea",
+                    "sku": "TEA-1",
+                    "price": 7,
+                },
+                {
+                    "url": f"http://{host}:{port}/product/mug",
+                    "sku": "MUG-2",
+                    "price": 12,
+                },
+            ]
+        }
+        body = json.dumps(products).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def build_mock_server() -> tuple[ThreadingHTTPServer, Thread]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ProductHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+class ProductList:
+    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+        response = client.get(ref.url)
+        if not response.ok or response.value is None:
+            raise ChildListUnavailableError(f"listing failed: {response.error}")
+        products = json.loads(response.value)["products"]
+        children = [
+            Ref(
+                product["url"],
+                raw={"sku": product["sku"], "price": product["price"]},
+            )
+            for product in products
+        ]
+        return Expansion(record={"category": ref.url}, child_refs=children)
+
+
+class ProductSink:
+    def consume(self, ref: Ref, client: HttpClient) -> dict[str, object]:
+        if "sku" not in ref.raw:
+            raise LeafUnavailableError("listing did not provide a SKU")
+        return {"sku": ref.raw["sku"], "price": ref.raw["price"]}
+
+
+class ProductSource:
+    def discover(self, client: HttpClient) -> Sequence[Ref]:
+        return ()
+
+
+@dataclass(frozen=True)
+class ProductPlugin:
+    name: str = "local-products"
+    source: ProductSource = ProductSource()
+    expanders: tuple[ProductList, ...] = (ProductList(),)
+    sink: ProductSink = ProductSink()
+
+
+def run_example() -> RunResult:
+    server, thread = build_mock_server()
+    host, port = cast(tuple[str, int], server.server_address)
+    try:
+        with HttpClient(
+            HttpClientConfig(user_agent="example-crawler/1.0")
+        ) as client:
+            result = run_crawl(
+                Ref(f"http://{host}:{port}/products"),
+                cast("CrawlPlugin", ProductPlugin()),
+                client,
+                RunConfig(),
+            )
+        print(result.leaves_consumed, result.errors)
+        return result
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+if __name__ == "__main__":
+    run_example()
+# --8<-- [end:example]

--- a/examples/cookbook/resume_partial_crawl.py
+++ b/examples/cookbook/resume_partial_crawl.py
@@ -1,0 +1,165 @@
+"""Handle not-ready and partial local crawl responses at the scheduler boundary."""
+
+# --8<-- [start:example]
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import cast
+from urllib.parse import parse_qs, urlparse
+
+from ladon import (
+    ChildListUnavailableError,
+    CrawlPlugin,
+    Expansion,
+    ExpansionNotReadyError,
+    HttpClient,
+    HttpClientConfig,
+    LeafUnavailableError,
+    PartialExpansionError,
+    Ref,
+    RunConfig,
+    RunResult,
+    run_crawl,
+)
+
+
+class CrawlStateHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
+        host, port = cast(tuple[str, int], self.server.server_address)
+        base_url = f"http://{host}:{port}"
+        if parsed.path == "/top":
+            mode = query.get("mode", ["complete"])[0]
+            body = {"status": mode, "categories": ["tea", "mugs"]}
+        elif parsed.path == "/category/tea":
+            body = {"status": "complete", "items": [f"{base_url}/item/tea"]}
+        elif parsed.path == "/category/mugs":
+            body = {"status": "partial", "items": [f"{base_url}/item/mug"]}
+        elif parsed.path.startswith("/item/"):
+            body = {"name": parsed.path.rsplit("/", 1)[1]}
+        else:
+            self.send_error(404)
+            return
+        encoded = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def build_mock_server() -> tuple[ThreadingHTTPServer, Thread]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), CrawlStateHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def load_json(ref: Ref, client: HttpClient) -> dict[str, object]:
+    response = client.get(ref.url)
+    if not response.ok or response.value is None:
+        raise ChildListUnavailableError(f"request failed: {response.error}")
+    return json.loads(response.value)
+
+
+class CategoryList:
+    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+        payload = load_json(ref, client)
+        status = cast(str, payload["status"])
+        if status == "not-ready":
+            raise ExpansionNotReadyError("listing is not published yet")
+        if status == "partial":
+            raise PartialExpansionError("top-level listing is incomplete")
+        return Expansion(
+            record={"status": status},
+            child_refs=[
+                Ref(f"{ref.url.rsplit('/top', 1)[0]}/category/{name}")
+                for name in cast(list[str], payload["categories"])
+            ],
+        )
+
+
+class ItemList:
+    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+        payload = load_json(ref, client)
+        if payload["status"] == "partial":
+            raise PartialExpansionError("category still has another page")
+        return Expansion(
+            record={"category": ref.url},
+            child_refs=[Ref(url) for url in cast(list[str], payload["items"])],
+        )
+
+
+class ItemSink:
+    def consume(self, ref: Ref, client: HttpClient) -> dict[str, object]:
+        response = client.get(ref.url)
+        if not response.ok or response.value is None:
+            raise LeafUnavailableError(f"item failed: {response.error}")
+        return json.loads(response.value)
+
+
+class LocalSource:
+    def discover(self, client: HttpClient) -> Sequence[Ref]:
+        return ()
+
+
+@dataclass(frozen=True)
+class LocalCatalogPlugin:
+    name: str = "local-catalog"
+    source: LocalSource = LocalSource()
+    expanders: tuple[CategoryList, ItemList] = (CategoryList(), ItemList())
+    sink: ItemSink = ItemSink()
+
+
+def crawl_one(
+    top_ref: Ref, plugin: LocalCatalogPlugin, client: HttpClient
+) -> RunResult | None:
+    try:
+        result = run_crawl(
+            top_ref, cast("CrawlPlugin", plugin), client, RunConfig()
+        )
+    except ExpansionNotReadyError as exc:
+        print(f"retry next scheduled run: {exc}")
+        return None
+    except PartialExpansionError as exc:
+        print(f"retry after the listing is complete: {exc}")
+        return None
+
+    print(f"persisted {result.leaves_persisted} item(s)")
+    branch_errors = [
+        error for error in result.errors if error.startswith("expander branch")
+    ]
+    if branch_errors:
+        print(f"partial branches: {branch_errors}")
+    return result
+
+
+def run_example() -> RunResult:
+    server, thread = build_mock_server()
+    host, port = cast(tuple[str, int], server.server_address)
+    base_url = f"http://{host}:{port}"
+    plugin = LocalCatalogPlugin()
+    try:
+        with HttpClient(
+            HttpClientConfig(user_agent="example-crawler/1.0")
+        ) as client:
+            crawl_one(Ref(f"{base_url}/top?mode=not-ready"), plugin, client)
+            crawl_one(Ref(f"{base_url}/top?mode=partial"), plugin, client)
+            result = crawl_one(Ref(f"{base_url}/top"), plugin, client)
+        assert result is not None
+        return result
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+if __name__ == "__main__":
+    run_example()
+# --8<-- [end:example]

--- a/examples/cookbook/robots_txt.py
+++ b/examples/cookbook/robots_txt.py
@@ -1,0 +1,132 @@
+"""Respect a locally served robots.txt file during a crawl."""
+
+# --8<-- [start:example]
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import cast
+
+from ladon import (
+    ChildListUnavailableError,
+    CrawlPlugin,
+    Expansion,
+    HttpClient,
+    HttpClientConfig,
+    LeafUnavailableError,
+    Ref,
+    RobotsBlockedError,
+    RunConfig,
+    RunResult,
+    run_crawl,
+)
+
+
+class RobotsHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/robots.txt":
+            body = b"User-agent: example-crawler\nDisallow: /blocked\n"
+        elif self.path == "/allowed":
+            body = json.dumps({"item": "/item"}).encode()
+        elif self.path == "/item":
+            body = json.dumps({"title": "allowed local result"}).encode()
+        elif self.path == "/blocked":
+            body = b"this response must never be fetched"
+        else:
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def build_mock_server() -> tuple[ThreadingHTTPServer, Thread]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RobotsHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+class PublicPageSource:
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url
+
+    def discover(self, client: HttpClient) -> Sequence[Ref]:
+        return [
+            Ref(f"{self._base_url}/allowed"),
+            Ref(f"{self._base_url}/blocked"),
+        ]
+
+
+class PublicPage:
+    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+        response = client.get(ref.url)
+        if isinstance(response.error, RobotsBlockedError):
+            raise response.error
+        if not response.ok or response.value is None:
+            raise ChildListUnavailableError(f"page failed: {response.error}")
+        payload = json.loads(response.value)
+        return Expansion(
+            record={"page": ref.url},
+            child_refs=[Ref(f"{ref.url.rsplit('/', 1)[0]}{payload['item']}")],
+        )
+
+
+class PublicPageSink:
+    def consume(self, ref: Ref, client: HttpClient) -> dict[str, object]:
+        response = client.get(ref.url)
+        if not response.ok or response.value is None:
+            raise LeafUnavailableError(f"item failed: {response.error}")
+        return json.loads(response.value)
+
+
+@dataclass(frozen=True)
+class PublicPagePlugin:
+    name: str
+    source: PublicPageSource
+    expanders: tuple[PublicPage, ...] = (PublicPage(),)
+    sink: PublicPageSink = PublicPageSink()
+
+
+def run_example() -> list[RunResult]:
+    server, thread = build_mock_server()
+    host, port = cast(tuple[str, int], server.server_address)
+    base_url = f"http://{host}:{port}"
+    plugin = PublicPagePlugin("robots-local-site", PublicPageSource(base_url))
+    results: list[RunResult] = []
+    config = HttpClientConfig(
+        user_agent="example-crawler/1.0",
+        respect_robots_txt=True,
+        min_request_interval_seconds=0.0,
+    )
+    try:
+        with HttpClient(config) as client:
+            for top_ref in plugin.source.discover(client):
+                try:
+                    result = run_crawl(
+                        top_ref,
+                        cast("CrawlPlugin", plugin),
+                        client,
+                        RunConfig(leaf_limit=100),
+                    )
+                except RobotsBlockedError as exc:
+                    print(f"skipped {top_ref.url}: {exc}")
+                    continue
+                results.append(result)
+                print(f"saved {result.leaves_consumed} result(s)")
+        return results
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+if __name__ == "__main__":
+    run_example()
+# --8<-- [end:example]

--- a/examples/cookbook/tree_crawl_hackernews.py
+++ b/examples/cookbook/tree_crawl_hackernews.py
@@ -1,0 +1,50 @@
+"""Crawl Hacker News comments using the external ladon-hackernews adapter."""
+
+# --8<-- [start:example]
+from typing import Protocol, cast
+
+from ladon_hackernews import HNPlugin
+
+from ladon import (
+    ExpansionNotReadyError,
+    HttpClient,
+    HttpClientConfig,
+    RunConfig,
+    RunResult,
+    run_crawl,
+)
+
+
+class HasId(Protocol):
+    id: object
+
+
+def print_comment(comment: object, story: object) -> None:
+    print(cast(HasId, story).id, cast(HasId, comment).id)
+
+
+def run_example() -> list[RunResult]:
+    plugin = HNPlugin(top=10)
+    results: list[RunResult] = []
+    with HttpClient(
+        HttpClientConfig(user_agent="my-hn-research-bot/1.0")
+    ) as client:
+        for story_ref in plugin.source.discover(client):
+            try:
+                result = run_crawl(
+                    story_ref,
+                    plugin,
+                    client,
+                    RunConfig(leaf_limit=50),
+                    on_leaf=print_comment,
+                )
+            except ExpansionNotReadyError:
+                continue  # Rediscover this story on the next scheduled run.
+            results.append(result)
+            print(result.leaves_consumed, result.leaves_failed, result.errors)
+    return results
+
+
+if __name__ == "__main__":
+    run_example()
+# --8<-- [end:example]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,10 +117,13 @@ ignore = [
 # ----------------------------------------
 [tool.pyright]
 typeCheckingMode = "strict"
-include = ["src", "tests"]
+include = ["src", "tests", "examples"]
 extraPaths = ["src"]
 reportMissingImports = "none"
 reportUntypedFunctionDecorator = "none"
+executionEnvironments = [
+    { root = "examples", reportUnknownVariableType = "none", reportUnknownMemberType = "none", reportUnknownArgumentType = "none" },
+]
 
 # ----------------------------------------
 # PYTEST


### PR DESCRIPTION
## Summary

Closes #146.

Extracts all six cookbook code samples from inline markdown fences into standalone, runnable scripts under `examples/cookbook/`, transcluded into `docs/guides/cookbook.md` via `pymdownx.snippets` (same mechanism #145 used for CHANGELOG.md, applied in reverse: the script is the source of truth, the doc pulls from it). This makes doc/code drift structurally impossible and unblocks #147 (offline pytest suite) and #148 (scheduled live-network check), which will import these same scripts directly.

- `flat_crawl.py`, `tree_crawl_hackernews.py` — hit real external services (GitHub API, `ladon-hackernews`), as before
- `ref_raw_context.py`, `resume_partial_crawl.py`, `async_crawl.py`, `robots_txt.py` — now fully self-contained, each spins up a local `http.server` mock so they run with zero network dependency
- `resume_partial_crawl.py`'s mock server can actually trigger `ExpansionNotReadyError` and `PartialExpansionError`, demonstrating the real exception-handling flow rather than only the happy path
- `robots_txt.py`'s mock serves a real `/robots.txt`, so `RobotsBlockedError` fires for real

## Verification

Two rounds of review. Round 1 caught a documentation-accuracy gap: the robots.txt prose never explained that `RobotsBlockedError` arrives inside `response.error` (not raised directly by `client.get()`), so a plugin must explicitly check and re-raise it — without that, a naively-written plugin would silently misclassify blocked URLs as generic failures. Fixed with a clarifying prose addition pointing at `PublicPage.expand()`.

All six scripts independently executed (not just read) with correct output, re-verified again after rebasing onto `main` post-#149-merge. `mkdocs build --strict`, `ruff check .`, and the full 672-test suite all pass. `pyright` scoped to `examples/` (added to pyright's include list without strict mode) is clean.