### PR TITLE
ci(cookbook): add scheduled live-network check for GitHub API and Hacker News examples

### DIFF
--- a/.github/workflows/cookbook-live-check.yml
+++ b/.github/workflows/cookbook-live-check.yml
@@ -1,0 +1,68 @@
+name: Cookbook Live Check
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  live-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install Ladon and the Hacker News adapter
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install ladon-hackernews
+
+      - name: Run and verify live cookbook examples
+        run: |
+          python - <<'PY'
+          import runpy
+          import sys
+
+          def fail(message: str) -> None:
+              print(f"Live cookbook check failed: {message}", file=sys.stderr)
+              sys.exit(1)
+
+          flat_results = runpy.run_path(
+              "examples/cookbook/flat_crawl.py"
+          )["run_example"]()
+          if len(flat_results) != 2:
+              fail(f"GitHub example returned {len(flat_results)} runs, expected 2")
+          for index, result in enumerate(flat_results, start=1):
+              if result.leaves_consumed <= 0 or result.errors:
+                  fail(
+                      "GitHub run "
+                      f"{index} was not clean: consumed={result.leaves_consumed}, "
+                      f"errors={result.errors}"
+                  )
+
+          hn_results = runpy.run_path(
+              "examples/cookbook/tree_crawl_hackernews.py"
+          )["run_example"]()
+          if not hn_results:
+              fail("Hacker News example found no ready stories to crawl")
+          if sum(result.leaves_consumed for result in hn_results) <= 0:
+              fail("Hacker News example consumed no comments")
+
+          unexpected_errors = [
+              error
+              for result in hn_results
+              for error in result.errors
+              if "is null, dead, or deleted" not in error
+          ]
+          if unexpected_errors:
+              fail(f"Hacker News returned unexpected errors: {unexpected_errors}")
+          PY

--- a/docs/guides/cookbook.md
+++ b/docs/guides/cookbook.md
@@ -13,6 +13,10 @@ Have your `Source.discover()` return one `Ref` per page, then call
 `run_crawl()` for each returned ref. This example uses a public GitHub API
 listing page; the `page` value is context you can use in logs or persistence.
 
+This example and the Hacker News tree crawl below use live external services,
+so they are verified by a weekly scheduled GitHub Actions check rather than
+the offline pytest suite.
+
 ```python
 --8<-- "examples/cookbook/flat_crawl.py:example"
 ```


### PR DESCRIPTION
## Summary

Closes #148.

Adds `.github/workflows/cookbook-live-check.yml`, running weekly (Mondays 06:00 UTC) plus `workflow_dispatch:`, to catch upstream API drift in the two cookbook examples that hit real external services (`flat_crawl.py` against the GitHub API, `tree_crawl_hackernews.py` against the real `ladon-hackernews` package + live Hacker News). Deliberately not run on every PR — live external dependencies in required checks cause flaky, rate-limited failures unrelated to the change under review.

The workflow asserts meaningfully rather than just checking exit codes: both GitHub runs must be clean (`leaves_consumed > 0`, no errors), and the HN run must consume at least one comment while tolerating only the expected "is null, dead, or deleted" errors (real HN data always has some) — any other error type fails the job.

Also adds a short note in `docs/guides/cookbook.md` explaining why these two examples are live-verified weekly instead of covered by #147's offline suite.

## Verification

Extracted the embedded Python assertion script exactly as GitHub Actions' YAML parser would (via `yaml.safe_load`) and executed it for real against live GitHub API + live Hacker News — exit code 0, correctly passing through real dead/deleted-comment noise while still being strict about unexpected failures. `mkdocs build --strict` and the real `pre-commit run --all-files` both pass.