### PR TITLE
docs(site): add logo, favicon, social cards, and footer branding

### DIFF
--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title>Ladon dragon and golden apple</title>
+  <rect width="64" height="64" rx="14" fill="#3f51b5"/>
+  <circle cx="42" cy="24" r="11" fill="#ffca28"/>
+  <path d="M43 13c-4 1-7 4-8 8" fill="none" stroke="#fff" stroke-linecap="round" stroke-width="3"/>
+  <path d="M17 18c-8 7-8 21 1 28 8 6 20 4 25-4 4-6 2-14-4-17-5-2-10 0-12 4-2 4 0 8 4 9 4 1 7-2 7-5" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="6"/>
+  <path d="m16 18 8 1-5 6z" fill="#fff"/>
+  <circle cx="22" cy="22" r="1.5" fill="#3f51b5"/>
+</svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,8 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  logo: assets/logo.svg
+  favicon: assets/logo.svg
   palette:
     - scheme: default
       primary: indigo
@@ -34,6 +36,7 @@ exclude_docs: |
 
 plugins:
   - search
+  - social
   - mkdocstrings:
       handlers:
         python:
@@ -42,6 +45,17 @@ plugins:
             show_source: true
             members_order: source
             filters: ["!^_"]
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/MoonyFringers/ladon
+      name: Ladon on GitHub
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/ladon-crawl/
+      name: Ladon on PyPI
+
+copyright: Copyright &copy; 2026 MoonyFringers
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ dev = [
 docs = [
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.25",
+    "pillow",
+    "cairosvg",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Closes #140.

Adds a hand-authored SVG logo (coiled serpent + golden apple, referencing the Ladon myth — the dragon that guarded the Hesperides' golden apples), wired as both `theme.logo` and `theme.favicon`. Enables mkdocs-material's `social` plugin for auto-generated Open Graph preview cards (`pillow`/`cairosvg` added to the `docs` extra). Adds footer `extra.social` links to GitHub and PyPI, plus a copyright line.

## Verification

Not just a build check — actually looked at the results:

- Rendered the SVG at 256px, 32px, and 16px (actual favicon size) and visually confirmed it reads as a coiled dragon with an apple, legible at small sizes
- Served the site and confirmed the real rendered HTML: `<link rel="icon" href="assets/logo.svg">`, header/nav `<img src="assets/logo.svg">`, footer GitHub/PyPI links, and copyright text all present and correct
- Viewed one of the 25 auto-generated social card PNGs directly — clean, on-brand, shows page title + description + logo
- Initially suspected a bug (an unrelated bundled theme asset at `site/assets/images/favicon.png` shows mkdocs-material's stock icon) but traced it down: that file is unreferenced boilerplate, not the actual favicon — the real `<link rel="icon">` tag is correct

`mkdocs build --strict` passes (with the social plugin actually generating images, not just config validation) and the real `pre-commit run --all-files` is clean.