### PR TITLE
docs(guides): use a category name instead of a year in example URL

### DIFF
--- a/docs/guides/authoring-plugins.md
+++ b/docs/guides/authoring-plugins.md
@@ -114,7 +114,7 @@ client = HttpClient(config)
 plugin = ShopPlugin(client=client)
 
 result = run_crawl(
-    top_ref="https://example-shop.com/categories/2026",
+    top_ref="https://example-shop.com/categories/electronics",
     plugin=plugin,
     client=client,
     config=RunConfig(leaf_limit=100),
@@ -128,7 +128,7 @@ client.close()
 
 ```bash
 ladon run --plugin mypackage.adapters:ShopPlugin \
-          --ref https://example-shop.com/categories/2026
+          --ref https://example-shop.com/categories/electronics
 ```
 
 The CLI uses default `RunConfig` settings (no leaf limit, no `on_leaf`
@@ -174,7 +174,7 @@ async def main() -> None:
     config = HttpClientConfig(retries=2, min_request_interval_seconds=0.5)
     async with AsyncHttpClient(config) as client:
         result = await async_run_crawl(
-            top_ref="https://example-shop.com/categories/2026",
+            top_ref="https://example-shop.com/categories/electronics",
             plugin=AsyncShopPlugin(),
             client=client,
             config=RunConfig(leaf_limit=100, async_concurrency=20),


### PR DESCRIPTION
## Summary

Closes #158.

Follow-up to #157. Replaces `https://example-shop.com/categories/2026` with `https://example-shop.com/categories/electronics` in all three occurrences in `docs/guides/authoring-plugins.md` — the trailing `/2026` was a leftover from the example's former auction-catalogue framing and read oddly for a generic e-commerce category path.

Purely cosmetic, no technical content changed.

## Verification

`mkdocs build --strict` and the real `pre-commit run --all-files` both pass.