### PR TITLE
docs(first-run): correct response metadata key

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ with HttpClient(config) as client:
     result = client.get("https://httpbin.org/get")
     if result.ok:
         print(result.value)       # response bytes
-        print(result.meta["status"])  # HTTP status code
+        print(result.meta["status_code"])  # HTTP status code
     else:
         print("error:", result.error)
 ```


### PR DESCRIPTION
## Summary

Addresses the immediate first-run crash in #163.

- correct the documented response metadata key from `status` to `status_code`

The source-driven runner contract and its documentation are intentionally owned by #174 / PR #175, so this hotfix stays independently mergeable.

## Verification

- `mkdocs build --strict`
- `pre-commit run --all-files`
- executed the corrected first-request example against httpbin.org
