### PR TITLE
feat(runner): add source-driven crawl entry points

### DIFF
--- a/.github/workflows/cookbook-live-check.yml
+++ b/.github/workflows/cookbook-live-check.yml
@@ -39,9 +39,11 @@ jobs:
           flat_results = runpy.run_path(
               "examples/cookbook/flat_crawl.py"
           )["run_example"]()
-          if len(flat_results) != 2:
-              fail(f"GitHub example returned {len(flat_results)} runs, expected 2")
-          for index, result in enumerate(flat_results, start=1):
+          if len(flat_results.results) != 2:
+              fail(
+                  f"GitHub example returned {len(flat_results.results)} runs, expected 2"
+              )
+          for index, result in enumerate(flat_results.results, start=1):
               if result.leaves_consumed <= 0 or result.errors:
                   fail(
                       "GitHub run "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`run_plugin()` / `async_run_plugin()`** — source-driven whole-plugin
+  entry points. They discover roots once, preserve one `RunResult` per root,
+  and return aggregate counts and source-indexed errors in `PluginRunResult`.
 - **`rejection_info()`** — optional duck-typed extension point on
   `FetchPredicate` implementations for adding predicate-specific diagnostics
   to `predicate_rejected` decision-event metadata.

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ ladon --version
 Exit codes: `0` success · `1` fatal error · `2` partial failures · `3` data not ready (retry later)
 
 `ladon run` uses default `HttpClientConfig` settings. For retries, rate
-limiting, circuit breaking, or a persistence layer, call `run_crawl()`
-directly from Python — see
+limiting, circuit breaking, or a persistence layer, call `run_plugin()`
+directly from Python; use `run_crawl()` when your application already owns a
+single top-level ref — see
 [`ladon-hackernews` — Use as a library](https://github.com/MoonyFringers/ladon-hackernews#use-as-a-library)
 for a full example.
 
@@ -137,21 +138,21 @@ considerations.
 
 ## Async crawling
 
-`async_run_crawl()` is the asyncio-native counterpart to `run_crawl()`.
-Phase 1 (expander traversal) runs sequentially; Phase 3 issues leaf fetches
+`async_run_plugin()` is the asyncio-native whole-plugin entry point. It
+discovers roots once and processes them in source order; for each root, Phase 1
+(expander traversal) runs sequentially and Phase 3 issues leaf fetches
 concurrently behind `asyncio.Semaphore(config.async_concurrency)` (default 10):
 
 ```python
 import asyncio
-from ladon import AsyncHttpClient, async_run_crawl
+from ladon import AsyncHttpClient, async_run_plugin
 from ladon.networking.config import HttpClientConfig
 from ladon.runner import RunConfig
 
 async def main() -> None:
     config = HttpClientConfig(retries=2, timeout_seconds=10)
     async with AsyncHttpClient(config) as client:
-        result = await async_run_crawl(
-            top_ref=my_ref,
+        result = await async_run_plugin(
             plugin=my_async_plugin,
             client=client,
             config=RunConfig(async_concurrency=20),

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -7,6 +7,22 @@ protocols are structural (PEP 544) — no inheritance from Ladon is required.
 
 Ladon ships two parallel protocol hierarchies: sync and async.
 
+## Running a plugin
+
+Use `run_plugin()` for the normal whole-plugin path: it calls
+`plugin.source.discover(client)` once, runs every discovered root in source
+order, and returns a `PluginRunResult`. The aggregate exposes total leaf
+counts and errors while retaining a `RunResult` per root in `results`.
+`RunConfig.leaf_limit` applies separately to every discovered root. If a
+later root raises a globally fatal error, earlier roots may already have run
+their `on_leaf` callback; make that callback idempotent when retrying a whole
+plugin run.
+
+`run_crawl(top_ref, ...)` remains available when the caller intentionally
+owns root discovery or needs to process one known root. The async equivalents
+are `async_run_plugin()` and `async_run_crawl()`; async whole-plugin runs keep
+root processing ordered, while each root's leaf work uses `async_concurrency`.
+
 ## Sync protocols
 
 ::: ladon.plugins.protocol
@@ -14,8 +30,7 @@ Ladon ships two parallel protocol hierarchies: sync and async.
 ## Async protocols
 
 The async protocols mirror the sync ones exactly but use `async def`
-methods and accept `AsyncHttpClient` instead of `HttpClient`.  Use them
-with `async_run_crawl()`.
+methods and accept `AsyncHttpClient` instead of `HttpClient`.
 
 ::: ladon.plugins.async_protocol
 

--- a/docs/api/runner.md
+++ b/docs/api/runner.md
@@ -1,16 +1,31 @@
 # Runner API
 
-The runner drives the crawl loop: it expands refs through the plugin's
-expander chain and passes each leaf to the sink.
+The runner drives the crawl loop: it discovers a plugin's roots, expands refs
+through the expander chain, and passes each leaf to the sink.
 
-Ladon ships two runners: a synchronous `run_crawl()` and an async
-`async_run_crawl()`.  Both use the same `RunConfig` and return the same
-`RunResult`.
+Use `run_plugin()` or `async_run_plugin()` for a complete plugin run. They
+call `Source.discover()` once and return a `PluginRunResult` containing the
+individual `RunResult` values and their aggregate counts. Use `run_crawl()` or
+`async_run_crawl()` only when the caller deliberately owns root discovery or
+needs to process one known root.
+
+All runners use the same `RunConfig`. Its `leaf_limit` is a per-root cap for
+whole-plugin runs. If a later root raises a globally fatal error, earlier
+roots may already have invoked `on_leaf`; persistence callbacks must therefore
+be idempotent when retrying `run_plugin()` or `async_run_plugin()`.
 
 ## See also
 
 [Concepts](../guides/concepts.md) explains the `RunResult` counters and the
 typed plugin errors that determine runner recovery behaviour.
+
+## run_plugin
+
+::: ladon.runner.run_plugin
+
+## async_run_plugin
+
+::: ladon.async_runner.async_run_plugin
 
 ## run_crawl
 
@@ -27,3 +42,7 @@ typed plugin errors that determine runner recovery behaviour.
 ## RunResult
 
 ::: ladon.runner.RunResult
+
+## PluginRunResult
+
+::: ladon.runner.PluginRunResult

--- a/docs/decisions/adr-004-ses-protocol-design.md
+++ b/docs/decisions/adr-004-ses-protocol-design.md
@@ -75,13 +75,27 @@ class CrawlPlugin(Protocol):
     def sink(self) -> Sink: ...
 ```
 
-The runner drives the pipeline for a single `top_ref`:
+`run_crawl()` drives the pipeline for a single `top_ref`:
 
 1. **Phase 1 — Expand**: traverse `expanders` in order; each level produces
    refs for the next.
 2. **Phase 2 — Limit**: apply `RunConfig.leaf_limit` if set.
 3. **Phase 3 — Sink**: consume each leaf ref; fire `on_leaf` callback after
    each success.
+
+For the normal whole-plugin path, `run_plugin()` calls `Source.discover()`
+once and delegates each discovered root to `run_crawl()` in source order.
+It returns a `PluginRunResult` with the individual root outcomes and aggregate
+counts. `async_run_plugin()` provides the corresponding async entry point;
+root dispatch stays ordered while each root retains `async_concurrency` for
+its leaves. This keeps `Source` an executable part of the plugin contract
+without changing the lower-level single-root API.
+
+`RunConfig.leaf_limit` remains a per-root cap: `run_plugin()` forwards the
+same configuration to every discovered root. A globally fatal error still
+propagates rather than producing a partial aggregate. Consequently, roots
+completed before a later failure may already have called `on_leaf`; persistence
+callbacks used with the whole-plugin API must be idempotent across retries.
 
 ### The three roles
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,19 @@ ladon run --plugin mypackage.adapters:MyPlugin --ref https://example.com
 given reference URL.  Exit codes: 0 = success, 1 = error, 2 = partial
 failures, 3 = data not ready (retry later).  Uses default `HttpClientConfig`
 settings (30 s timeout, no retries, no rate limiting).  For fine-grained
-control call `run_crawl()` directly from Python.
+control, call `run_plugin()` directly from Python; use `run_crawl()` only when
+your application already owns one top-level ref.
+
+## Running a complete plugin from Python
+
+`run_plugin()` is the normal library entry point. It calls the plugin's
+`Source.discover()` once and returns aggregate counts plus one `RunResult` per
+discovered root. `RunConfig(leaf_limit=...)` applies to each root. If a later
+root raises a globally fatal error, earlier roots may already have persisted
+records through `on_leaf`, so make that callback idempotent before retrying.
+
+See [Authoring Plugins](guides/authoring-plugins.md) for a complete sync and
+async example.
 
 ## Configuration reference
 
@@ -121,11 +133,12 @@ the config is immutable after construction.
 
 ## Async crawling
 
-For high-throughput crawls use `async_run_crawl()` with `AsyncHttpClient`:
+For high-throughput whole-plugin crawls use `async_run_plugin()` with
+`AsyncHttpClient`:
 
 ```python
 import asyncio
-from ladon import AsyncHttpClient, async_run_crawl
+from ladon import AsyncHttpClient, async_run_plugin
 from ladon.networking.config import HttpClientConfig
 from ladon.runner import RunConfig
 
@@ -133,8 +146,7 @@ config = HttpClientConfig(retries=2, timeout_seconds=10)
 
 async def main() -> None:
     async with AsyncHttpClient(config) as client:
-        result = await async_run_crawl(
-            top_ref=my_ref,
+        result = await async_run_plugin(
             plugin=my_async_plugin,
             client=client,
             config=RunConfig(async_concurrency=20),
@@ -150,7 +162,7 @@ fetches concurrently behind `asyncio.Semaphore(async_concurrency)`.  Each
 slot covers the full `sink.consume()` + `on_leaf` pair so slow callbacks
 do not cause unbounded parallelism.
 
-`on_leaf` must be an `async def` function when used with `async_run_crawl`.
+`on_leaf` must be an `async def` function when used with `async_run_plugin`.
 
 ## Next steps
 
@@ -158,4 +170,4 @@ do not cause unbounded parallelism.
 - [Cookbook](guides/cookbook.md) — runnable patterns for common real-world crawls
 - [Authoring Plugins](guides/authoring-plugins.md) — build a site adapter
 - [API Reference → Networking](api/networking.md) — `HttpClient`, `AsyncHttpClient`, and config
-- [API Reference → Runner](api/runner.md) — `run_crawl`, `async_run_crawl`, and result types
+- [API Reference → Runner](api/runner.md) — whole-plugin and single-root runners, plus result types

--- a/docs/guides/authoring-plugins.md
+++ b/docs/guides/authoring-plugins.md
@@ -107,14 +107,13 @@ class ShopPlugin:
 ```python
 from ladon.networking.client import HttpClient
 from ladon.networking.config import HttpClientConfig
-from ladon.runner import RunConfig, run_crawl
+from ladon.runner import RunConfig, run_plugin
 
 config = HttpClientConfig(retries=2, min_request_interval_seconds=1.0)
 client = HttpClient(config)
 plugin = ShopPlugin(client=client)
 
-result = run_crawl(
-    top_ref="https://example-shop.com/categories/electronics",
+result = run_plugin(
     plugin=plugin,
     client=client,
     config=RunConfig(leaf_limit=100),
@@ -124,6 +123,14 @@ print(f"fetched {result.leaves_consumed}, failed {result.leaves_failed}")
 client.close()
 ```
 
+`run_plugin()` calls `plugin.source.discover(client)` once and processes each
+returned root in source order. Its `PluginRunResult.results` preserves each
+root's `RunResult`; `leaf_limit` applies per root. Use `run_crawl(top_ref, ...)`
+when your application deliberately owns discovery or has one known root.
+If a later root raises a globally fatal error, earlier roots may already have
+called `on_leaf`; make persistence callbacks idempotent before retrying a
+whole-plugin run.
+
 ## Running from the CLI
 
 ```bash
@@ -132,13 +139,13 @@ ladon run --plugin mypackage.adapters:ShopPlugin \
 ```
 
 The CLI uses default `RunConfig` settings (no leaf limit, no `on_leaf`
-callback).  For production use write a Python script that calls `run_crawl`
-directly.
+callback). For production use write a Python script that usually calls
+`run_plugin()`; use `run_crawl()` when you need explicit per-root dispatch.
 
 ## Async plugins
 
 For high-concurrency crawls implement `AsyncCrawlPlugin` and call
-`async_run_crawl()` instead.  The async protocols mirror the sync ones with
+`async_run_plugin()` instead. The async protocols mirror the sync ones with
 `async def` methods and `AsyncHttpClient` as the client parameter.
 
 ```python
@@ -166,15 +173,14 @@ Run it:
 
 ```python
 import asyncio
-from ladon import AsyncHttpClient, async_run_crawl
+from ladon import AsyncHttpClient, async_run_plugin
 from ladon.networking.config import HttpClientConfig
 from ladon.runner import RunConfig
 
 async def main() -> None:
     config = HttpClientConfig(retries=2, min_request_interval_seconds=0.5)
     async with AsyncHttpClient(config) as client:
-        result = await async_run_crawl(
-            top_ref="https://example-shop.com/categories/electronics",
+        result = await async_run_plugin(
             plugin=AsyncShopPlugin(),
             client=client,
             config=RunConfig(leaf_limit=100, async_concurrency=20),
@@ -185,9 +191,9 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-`async_run_crawl` accepts the same `RunConfig` as `run_crawl`.  The
+`async_run_plugin` accepts the same `RunConfig` as `run_plugin`. The
 `async_concurrency` field controls how many leaf fetches run simultaneously
-(default 10).  The sync runner ignores it.
+(within each discovered root; default 10). The sync runner ignores it.
 
 ## Error taxonomy
 

--- a/docs/guides/cookbook.md
+++ b/docs/guides/cookbook.md
@@ -3,15 +3,16 @@
 These patterns are small, complete crawl building blocks. They use Ladon's
 current Source → Expander → Sink contracts: a source discovers root `Ref`s,
 each expander returns an `Expansion`, and the sink turns leaf refs into
-records. Replace the parsing and URLs with those for the site you are allowed
-to crawl.
+records. `run_plugin()` drives the source and each discovered root; use the
+single-root `run_crawl()` only when your caller deliberately owns dispatch.
+Replace the parsing and URLs with those for the site you are allowed to crawl.
 
 ## Flat crawl: one listing page to item records
 
 Use one expander when every page in a paginated listing contains the leaves.
 Have your `Source.discover()` return one `Ref` per page, then call
-`run_crawl()` for each returned ref. This example uses a public GitHub API
-listing page; the `page` value is context you can use in logs or persistence.
+`run_plugin()` once. This example uses a public GitHub API listing page; the
+`page` value is context you can use in logs or persistence.
 
 This example and the Hacker News tree crawl below use live external services,
 so they are verified by a weekly scheduled GitHub Actions check rather than

--- a/docs/guides/how-ladon-works.md
+++ b/docs/guides/how-ladon-works.md
@@ -20,16 +20,25 @@ Source  →  [Expander, …]  →  Sink
 | **Expander** | What's inside this node? | A record + child refs |
 | **Sink** | What's at this leaf? | A final record |
 
-The runner drives the pipeline:
+For the normal whole-plugin path, call `run_plugin()` (or
+`async_run_plugin()`). Ladon calls `Source.discover()` once, dispatches the
+discovered roots in source order, and then:
 
-1. Call `Source.discover()` to get the top-level ref list.
-2. For each ref, call the first `Expander.expand()` to get its record and children.
-3. Repeat with subsequent Expanders for deeper levels.
-4. Call `Sink.consume()` on every leaf ref.
-5. Fire the `on_leaf` callback (your persistence hook) after each success.
+1. Calls the first `Expander.expand()` for each root to get its record and children.
+2. Repeats with subsequent Expanders for deeper levels.
+3. Calls `Sink.consume()` on every leaf ref.
+4. Fires the `on_leaf` callback (your persistence hook) after each success.
 
-You never write the loop. Ladon owns traversal, error counting, rate limiting,
-and the leaf limit. Your code owns the parsing.
+Ladon owns discovery, traversal, error counting, rate limiting, and the leaf
+limit. Your code owns the parsing. Use `run_crawl(top_ref, ...)` or
+`async_run_crawl(top_ref, ...)` only when your application deliberately owns
+root discovery or must process one known root. For that lower-level path, call
+`Source.discover(client)` and loop over its refs, calling `run_crawl()` once
+per ref. With the async API, discovery must be awaited: call
+`await AsyncSource.discover(client)` and loop over its refs, calling
+`async_run_crawl()` once per ref. See the [Hacker News tree-crawl cookbook
+example](cookbook.md#multi-level-tree-crawl-hacker-news) for the complete
+pattern.
 
 ## A concrete example: Hacker News
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ plumbing.
 | robots.txt | RFC 9309 enforcement with fail-open and Crawl-delay propagation |
 | Plugin protocol | Typed `Expander` / `Sink` / `CrawlPlugin` interface |
 | Result type | `Ok` / `Err` without exceptions crossing API boundaries |
-| Async crawling | `async_run_crawl()` with `asyncio.Semaphore` concurrency control |
+| Plugin crawling | `run_plugin()` / `async_run_plugin()` with source discovery and bounded leaf concurrency |
 | Async client | `AsyncHttpClient` — full httpx-backed mirror of `HttpClient` |
 
 ## Quick start

--- a/examples/cookbook/flat_crawl.py
+++ b/examples/cookbook/flat_crawl.py
@@ -13,10 +13,10 @@ from ladon import (
     HttpClient,
     HttpClientConfig,
     LeafUnavailableError,
+    PluginRunResult,
     Ref,
     RunConfig,
-    RunResult,
-    run_crawl,
+    run_plugin,
 )
 
 
@@ -60,19 +60,14 @@ class GitHubIssuesPlugin:
     sink: IssueSink = IssueSink()
 
 
-def run_example() -> list[RunResult]:
+def run_example() -> PluginRunResult:
     plugin = GitHubIssuesPlugin()
-    results: list[RunResult] = []
     with HttpClient(
         HttpClientConfig(user_agent="example-crawler/1.0")
     ) as client:
-        for page_ref in plugin.source.discover(client):
-            result = run_crawl(
-                page_ref, cast("CrawlPlugin", plugin), client, RunConfig()
-            )
-            results.append(result)
-            print(result.leaves_consumed, result.errors)
-    return results
+        result = run_plugin(cast("CrawlPlugin", plugin), client, RunConfig())
+        print(result.leaves_consumed, result.errors)
+        return result
 
 
 if __name__ == "__main__":

--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -2,7 +2,12 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from .async_runner import async_run_crawl, execute_plan, plan_crawl
+from .async_runner import (
+    async_run_crawl,
+    async_run_plugin,
+    execute_plan,
+    plan_crawl,
+)
 from .mcp import LadonMCPAdapter
 from .networking import make_async_http_client, make_http_client
 from .networking.async_client import AsyncHttpClient
@@ -43,11 +48,13 @@ from .plugins import (
 )
 from .runner import (
     CrawlPlan,
+    PluginRunResult,
     RunConfig,
     RunResult,
     execute_plan_sync,
     plan_crawl_sync,
     run_crawl,
+    run_plugin,
 )
 from .storage import (
     LocalFileStorage,
@@ -69,13 +76,16 @@ except PackageNotFoundError:
 __all__ = [
     # Runner — sync
     "run_crawl",
+    "run_plugin",
     "plan_crawl_sync",
     "execute_plan_sync",
     "RunConfig",
     "RunResult",
+    "PluginRunResult",
     "CrawlPlan",
     # Runner — async
     "async_run_crawl",
+    "async_run_plugin",
     "plan_crawl",
     "execute_plan",
     # Sync plugin protocols

--- a/src/ladon/async_runner.py
+++ b/src/ladon/async_runner.py
@@ -43,7 +43,12 @@ from ladon.plugins.errors import (
     LeafUnavailableError,
     PartialExpansionError,
 )
-from ladon.runner import CrawlPlan, RunConfig, RunResult
+from ladon.runner import (
+    CrawlPlan,
+    PluginRunResult,
+    RunConfig,
+    RunResult,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -230,6 +235,37 @@ async def async_run_crawl(
         leaves_failed=leaves_failed,
         errors=tuple(errors),
     )
+
+
+async def async_run_plugin(
+    plugin: AsyncCrawlPlugin,
+    client: AsyncHttpClient,
+    config: RunConfig,
+    on_leaf: Callable[[object, object], Awaitable[None]] | None = None,
+) -> PluginRunResult:
+    """Discover and run every top-level ref exposed by an async plugin.
+
+    This is the whole-plugin counterpart to :func:`async_run_crawl`. It
+    awaits ``plugin.source.discover(client)`` exactly once, then processes
+    roots in source order. Each root retains the existing bounded concurrent
+    leaf processing from :func:`async_run_crawl`; roots are intentionally not
+    run concurrently so the public API has one clear concurrency boundary.
+
+    Discovery and globally-fatal per-root errors propagate unchanged rather
+    than being converted into a partial aggregate. Earlier roots may already
+    have invoked ``on_leaf`` when a later root aborts, so callbacks must be
+    idempotent if the caller retries the plugin.
+    """
+
+    top_refs = tuple(await plugin.source.discover(client))
+    results: list[RunResult] = []
+    for top_ref in top_refs:
+        results.append(
+            await async_run_crawl(
+                top_ref, plugin, client, config, on_leaf=on_leaf
+            )
+        )
+    return PluginRunResult.from_runs(top_refs, tuple(results))
 
 
 async def plan_crawl(

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -91,9 +91,11 @@ class CrawlPlan:
 
 @dataclass(frozen=True)
 class RunConfig:
-    """Configuration for a single runner invocation.
+    """Configuration for one single-root runner invocation.
 
-    ``leaf_limit`` caps the number of leaves processed; 0 means no limit.
+    ``leaf_limit`` caps the number of leaves processed by one root; 0 means
+    no limit. ``run_plugin()`` applies the same cap independently to every
+    root discovered by its source.
     ``async_concurrency`` bounds the number of concurrent leaf-processing
     slots in ``async_run_crawl`` — each slot covers the full
     ``sink.consume()`` + ``on_leaf`` pair, so slow callbacks reduce effective
@@ -143,6 +145,52 @@ class RunResult:
     leaves_persisted: int
     leaves_failed: int
     errors: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PluginRunResult:
+    """Aggregate outcome of running every top-level ref from a plugin Source.
+
+    ``top_refs`` and ``results`` have the same order and length: result ``i``
+    is the outcome for discovered ref ``i``. ``errors`` flattens each
+    per-root result's errors with its stable source-order index so callers can
+    consume a single summary without losing the individual ``RunResult``
+    values.
+
+    ``RunConfig.leaf_limit`` applies independently to each top-level run,
+    because :func:`run_plugin` delegates to :func:`run_crawl` once per
+    discovered ref. A discovery failure or an exception that is globally fatal
+    for a root keeps the existing runner semantics and propagates instead of
+    returning a partial aggregate. Earlier roots may already have invoked
+    ``on_leaf`` when a later root aborts, so callbacks passed to
+    :func:`run_plugin` must be idempotent if the caller retries the plugin.
+    """
+
+    top_refs: tuple[object, ...]
+    results: tuple[RunResult, ...]
+    leaves_consumed: int
+    leaves_persisted: int
+    leaves_failed: int
+    errors: tuple[str, ...]
+
+    @classmethod
+    def from_runs(
+        cls, top_refs: tuple[object, ...], results: tuple[RunResult, ...]
+    ) -> PluginRunResult:
+        """Build a stable aggregate from source-order per-root outcomes."""
+
+        return cls(
+            top_refs=top_refs,
+            results=results,
+            leaves_consumed=sum(result.leaves_consumed for result in results),
+            leaves_persisted=sum(result.leaves_persisted for result in results),
+            leaves_failed=sum(result.leaves_failed for result in results),
+            errors=tuple(
+                f"top_ref[{index}]: {error}"
+                for index, result in enumerate(results)
+                for error in result.errors
+            ),
+        )
 
 
 def run_crawl(
@@ -308,6 +356,48 @@ def run_crawl(
         leaves_failed=leaves_failed,
         errors=tuple(errors),
     )
+
+
+def run_plugin(
+    plugin: CrawlPlugin,
+    client: HttpClient,
+    config: RunConfig,
+    on_leaf: Callable[[object, object], None] | None = None,
+) -> PluginRunResult:
+    """Discover and run every top-level ref exposed by a sync plugin.
+
+    This is the whole-plugin counterpart to :func:`run_crawl`. It calls
+    ``plugin.source.discover(client)`` exactly once, then processes discovered
+    refs in source order by delegating to :func:`run_crawl`.
+
+    Processing roots sequentially deliberately avoids introducing a second,
+    undocumented concurrency layer. Use :func:`async_run_plugin` for async
+    adapters; it preserves this root ordering while each root's leaves retain
+    the configured ``async_concurrency``.
+
+    Args:
+        plugin:  Crawl plugin providing a source, expanders, and sink.
+        client:  Configured HttpClient instance.
+        config:  Run configuration forwarded to each discovered root.
+        on_leaf: Optional callback forwarded to each :func:`run_crawl` call.
+
+    Returns:
+        A PluginRunResult containing source-order per-root outcomes and totals.
+
+    Raises:
+        Exception: Propagates exceptions from ``source.discover`` and
+            :func:`run_crawl`. Globally fatal expansion errors are never
+            converted into a partial aggregate. Roots completed before a later
+            fatal error may already have invoked ``on_leaf``; callbacks must
+            therefore be idempotent when the caller retries the whole plugin.
+    """
+
+    top_refs = tuple(plugin.source.discover(client))
+    results = tuple(
+        run_crawl(top_ref, plugin, client, config, on_leaf=on_leaf)
+        for top_ref in top_refs
+    )
+    return PluginRunResult.from_runs(top_refs, results)
 
 
 def plan_crawl_sync(

--- a/tests/test_async_plugin_runner.py
+++ b/tests/test_async_plugin_runner.py
@@ -1,0 +1,249 @@
+# pyright: reportUnknownMemberType=false
+"""Contract tests for the source-driven async runner entry point."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+
+from ladon.async_runner import async_run_plugin
+from ladon.networking.async_client import AsyncHttpClient
+from ladon.plugins.async_protocol import (
+    AsyncCrawlPlugin,
+    AsyncExpander,
+    AsyncSink,
+    AsyncSource,
+)
+from ladon.plugins.errors import ExpansionNotReadyError, LeafUnavailableError
+from ladon.plugins.models import Expansion, Ref
+from ladon.runner import PluginRunResult, RunConfig
+
+
+@dataclass(frozen=True)
+class _Record:
+    url: str
+
+
+class _AsyncSource:
+    def __init__(self, refs: Sequence[Ref]) -> None:
+        self._refs = refs
+        self.calls = 0
+
+    async def discover(self, client: AsyncHttpClient) -> Sequence[Ref]:
+        self.calls += 1
+        return self._refs
+
+
+class _AsyncExpander:
+    def __init__(
+        self,
+        error: Exception | None = None,
+        error_for: Callable[[Ref], Exception | None] | None = None,
+    ) -> None:
+        self._error = error
+        self._error_for = error_for
+
+    async def expand(self, ref: object, client: AsyncHttpClient) -> Expansion:
+        if self._error is not None:
+            raise self._error
+        assert isinstance(ref, Ref)
+        if self._error_for is not None:
+            error = self._error_for(ref)
+            if error is not None:
+                raise error
+        return Expansion(
+            record=_Record(ref.url),
+            child_refs=(Ref(f"{ref.url}/leaf/1"), Ref(f"{ref.url}/leaf/2")),
+        )
+
+
+class _AsyncSink:
+    def __init__(self, fail: Callable[[Ref], bool] | None = None) -> None:
+        self._fail: Callable[[Ref], bool] = fail or _never_fail
+
+    async def consume(self, ref: object, client: AsyncHttpClient) -> _Record:
+        assert isinstance(ref, Ref)
+        if self._fail(ref):
+            raise LeafUnavailableError("unavailable")
+        return _Record(ref.url)
+
+
+class _AsyncPlugin:
+    name = "whole-async-plugin"
+
+    def __init__(
+        self,
+        refs: Sequence[Ref],
+        *,
+        expander: _AsyncExpander | None = None,
+        sink: _AsyncSink | None = None,
+    ) -> None:
+        self.source: AsyncSource = _AsyncSource(refs)
+        self.expanders: Sequence[AsyncExpander] = (
+            expander or _AsyncExpander(),
+        )
+        self.sink: AsyncSink = sink or _AsyncSink()
+
+
+def _never_fail(_ref: Ref) -> bool:
+    return False
+
+
+def _refs() -> tuple[Ref, Ref]:
+    return (
+        Ref("https://example.test/top/1"),
+        Ref("https://example.test/top/2"),
+    )
+
+
+def test_async_whole_plugin_api_is_exported_from_ladon() -> None:
+    from ladon import async_run_plugin as exported_async_run_plugin
+
+    assert exported_async_run_plugin is async_run_plugin
+
+
+async def test_runs_every_discovered_root_and_aggregates_results() -> None:
+    plugin = _AsyncPlugin(_refs())
+
+    result = await async_run_plugin(
+        cast(AsyncCrawlPlugin, plugin), cast(AsyncHttpClient, None), RunConfig()
+    )
+
+    assert isinstance(result, PluginRunResult)
+    assert isinstance(plugin.source, _AsyncSource)
+    assert plugin.source.calls == 1
+    assert result.top_refs == _refs()
+    assert len(result.results) == 2
+    assert result.leaves_consumed == 4
+    assert result.leaves_persisted == 4
+    assert result.leaves_failed == 0
+    assert result.errors == ()
+
+
+async def test_empty_discovery_returns_zero_count_aggregate() -> None:
+    plugin = _AsyncPlugin(())
+
+    result = await async_run_plugin(
+        cast(AsyncCrawlPlugin, plugin), cast(AsyncHttpClient, None), RunConfig()
+    )
+
+    assert isinstance(plugin.source, _AsyncSource)
+    assert plugin.source.calls == 1
+    assert result.top_refs == ()
+    assert result.results == ()
+    assert result.leaves_consumed == 0
+    assert result.leaves_persisted == 0
+    assert result.leaves_failed == 0
+    assert result.errors == ()
+
+
+async def test_forwards_on_leaf_to_each_single_root_run() -> None:
+    plugin = _AsyncPlugin(_refs())
+    received: list[tuple[_Record, _Record]] = []
+
+    async def on_leaf(leaf: object, parent: object) -> None:
+        assert isinstance(leaf, _Record)
+        assert isinstance(parent, _Record)
+        received.append((leaf, parent))
+
+    result = await async_run_plugin(
+        cast(AsyncCrawlPlugin, plugin),
+        cast(AsyncHttpClient, None),
+        RunConfig(),
+        on_leaf=on_leaf,
+    )
+
+    assert result.leaves_persisted == 4
+    assert len(received) == 4
+
+
+async def test_applies_leaf_limit_to_each_discovered_root() -> None:
+    result = await async_run_plugin(
+        cast(AsyncCrawlPlugin, _AsyncPlugin(_refs())),
+        cast(AsyncHttpClient, None),
+        RunConfig(leaf_limit=1),
+    )
+
+    assert result.leaves_consumed == 2
+    assert tuple(run.leaves_consumed for run in result.results) == (1, 1)
+
+
+async def test_aggregates_leaf_errors_with_root_index() -> None:
+    plugin = _AsyncPlugin(
+        _refs(), sink=_AsyncSink(lambda ref: ref.url.endswith("top/2/leaf/2"))
+    )
+
+    result = await async_run_plugin(
+        cast(AsyncCrawlPlugin, plugin), cast(AsyncHttpClient, None), RunConfig()
+    )
+
+    assert result.leaves_consumed == 3
+    assert result.leaves_failed == 1
+    assert result.errors == ("top_ref[1]: ref[1] consume failed: unavailable",)
+    assert result.results[0].errors == ()
+    assert result.results[1].errors == ("ref[1] consume failed: unavailable",)
+
+
+async def test_discovery_errors_propagate() -> None:
+    class _FailingSource(_AsyncSource):
+        async def discover(self, client: AsyncHttpClient) -> Sequence[Ref]:
+            raise RuntimeError("discovery failed")
+
+    plugin = _AsyncPlugin(_refs())
+    plugin.source = _FailingSource(())
+
+    with pytest.raises(RuntimeError, match="discovery failed"):
+        await async_run_plugin(
+            cast(AsyncCrawlPlugin, plugin),
+            cast(AsyncHttpClient, None),
+            RunConfig(),
+        )
+
+
+async def test_globally_fatal_root_errors_propagate() -> None:
+    plugin = _AsyncPlugin(
+        _refs(), expander=_AsyncExpander(ExpansionNotReadyError("later"))
+    )
+
+    with pytest.raises(ExpansionNotReadyError, match="later"):
+        await async_run_plugin(
+            cast(AsyncCrawlPlugin, plugin),
+            cast(AsyncHttpClient, None),
+            RunConfig(),
+        )
+
+
+async def test_later_fatal_root_preserves_earlier_callback_side_effects() -> (
+    None
+):
+    persisted: list[str] = []
+    plugin = _AsyncPlugin(
+        _refs(),
+        expander=_AsyncExpander(
+            error_for=lambda ref: (
+                ExpansionNotReadyError("later")
+                if ref.url.endswith("top/2")
+                else None
+            )
+        ),
+    )
+
+    async def on_leaf(leaf: object, _parent: object) -> None:
+        assert isinstance(leaf, _Record)
+        persisted.append(leaf.url)
+
+    with pytest.raises(ExpansionNotReadyError, match="later"):
+        await async_run_plugin(
+            cast(AsyncCrawlPlugin, plugin),
+            cast(AsyncHttpClient, None),
+            RunConfig(),
+            on_leaf=on_leaf,
+        )
+
+    assert persisted == [
+        "https://example.test/top/1/leaf/1",
+        "https://example.test/top/1/leaf/2",
+    ]

--- a/tests/test_plugin_runner.py
+++ b/tests/test_plugin_runner.py
@@ -1,0 +1,237 @@
+# pyright: reportUnknownMemberType=false
+"""Contract tests for the source-driven sync runner entry point."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+
+from ladon.networking.client import HttpClient
+from ladon.plugins.errors import ExpansionNotReadyError, LeafUnavailableError
+from ladon.plugins.models import Expansion, Ref
+from ladon.plugins.protocol import CrawlPlugin, Expander, Sink, Source
+from ladon.runner import PluginRunResult, RunConfig, run_plugin
+
+
+@dataclass(frozen=True)
+class _Record:
+    url: str
+
+
+class _Source:
+    def __init__(self, refs: Sequence[Ref]) -> None:
+        self._refs = refs
+        self.calls = 0
+
+    def discover(self, client: HttpClient) -> Sequence[Ref]:
+        self.calls += 1
+        return self._refs
+
+
+class _Expander:
+    def __init__(
+        self,
+        error: Exception | None = None,
+        error_for: Callable[[Ref], Exception | None] | None = None,
+    ) -> None:
+        self._error = error
+        self._error_for = error_for
+
+    def expand(self, ref: object, client: HttpClient) -> Expansion:
+        if self._error is not None:
+            raise self._error
+        assert isinstance(ref, Ref)
+        if self._error_for is not None:
+            error = self._error_for(ref)
+            if error is not None:
+                raise error
+        return Expansion(
+            record=_Record(ref.url),
+            child_refs=(Ref(f"{ref.url}/leaf/1"), Ref(f"{ref.url}/leaf/2")),
+        )
+
+
+class _Sink:
+    def __init__(self, fail: Callable[[Ref], bool] | None = None) -> None:
+        self._fail: Callable[[Ref], bool] = fail or _never_fail
+
+    def consume(self, ref: object, client: HttpClient) -> _Record:
+        assert isinstance(ref, Ref)
+        if self._fail(ref):
+            raise LeafUnavailableError("unavailable")
+        return _Record(ref.url)
+
+
+class _Plugin:
+    name = "whole-plugin"
+
+    def __init__(
+        self,
+        refs: Sequence[Ref],
+        *,
+        expander: _Expander | None = None,
+        sink: _Sink | None = None,
+    ) -> None:
+        self.source: Source = _Source(refs)
+        self.expanders: Sequence[Expander] = (expander or _Expander(),)
+        self.sink: Sink = sink or _Sink()
+
+
+def _never_fail(_ref: Ref) -> bool:
+    return False
+
+
+def _refs() -> tuple[Ref, Ref]:
+    return (
+        Ref("https://example.test/top/1"),
+        Ref("https://example.test/top/2"),
+    )
+
+
+def test_sync_whole_plugin_api_is_exported_from_ladon() -> None:
+    from ladon import PluginRunResult as exported_result
+    from ladon import run_plugin as exported_run_plugin
+
+    assert exported_result is PluginRunResult
+    assert exported_run_plugin is run_plugin
+
+
+def test_runs_every_discovered_root_and_aggregates_results() -> None:
+    plugin = _Plugin(_refs())
+
+    result = run_plugin(
+        cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+    )
+
+    assert isinstance(result, PluginRunResult)
+    assert isinstance(plugin.source, _Source)
+    assert plugin.source.calls == 1
+    assert result.top_refs == _refs()
+    assert len(result.results) == 2
+    assert result.leaves_consumed == 4
+    assert result.leaves_persisted == 4
+    assert result.leaves_failed == 0
+    assert result.errors == ()
+
+
+def test_empty_discovery_returns_zero_count_aggregate() -> None:
+    plugin = _Plugin(())
+
+    result = run_plugin(
+        cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+    )
+
+    assert isinstance(plugin.source, _Source)
+    assert plugin.source.calls == 1
+    assert result.top_refs == ()
+    assert result.results == ()
+    assert result.leaves_consumed == 0
+    assert result.leaves_persisted == 0
+    assert result.leaves_failed == 0
+    assert result.errors == ()
+
+
+def test_forwards_on_leaf_to_each_single_root_run() -> None:
+    plugin = _Plugin(_refs())
+    received: list[tuple[_Record, _Record]] = []
+
+    def on_leaf(leaf: object, parent: object) -> None:
+        assert isinstance(leaf, _Record)
+        assert isinstance(parent, _Record)
+        received.append((leaf, parent))
+
+    result = run_plugin(
+        cast(CrawlPlugin, plugin),
+        cast(HttpClient, None),
+        RunConfig(),
+        on_leaf=on_leaf,
+    )
+
+    assert result.leaves_persisted == 4
+    assert len(received) == 4
+
+
+def test_applies_leaf_limit_to_each_discovered_root() -> None:
+    result = run_plugin(
+        cast(CrawlPlugin, _Plugin(_refs())),
+        cast(HttpClient, None),
+        RunConfig(leaf_limit=1),
+    )
+
+    assert result.leaves_consumed == 2
+    assert tuple(run.leaves_consumed for run in result.results) == (1, 1)
+
+
+def test_aggregates_leaf_errors_with_root_index() -> None:
+    plugin = _Plugin(
+        _refs(), sink=_Sink(lambda ref: ref.url.endswith("top/2/leaf/2"))
+    )
+
+    result = run_plugin(
+        cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+    )
+
+    assert result.leaves_consumed == 3
+    assert result.leaves_failed == 1
+    assert result.errors == ("top_ref[1]: ref[1] consume failed: unavailable",)
+    assert result.results[0].errors == ()
+    assert result.results[1].errors == ("ref[1] consume failed: unavailable",)
+
+
+def test_discovery_errors_propagate() -> None:
+    class _FailingSource(_Source):
+        def discover(self, client: HttpClient) -> Sequence[Ref]:
+            raise RuntimeError("discovery failed")
+
+    plugin = _Plugin(_refs())
+    plugin.source = _FailingSource(())
+
+    with pytest.raises(RuntimeError, match="discovery failed"):
+        run_plugin(
+            cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+        )
+
+
+def test_globally_fatal_root_errors_propagate() -> None:
+    plugin = _Plugin(
+        _refs(), expander=_Expander(ExpansionNotReadyError("later"))
+    )
+
+    with pytest.raises(ExpansionNotReadyError, match="later"):
+        run_plugin(
+            cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+        )
+
+
+def test_later_fatal_root_preserves_earlier_callback_side_effects() -> None:
+    persisted: list[str] = []
+    plugin = _Plugin(
+        _refs(),
+        expander=_Expander(
+            error_for=lambda ref: (
+                ExpansionNotReadyError("later")
+                if ref.url.endswith("top/2")
+                else None
+            )
+        ),
+    )
+
+    def on_leaf(leaf: object, _parent: object) -> None:
+        assert isinstance(leaf, _Record)
+        persisted.append(leaf.url)
+
+    with pytest.raises(ExpansionNotReadyError, match="later"):
+        run_plugin(
+            cast(CrawlPlugin, plugin),
+            cast(HttpClient, None),
+            RunConfig(),
+            on_leaf=on_leaf,
+        )
+
+    assert persisted == [
+        "https://example.test/top/1/leaf/1",
+        "https://example.test/top/1/leaf/2",
+    ]


### PR DESCRIPTION
## Summary

Fixes #174 and completes the source-driven runner-contract portion of #163.

- add `run_plugin()` and `async_run_plugin()` to execute a plugin from its required `Source`
- return `PluginRunResult`, retaining one `RunResult` per root alongside aggregate counts and source-indexed errors
- retain `run_crawl()` and `async_run_crawl()` for explicit single-root dispatch
- complete the runner API reference, Getting Started, authoring guide, cookbook, README, ADR-004, and runnable examples

## Contract

Discovery runs exactly once. Roots run in source order; async concurrency remains bounded within each root's leaf work. `RunConfig.leaf_limit` applies per root and is now documented and tested as such. Globally fatal errors propagate unchanged. Since an earlier root may already have invoked `on_leaf` before a later root fails, persistence callbacks must be idempotent when retrying a whole plugin run.

## Relationship to #163

PR #173 is now the independent metadata-key hotfix. This PR owns the executable source contract and all whole-plugin guidance. #163 can close after both PRs merge.

## Verification

- `pytest -q` — 696 passed
- `pytest -q tests/test_plugin_runner.py tests/test_async_plugin_runner.py` — 18 passed
- `pre-commit run --all-files`
- `mkdocs build --strict`
