### PR TITLE
fix(http): make async policies concurrency-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `FetchPredicate` implementations for adding predicate-specific diagnostics
   to `predicate_rejected` decision-event metadata.
 
+### Fixed
+
+- **Async politeness under concurrency** — same-host requests now reserve
+  rate-limit slots instead of waking in a batch, and HALF_OPEN circuit
+  breakers admit exactly one probe. Both guards are cancellation-safe and
+  remain independent across hosts.
+
 ---
 
 ## [0.3.2] — 2026-06-08

--- a/docs/decisions/adr-007-circuit-breaker.md
+++ b/docs/decisions/adr-007-circuit-breaker.md
@@ -3,7 +3,7 @@ status: accepted
 date: 2026-03-18
 decision-makers: [Maintainers]
 informed: [Contributors]
-refs: [ADR-001, Issue #38]
+refs: [ADR-001, "Issue #38", "Issue #160"]
 ---
 
 # ADR-007 — Per-Host Circuit Breaker
@@ -63,6 +63,30 @@ CLOSED ─(failures >= threshold)─► OPEN ─(recovery elapsed)─► HALF_OP
   `CircuitOpenError` if blocked.
 * Record success/failure on every `_request()` completion.
 
+### Async concurrency amendment (2026-08-02, Issue #160)
+
+The original caller-enforced single-probe assumption is insufficient for
+`AsyncHttpClient` and `AsyncCurlHttpClient`: several tasks can be admitted
+before any one of them records an outcome. The shared async policy therefore
+uses an event-loop-local admission guard with these semantics:
+
+* CLOSED requests remain concurrent. Outcome updates are synchronous between
+  await points, so failure counts cannot be partially mutated.
+* The first request after OPEN recovery reserves the HALF_OPEN probe. Other
+  requests to that host receive `CircuitOpenError` until the probe records an
+  outcome or is cancelled.
+* Every admission carries a circuit generation. A slow CLOSED request from an
+  earlier generation cannot close or re-open a newer HALF_OPEN probe.
+* Cancellation releases a HALF_OPEN reservation without counting as host
+  success or failure.
+
+Async rate limiting uses a separate per-host `asyncio.Lock`. A caller waits
+and commits its next eligible start time while holding that host's lock, so
+concurrent callers cannot wake as a batch. Locks are not shared across hosts,
+and all event-loop-bound guard state is discarded when the client closes.
+Async client instances remain single-event-loop objects and must not be shared
+across threads or loops.
+
 ## Consequences
 
 * **Good**: cascading failures to a dead host are cut off quickly.
@@ -75,14 +99,15 @@ CLOSED ─(failures >= threshold)─► OPEN ─(recovery elapsed)─► HALF_OP
   in mind — a value of 3 is more tolerant than it first appears.  During
   HALF_OPEN, the single probe may itself involve up to `retries + 1` raw
   HTTP attempts; observers watching traffic may see more than one request.
-* **Bad**: no persistence across `HttpClient` instances — circuit state
-  resets on every new client construction (acceptable for sync/single-run).
+* **Bad**: no persistence across client instances — circuit state resets on
+  every new client construction.
 
 ## Rejected options
 
 **B (rate-based):** Requires a sliding window, timestamps per request,
-and is harder to reason about in tests.  Count-based is sufficient for
-the single-threaded, single-run crawler model.
+and is harder to reason about in tests. Count-based state plus explicit async
+admission generations provides deterministic semantics without that extra
+model.
 
 **C (pybreaker):** Adds a runtime dependency for functionality that is
 straightforward to implement cleanly.  Keeping it in-house means the

--- a/src/ladon/networking/_async_policy_base.py
+++ b/src/ladon/networking/_async_policy_base.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from random import uniform
@@ -37,6 +38,14 @@ from .types import Err, Ok, Result
 ResponseValue = TypeVar("ResponseValue")
 
 
+@dataclass(frozen=True)
+class _CircuitAdmission:
+    """Generation-scoped permission for one logical request."""
+
+    generation: int
+    is_half_open_probe: bool
+
+
 class AsyncPolicyBase(ABC):
     """Abstract base for asynchronous HTTP clients with unified policy pipeline.
 
@@ -47,7 +56,10 @@ class AsyncPolicyBase(ABC):
     def __init__(self, config: HttpClientConfig) -> None:
         self._config = config
         self._last_request_time: dict[str, float] = {}
+        self._rate_limit_locks: dict[str, asyncio.Lock] = {}
         self._circuit_breakers: dict[str, CircuitBreaker] = {}
+        self._circuit_generations: dict[str, int] = {}
+        self._half_open_probes: dict[str, int] = {}
         self._crawl_delay_overrides: dict[str, float] = {}
 
     async def __aenter__(self) -> Self:
@@ -152,9 +164,14 @@ class AsyncPolicyBase(ABC):
     async def _enforce_rate_limit(self, host: str) -> None:
         """Enforce per-host politeness delay before issuing a request.
 
-        Only waits — does not stamp ``_last_request_time``.  All stamping is
-        done by the ``_request`` loop's ``finally`` block so that every actual
-        attempt (including retries) updates the timestamp.
+        Concurrent callers reserve start slots while holding a host-specific
+        lock. The reservation is committed before the lock is released, so a
+        burst cannot observe one stale timestamp and wake as a batch. Actual
+        attempt completion is still stamped by ``_request`` to preserve the
+        existing conservative end-to-start delay for sequential calls.
+
+        A task cancelled while waiting never commits a reservation, and the
+        ``async with`` block releases the lock for the next waiter.
         """
         if not host:
             return
@@ -164,12 +181,19 @@ class AsyncPolicyBase(ABC):
         )
         if interval <= 0:
             return
-        last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                await asyncio.sleep(remaining)
+
+        lock = self._rate_limit_locks.get(host)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._rate_limit_locks[host] = lock
+        async with lock:
+            last = self._last_request_time.get(host)
+            if last is not None:
+                elapsed = monotonic() - last
+                remaining = interval - elapsed
+                if remaining > 0:
+                    await asyncio.sleep(remaining)
+            self._last_request_time[host] = monotonic()
 
     def _get_circuit_breaker(self, host: str) -> CircuitBreaker | None:
         """Return the CircuitBreaker for *host*, or None if circuit breaking is disabled."""
@@ -184,6 +208,81 @@ class AsyncPolicyBase(ABC):
                 recovery_seconds=self._config.circuit_breaker_recovery_seconds,
             )
         return self._circuit_breakers[host]
+
+    def _admit_circuit_request(
+        self, host: str, cb: CircuitBreaker
+    ) -> _CircuitAdmission | None:
+        """Atomically admit one request in this client's asyncio event loop.
+
+        No await occurs while breaker state and the probe reservation are
+        inspected, so cooperative asyncio scheduling makes this section
+        atomic. CLOSED traffic remains concurrent. Once OPEN recovers, one
+        caller reserves the HALF_OPEN probe and later callers are rejected
+        until that probe records an outcome or is cancelled.
+        """
+        if host in self._half_open_probes:
+            return None
+
+        previous_state = cb.state
+        if not cb.allow_request():
+            return None
+
+        generation = self._circuit_generations.get(host, 0)
+        is_half_open_probe = cb.state is CircuitState.HALF_OPEN
+        if is_half_open_probe:
+            if previous_state is CircuitState.OPEN:
+                generation += 1
+                self._circuit_generations[host] = generation
+            self._half_open_probes[host] = generation
+
+        return _CircuitAdmission(
+            generation=generation,
+            is_half_open_probe=is_half_open_probe,
+        )
+
+    def _record_circuit_outcome(
+        self,
+        host: str,
+        cb: CircuitBreaker,
+        admission: _CircuitAdmission,
+        *,
+        success: bool,
+    ) -> None:
+        """Record an outcome only if it belongs to the current generation."""
+        current_generation = self._circuit_generations.get(host, 0)
+        if admission.generation != current_generation:
+            return
+
+        previous_state = cb.state
+        if success:
+            cb.record_success()
+        else:
+            cb.record_failure()
+
+        if (
+            admission.is_half_open_probe
+            and self._half_open_probes.get(host) == admission.generation
+        ):
+            self._half_open_probes.pop(host, None)
+
+        if cb.state is not previous_state:
+            self._circuit_generations[host] = current_generation + 1
+
+    def _release_circuit_admission(
+        self, host: str, admission: _CircuitAdmission
+    ) -> None:
+        """Release a cancelled HALF_OPEN probe without recording an outcome."""
+        if (
+            admission.is_half_open_probe
+            and self._half_open_probes.get(host) == admission.generation
+        ):
+            self._half_open_probes.pop(host, None)
+
+    def _clear_concurrency_state(self) -> None:
+        """Drop event-loop-bound guards when the transport is closed."""
+        self._rate_limit_locks.clear()
+        self._half_open_probes.clear()
+        self._circuit_generations.clear()
 
     def circuit_state(self, url: str) -> CircuitState | None:
         """Return the current circuit-breaker state for *url*'s host, or None."""
@@ -244,126 +343,144 @@ class AsyncPolicyBase(ABC):
         """Execute async request with retries, circuit breaking, and rate limiting."""
         host = urlparse(url).netloc
         cb = self._get_circuit_breaker(host)
-        if cb is not None and not cb.allow_request():
-            meta = self._build_meta(
-                method=method,
-                request_url=url,
-                response=None,
-                context=context,
-                attempts=0,
-                timeout=timeout,
-                final_error="CircuitOpenError",
-            )
-            return Err(CircuitOpenError(host), meta=meta)
-
-        await self._enforce_rate_limit(host)
-        is_safe_method = method.upper() in {"GET", "HEAD"}
-        pool = self._config.proxy_pool
-        attempts = 0
-        last_error: Exception | None = None
-        last_blocked_response: Any = None
-        last_blocked_retry_after: float | None = None
-        current_proxy: Mapping[str, str] | None = None
-        if pool is not None:
-            current_proxy = pool.next_proxy()
-
-        for _ in range(self._max_attempts()):
-            attempts += 1
-            try:
-                response = await self._execute_attempt(
-                    request_fn, current_proxy
+        admission: _CircuitAdmission | None = None
+        if cb is not None:
+            admission = self._admit_circuit_request(host, cb)
+            if admission is None:
+                meta = self._build_meta(
+                    method=method,
+                    request_url=url,
+                    response=None,
+                    context=context,
+                    attempts=0,
+                    timeout=timeout,
+                    final_error="CircuitOpenError",
                 )
-                if (
-                    response.status_code in self._config.retry_on_status
-                    and is_safe_method
-                ):
-                    last_blocked_retry_after = self._parse_retry_after(response)
-                    last_blocked_response = response
-                    last_error = None
-                    if attempts < self._max_attempts():
-                        if pool is not None:
-                            pool.mark_failure(current_proxy)
-                            current_proxy = pool.next_proxy()
-                        await self._sleep_for_retry_after(
-                            last_blocked_retry_after, attempts
+                return Err(CircuitOpenError(host), meta=meta)
+
+        try:
+            await self._enforce_rate_limit(host)
+            is_safe_method = method.upper() in {"GET", "HEAD"}
+            pool = self._config.proxy_pool
+            attempts = 0
+            last_error: Exception | None = None
+            last_blocked_response: Any = None
+            last_blocked_retry_after: float | None = None
+            current_proxy: Mapping[str, str] | None = None
+            if pool is not None:
+                current_proxy = pool.next_proxy()
+
+            for _ in range(self._max_attempts()):
+                attempts += 1
+                try:
+                    response = await self._execute_attempt(
+                        request_fn, current_proxy
+                    )
+                    if (
+                        response.status_code in self._config.retry_on_status
+                        and is_safe_method
+                    ):
+                        last_blocked_retry_after = self._parse_retry_after(
+                            response
                         )
-                        continue
-                    break
-                if cb is not None:
-                    cb.record_success()
-                return Ok(
-                    value_builder(response),
-                    meta=self._build_meta(
-                        method=method,
-                        request_url=url,
-                        response=response,
-                        context=context,
-                        attempts=attempts,
-                        timeout=timeout,
-                    ),
-                )
-            except Exception as exc:
-                if not self._is_transport_exception(exc):  # pragma: no cover
-                    if cb is not None:
-                        cb.record_failure()
-                    return Err(
-                        HttpClientError(str(exc)),
+                        last_blocked_response = response
+                        last_error = None
+                        if attempts < self._max_attempts():
+                            if pool is not None:
+                                pool.mark_failure(current_proxy)
+                                current_proxy = pool.next_proxy()
+                            await self._sleep_for_retry_after(
+                                last_blocked_retry_after, attempts
+                            )
+                            continue
+                        break
+                    if cb is not None and admission is not None:
+                        self._record_circuit_outcome(
+                            host, cb, admission, success=True
+                        )
+                    return Ok(
+                        value_builder(response),
                         meta=self._build_meta(
                             method=method,
                             request_url=url,
-                            response=None,
+                            response=response,
                             context=context,
                             attempts=attempts,
                             timeout=timeout,
-                            final_error=type(exc).__name__,
                         ),
                     )
-                last_error = exc
-                last_blocked_response = None
-                last_blocked_retry_after = None
-                if (
-                    attempts >= self._max_attempts()
-                    or not self._is_retryable_exception(method, exc)
-                ):
-                    break
+                except Exception as exc:
+                    if not self._is_transport_exception(
+                        exc
+                    ):  # pragma: no cover
+                        if cb is not None and admission is not None:
+                            self._record_circuit_outcome(
+                                host, cb, admission, success=False
+                            )
+                        return Err(
+                            HttpClientError(str(exc)),
+                            meta=self._build_meta(
+                                method=method,
+                                request_url=url,
+                                response=None,
+                                context=context,
+                                attempts=attempts,
+                                timeout=timeout,
+                                final_error=type(exc).__name__,
+                            ),
+                        )
+                    last_error = exc
+                    last_blocked_response = None
+                    last_blocked_retry_after = None
+                    if (
+                        attempts >= self._max_attempts()
+                        or not self._is_retryable_exception(method, exc)
+                    ):
+                        break
+                    if pool is not None:
+                        pool.mark_failure(current_proxy)
+                        current_proxy = pool.next_proxy()
+                    await self._sleep_between_attempts(attempts)
+                finally:
+                    if host:
+                        self._last_request_time[host] = monotonic()
+
+            if last_blocked_response is not None:
+                if cb is not None and admission is not None:
+                    self._record_circuit_outcome(
+                        host, cb, admission, success=False
+                    )
                 if pool is not None:
                     pool.mark_failure(current_proxy)
-                    current_proxy = pool.next_proxy()
-                await self._sleep_between_attempts(attempts)
-            finally:
-                if host:
-                    self._last_request_time[host] = monotonic()
+                return Err(
+                    RateLimitedError(
+                        last_blocked_response.status_code,
+                        last_blocked_retry_after,
+                    ),
+                    meta=self._build_meta(
+                        method=method,
+                        request_url=url,
+                        response=last_blocked_response,
+                        context=context,
+                        attempts=attempts,
+                        timeout=timeout,
+                        final_error="RateLimitedError",
+                    ),
+                )
 
-        if last_blocked_response is not None:
-            if cb is not None:
-                cb.record_failure()
+            assert last_error is not None
+            if cb is not None and admission is not None:
+                self._record_circuit_outcome(host, cb, admission, success=False)
             if pool is not None:
                 pool.mark_failure(current_proxy)
-            return Err(
-                RateLimitedError(
-                    last_blocked_response.status_code, last_blocked_retry_after
-                ),
-                meta=self._build_meta(
-                    method=method,
-                    request_url=url,
-                    response=last_blocked_response,
-                    context=context,
-                    attempts=attempts,
-                    timeout=timeout,
-                    final_error="RateLimitedError",
-                ),
+            return self._handle_request_exception(
+                method=method,
+                request_url=url,
+                e=last_error,
+                context=context,
+                attempts=attempts,
+                timeout=timeout,
             )
-
-        assert last_error is not None
-        if cb is not None:
-            cb.record_failure()
-        if pool is not None:
-            pool.mark_failure(current_proxy)
-        return self._handle_request_exception(
-            method=method,
-            request_url=url,
-            e=last_error,
-            context=context,
-            attempts=attempts,
-            timeout=timeout,
-        )
+        finally:
+            if admission is not None:
+                self._release_circuit_admission(host, admission)

--- a/src/ladon/networking/async_client.py
+++ b/src/ladon/networking/async_client.py
@@ -47,7 +47,9 @@ class AsyncHttpClient(AsyncPolicyBase):
     Concurrent safety
     -----------------
     Safe for concurrent use within a single asyncio event loop. Do not share
-    an instance across threads.
+    an instance across threads or event loops. Same-host rate-limit slots and
+    HALF_OPEN circuit probes are coordinated; different hosts remain
+    independent.
     """
 
     def __init__(self, config: HttpClientConfig) -> None:
@@ -86,7 +88,10 @@ class AsyncHttpClient(AsyncPolicyBase):
 
     async def aclose(self) -> None:
         """Close the underlying httpx client and release connections."""
-        await self._http.aclose()
+        try:
+            await self._http.aclose()
+        finally:
+            self._clear_concurrency_state()
 
     # ------------------------------------------------------------------
     # httpx API delta converters — the blast-radius boundary

--- a/src/ladon/networking/async_curl_client.py
+++ b/src/ladon/networking/async_curl_client.py
@@ -50,7 +50,9 @@ class AsyncCurlHttpClient(AsyncPolicyBase):
     Concurrent safety
     -----------------
     Safe for concurrent use within a single asyncio event loop. Do not share
-    an instance across threads.
+    an instance across threads or event loops. Same-host rate-limit slots and
+    HALF_OPEN circuit probes are coordinated; different hosts remain
+    independent.
 
     Args:
         config: Standard ``HttpClientConfig``.
@@ -99,7 +101,10 @@ class AsyncCurlHttpClient(AsyncPolicyBase):
 
     async def aclose(self) -> None:
         """Close the underlying session and release pooled connections."""
-        await self._session.close()
+        try:
+            await self._session.close()
+        finally:
+            self._clear_concurrency_state()
 
     def _get_timeout(
         self, override: float | None

--- a/tests/test_async_curl_client.py
+++ b/tests/test_async_curl_client.py
@@ -684,14 +684,13 @@ async def test_rate_limit_sleep_enforced() -> None:
     )
     async with AsyncCurlHttpClient(config, impersonate="chrome136") as c:
         c._session.get = AsyncMock(return_value=_mock_response(content=b"ok"))
-        # Interval is measured end-to-start: timestamp written in finally after each attempt.
-        # First get() completes  → finally records 1000.0
-        # Second get() enforces  → now=1000.5, elapsed=0.5, remaining=1.5 → sleep(1.5)
-        # Second get() completes → finally records 1001.0
+        # The first request reserves 1000.0 and completes at 1000.1.
+        # The second checks at 1000.5, waits 1.6, reserves 1002.1, then
+        # completes at 1002.2.
         with (
             patch(
                 "ladon.networking._async_policy_base.monotonic",
-                side_effect=[1000.0, 1000.5, 1001.0],
+                side_effect=[1000.0, 1000.1, 1000.5, 1002.1, 1002.2],
             ),
             patch(
                 "ladon.networking._async_policy_base.asyncio.sleep"
@@ -701,4 +700,4 @@ async def test_rate_limit_sleep_enforced() -> None:
             await c.get("http://example.com")
             await c.get("http://example.com")
 
-    mock_sleep.assert_called_once_with(pytest.approx(1.5, abs=1e-9))
+    mock_sleep.assert_called_once_with(pytest.approx(1.6, abs=1e-9))

--- a/tests/test_async_policy_concurrency.py
+++ b/tests/test_async_policy_concurrency.py
@@ -1,0 +1,331 @@
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false
+"""Concurrency contracts shared by both asynchronous HTTP backends."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import timedelta
+from time import monotonic
+from typing import Any
+
+import pytest
+
+from ladon.networking._async_policy_base import AsyncPolicyBase
+from ladon.networking.circuit_breaker import CircuitState
+from ladon.networking.config import HttpClientConfig
+from ladon.networking.errors import CircuitOpenError, TransientNetworkError
+from ladon.networking.types import Err, Result
+
+
+class _TransportFailure(Exception):
+    pass
+
+
+@dataclass
+class _Response:
+    url: str
+    status_code: int = 200
+    content: bytes = b"ok"
+    reason: str = "OK"
+    headers: dict[str, str] = field(default_factory=lambda: {})
+    elapsed: timedelta = field(default_factory=timedelta)
+
+
+_Attempt = Callable[[str], Awaitable[_Response]]
+
+
+class _PolicyClient(AsyncPolicyBase):
+    """Minimal transport used to exercise the shared policy pipeline."""
+
+    def __init__(self, config: HttpClientConfig, attempt: _Attempt) -> None:
+        super().__init__(config)
+        self._attempt = attempt
+
+    async def aclose(self) -> None:
+        self._clear_concurrency_state()
+
+    def _is_transport_exception(self, exc: Exception) -> bool:
+        return isinstance(exc, _TransportFailure)
+
+    def _is_retryable_exception(self, method: str, exc: Exception) -> bool:
+        return False
+
+    async def _execute_attempt(
+        self,
+        request_fn: Any,
+        proxy: Mapping[str, str] | None,
+    ) -> Any:
+        return await request_fn()
+
+    def _handle_request_exception(
+        self,
+        method: str,
+        request_url: str,
+        e: Exception,
+        context: Mapping[str, Any] | None,
+        attempts: int,
+        timeout: Any,
+    ) -> Result[Any, Exception]:
+        return Err(TransientNetworkError(str(e)), meta={"attempts": attempts})
+
+    async def get(self, url: str) -> Result[_Response, Exception]:
+        async def request_fn() -> _Response:
+            return await self._attempt(url)
+
+        return await self._request(
+            method="GET",
+            url=url,
+            context=None,
+            timeout=1.0,
+            request_fn=request_fn,
+            value_builder=lambda response: response,
+        )
+
+
+async def test_same_host_concurrent_requests_reserve_spaced_slots() -> None:
+    interval = 0.02
+    starts: list[float] = []
+
+    async def attempt(url: str) -> _Response:
+        starts.append(monotonic())
+        return _Response(url)
+
+    client = _PolicyClient(
+        HttpClientConfig(min_request_interval_seconds=interval), attempt
+    )
+
+    results = await asyncio.gather(
+        *(
+            client.get(f"https://same.example/item/{index}")
+            for index in range(10)
+        )
+    )
+
+    assert all(result.ok for result in results)
+    assert len(starts) == 10
+    assert all(
+        later - earlier >= interval * 0.8
+        for earlier, later in zip(starts, starts[1:], strict=False)
+    )
+
+
+async def test_different_hosts_do_not_share_a_rate_limit_lock() -> None:
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+    started = 0
+
+    async def attempt(url: str) -> _Response:
+        nonlocal started
+        started += 1
+        if started == 2:
+            both_started.set()
+        await release.wait()
+        return _Response(url)
+
+    client = _PolicyClient(
+        HttpClientConfig(min_request_interval_seconds=60.0), attempt
+    )
+    requests = [
+        asyncio.create_task(client.get("https://alpha.example/item")),
+        asyncio.create_task(client.get("https://beta.example/item")),
+    ]
+
+    await asyncio.wait_for(both_started.wait(), timeout=0.5)
+    release.set()
+    results = await asyncio.gather(*requests)
+
+    assert all(result.ok for result in results)
+
+
+async def test_cancelled_rate_limit_wait_releases_the_host_lock() -> None:
+    async def attempt(url: str) -> _Response:
+        return _Response(url)
+
+    client = _PolicyClient(
+        HttpClientConfig(min_request_interval_seconds=60.0), attempt
+    )
+    url = "https://cancel-rate.example/item"
+    await client.get(url)
+
+    waiting = asyncio.create_task(client.get(url))
+    await asyncio.sleep(0)
+    host_lock = client._rate_limit_locks["cancel-rate.example"]
+    assert host_lock.locked()
+
+    waiting.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiting
+
+    assert not host_lock.locked()
+    client._last_request_time["cancel-rate.example"] = monotonic() - 60.0
+    result = await asyncio.wait_for(client.get(url), timeout=0.5)
+    assert result.ok
+
+
+async def test_half_open_allows_exactly_one_concurrent_probe() -> None:
+    probe_started = asyncio.Event()
+    release_probe = asyncio.Event()
+    attempts = 0
+
+    async def attempt(url: str) -> _Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _TransportFailure("open circuit")
+        probe_started.set()
+        await release_probe.wait()
+        return _Response(url)
+
+    client = _PolicyClient(
+        HttpClientConfig(
+            circuit_breaker_failure_threshold=1,
+            circuit_breaker_recovery_seconds=60.0,
+        ),
+        attempt,
+    )
+    url = "https://half-open.example/item"
+    failed = await client.get(url)
+    assert not failed.ok
+
+    breaker = client._get_circuit_breaker("half-open.example")
+    assert breaker is not None
+    breaker._opened_at = monotonic() - 61.0
+
+    probe = asyncio.create_task(client.get(url))
+    await asyncio.wait_for(probe_started.wait(), timeout=0.5)
+    blocked = await asyncio.gather(*(client.get(url) for _ in range(4)))
+
+    assert attempts == 2
+    assert all(
+        not result.ok and isinstance(result.error, CircuitOpenError)
+        for result in blocked
+    )
+
+    release_probe.set()
+    probe_result = await probe
+    assert probe_result.ok
+    assert client.circuit_state(url) is CircuitState.CLOSED
+
+
+async def test_concurrent_failures_open_at_the_configured_threshold() -> None:
+    all_started = asyncio.Event()
+    release = asyncio.Event()
+    attempts = 0
+
+    async def attempt(url: str) -> _Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 5:
+            all_started.set()
+        await release.wait()
+        raise _TransportFailure("failed")
+
+    client = _PolicyClient(
+        HttpClientConfig(
+            circuit_breaker_failure_threshold=3,
+            circuit_breaker_recovery_seconds=60.0,
+        ),
+        attempt,
+    )
+    url = "https://threshold.example/item"
+    requests = [asyncio.create_task(client.get(url)) for _ in range(5)]
+    await asyncio.wait_for(all_started.wait(), timeout=0.5)
+    release.set()
+    results = await asyncio.gather(*requests)
+
+    assert all(not result.ok for result in results)
+    assert client.circuit_state(url) is CircuitState.OPEN
+    blocked = await client.get(url)
+    assert not blocked.ok
+    assert isinstance(blocked.error, CircuitOpenError)
+    assert attempts == 5
+
+
+async def test_cancelled_half_open_probe_releases_its_reservation() -> None:
+    probe_started = asyncio.Event()
+    hold_probe = asyncio.Event()
+    attempts = 0
+
+    async def attempt(url: str) -> _Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _TransportFailure("open circuit")
+        if attempts == 2:
+            probe_started.set()
+            await hold_probe.wait()
+        return _Response(url)
+
+    client = _PolicyClient(
+        HttpClientConfig(
+            circuit_breaker_failure_threshold=1,
+            circuit_breaker_recovery_seconds=60.0,
+        ),
+        attempt,
+    )
+    url = "https://cancel-probe.example/item"
+    await client.get(url)
+    breaker = client._get_circuit_breaker("cancel-probe.example")
+    assert breaker is not None
+    breaker._opened_at = monotonic() - 61.0
+
+    cancelled_probe = asyncio.create_task(client.get(url))
+    await asyncio.wait_for(probe_started.wait(), timeout=0.5)
+    cancelled_probe.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled_probe
+
+    replacement = await asyncio.wait_for(client.get(url), timeout=0.5)
+    assert replacement.ok
+    assert attempts == 3
+    assert client.circuit_state(url) is CircuitState.CLOSED
+
+
+async def test_stale_closed_result_cannot_complete_a_new_probe() -> None:
+    slow_started = asyncio.Event()
+    release_slow = asyncio.Event()
+    probe_started = asyncio.Event()
+    release_probe = asyncio.Event()
+
+    async def attempt(url: str) -> _Response:
+        if url.endswith("/slow"):
+            slow_started.set()
+            await release_slow.wait()
+            return _Response(url)
+        if url.endswith("/fail"):
+            raise _TransportFailure("open circuit")
+        probe_started.set()
+        await release_probe.wait()
+        return _Response(url)
+
+    client = _PolicyClient(
+        HttpClientConfig(
+            circuit_breaker_failure_threshold=1,
+            circuit_breaker_recovery_seconds=60.0,
+        ),
+        attempt,
+    )
+    host = "generation.example"
+    slow = asyncio.create_task(client.get(f"https://{host}/slow"))
+    await asyncio.wait_for(slow_started.wait(), timeout=0.5)
+    await client.get(f"https://{host}/fail")
+
+    breaker = client._get_circuit_breaker(host)
+    assert breaker is not None
+    breaker._opened_at = monotonic() - 61.0
+    probe = asyncio.create_task(client.get(f"https://{host}/probe"))
+    await asyncio.wait_for(probe_started.wait(), timeout=0.5)
+
+    release_slow.set()
+    assert (await slow).ok
+    assert client.circuit_state(f"https://{host}") is CircuitState.HALF_OPEN
+
+    blocked = await client.get(f"https://{host}/blocked")
+    assert not blocked.ok
+    assert isinstance(blocked.error, CircuitOpenError)
+
+    release_probe.set()
+    assert (await probe).ok
+    assert client.circuit_state(f"https://{host}") is CircuitState.CLOSED


### PR DESCRIPTION
## Summary

Fixes #160.

- reserve same-host async rate-limit slots behind per-host locks while keeping different hosts independent
- admit exactly one HALF_OPEN circuit-breaker probe and reject concurrent probes
- generation-scope circuit outcomes so stale CLOSED requests cannot mutate a newer recovery probe
- release rate-limit locks and probe reservations safely on cancellation
- clear event-loop-bound guard state when either async client closes

## Root cause

Concurrent callers read the same completed-request timestamp before any task updated it, so they slept for the same duration and woke as a batch. Circuit admission had a similar split-phase race: multiple tasks could call `allow_request()` before the first HALF_OPEN probe recorded its outcome.

The shared async policy now commits request start reservations atomically per host. Circuit admission remains concurrent in CLOSED state, but HALF_OPEN uses a host-scoped reservation and generation token. Generation checks also prevent a slow request admitted before the circuit opened from closing or re-opening a newer probe.

## Behavior and compatibility

The change is internal to the shared async policy used by `AsyncHttpClient` and `AsyncCurlHttpClient`; public method signatures are unchanged. Instances remain safe for concurrent use within one asyncio event loop and must not be shared across threads or event loops.

## Verification

- `pytest -q` — 703 passed
- focused async policy/client/circuit suite — 109 passed
- `pre-commit run --all-files` — passed, including strict Pyright
- `mkdocs build --strict` — passed

Regression tests cover ten concurrent same-host requests, cross-host overlap, threshold races, single HALF_OPEN admission, cancellation during rate waiting and probing, and stale-generation outcomes.
