### PR TITLE
fix(networking): count HTTP 5xx responses as circuit-breaker failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Circuit-breaker HTTP 5xx accounting** — returned 5xx responses now count
   as origin-health failures without changing their `Ok(...)` result contract;
-  4xx responses remain successful breaker outcomes.
+  non-retryable 4xx responses remain successful breaker outcomes.
 - **Async politeness under concurrency** — same-host requests now reserve
   rate-limit slots instead of waking in a batch, and HALF_OPEN circuit
   breakers admit exactly one probe. Both guards are cancellation-safe and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Circuit-breaker HTTP 5xx accounting** — returned 5xx responses now count
+  as origin-health failures without changing their `Ok(...)` result contract;
+  4xx responses remain successful breaker outcomes.
 - **Async politeness under concurrency** — same-host requests now reserve
   rate-limit slots instead of waking in a batch, and HALF_OPEN circuit
   breakers admit exactly one probe. Both guards are cancellation-safe and

--- a/docs/decisions/adr-002-http-status-result-contract.md
+++ b/docs/decisions/adr-002-http-status-result-contract.md
@@ -37,6 +37,8 @@ metadata".
 * Good: callers can define house-specific behavior for 3xx/4xx/5xx.
 * Good: metadata remains available for logging, monitoring, and policy layers.
 * Bad: callers must explicitly handle non-2xx statuses (no implicit failure).
+* Neutral: ADR-007 separately treats 5xx responses as origin-health failures
+  for circuit-breaker accounting without changing their `Ok(...)` wrapping.
 
 ### Confirmation
 

--- a/docs/decisions/adr-007-circuit-breaker.md
+++ b/docs/decisions/adr-007-circuit-breaker.md
@@ -3,7 +3,7 @@ status: accepted
 date: 2026-03-18
 decision-makers: [Maintainers]
 informed: [Contributors]
-refs: [ADR-001, "Issue #38", "Issue #160"]
+refs: [ADR-001, ADR-002, "Issue #38", "Issue #160", "Issue #165"]
 ---
 
 # ADR-007 — Per-Host Circuit Breaker
@@ -86,6 +86,16 @@ concurrent callers cannot wake as a batch. Locks are not shared across hosts,
 and all event-loop-bound guard state is discarded when the client closes.
 Async client instances remain single-event-loop objects and must not be shared
 across threads or loops.
+
+### HTTP 5xx health-accounting amendment (2026-08-02, Issue #165)
+
+HTTP responses with `status_code >= 500` count as circuit-breaker failures;
+responses below 500, including 4xx responses, count as successes. This
+origin-health accounting is independent of ADR-002's result contract: a 5xx
+response can remain `Ok(...)` for caller-owned status interpretation while
+still contributing one failure for the logical call sequence. Statuses handled
+by `retry_on_status` continue to record that failure only after retries are
+exhausted.
 
 ## Consequences
 

--- a/docs/decisions/adr-007-circuit-breaker.md
+++ b/docs/decisions/adr-007-circuit-breaker.md
@@ -90,12 +90,12 @@ across threads or loops.
 ### HTTP 5xx health-accounting amendment (2026-08-02, Issue #165)
 
 HTTP responses with `status_code >= 500` count as circuit-breaker failures;
-responses below 500, including 4xx responses, count as successes. This
-origin-health accounting is independent of ADR-002's result contract: a 5xx
-response can remain `Ok(...)` for caller-owned status interpretation while
-still contributing one failure for the logical call sequence. Statuses handled
-by `retry_on_status` continue to record that failure only after retries are
-exhausted.
+responses below 500 that are not configured in `retry_on_status`, including
+ordinary 4xx responses, count as successes. This origin-health accounting is
+independent of ADR-002's result contract: a 5xx response can remain `Ok(...)`
+for caller-owned status interpretation while still contributing one failure
+for the logical call sequence. Statuses handled by `retry_on_status`, including
+4xx statuses such as 429, record one failure only after retries are exhausted.
 
 ## Consequences
 

--- a/src/ladon/networking/_async_policy_base.py
+++ b/src/ladon/networking/_async_policy_base.py
@@ -396,7 +396,10 @@ class AsyncPolicyBase(ABC):
                         break
                     if cb is not None and admission is not None:
                         self._record_circuit_outcome(
-                            host, cb, admission, success=True
+                            host,
+                            cb,
+                            admission,
+                            success=response.status_code < 500,
                         )
                     return Ok(
                         value_builder(response),

--- a/src/ladon/networking/_sync_policy_base.py
+++ b/src/ladon/networking/_sync_policy_base.py
@@ -413,7 +413,10 @@ class SyncPolicyBase(ABC):
                         continue
                     break
                 if cb is not None:
-                    cb.record_success()
+                    if response.status_code >= 500:
+                        cb.record_failure()
+                    else:
+                        cb.record_success()
                 return Ok(
                     value_builder(response),
                     meta=self._build_meta(

--- a/tests/test_async_policy_concurrency.py
+++ b/tests/test_async_policy_concurrency.py
@@ -15,7 +15,11 @@ import pytest
 from ladon.networking._async_policy_base import AsyncPolicyBase
 from ladon.networking.circuit_breaker import CircuitState
 from ladon.networking.config import HttpClientConfig
-from ladon.networking.errors import CircuitOpenError, TransientNetworkError
+from ladon.networking.errors import (
+    CircuitOpenError,
+    RateLimitedError,
+    TransientNetworkError,
+)
 from ladon.networking.types import Err, Result
 
 
@@ -82,6 +86,125 @@ class _PolicyClient(AsyncPolicyBase):
             request_fn=request_fn,
             value_builder=lambda response: response,
         )
+
+
+async def test_repeated_5xx_responses_open_circuit_at_threshold() -> None:
+    statuses = iter([500, 500])
+
+    async def attempt(url: str) -> _Response:
+        return _Response(url, status_code=next(statuses))
+
+    client = _PolicyClient(
+        HttpClientConfig(circuit_breaker_failure_threshold=2), attempt
+    )
+    url = "https://breaker-status.example/item"
+
+    first = await client.get(url)
+    assert first.ok
+    assert client.circuit_state(url) is CircuitState.CLOSED
+
+    second = await client.get(url)
+    assert second.ok
+    assert client.circuit_state(url) is CircuitState.OPEN
+
+
+async def test_2xx_response_resets_accumulated_5xx_failures() -> None:
+    statuses = iter([500, 200, 500, 500])
+
+    async def attempt(url: str) -> _Response:
+        return _Response(url, status_code=next(statuses))
+
+    client = _PolicyClient(
+        HttpClientConfig(circuit_breaker_failure_threshold=2), attempt
+    )
+    url = "https://breaker-status.example/item"
+
+    assert (await client.get(url)).ok
+    assert (await client.get(url)).ok
+    assert (await client.get(url)).ok
+    assert client.circuit_state(url) is CircuitState.CLOSED
+
+    assert (await client.get(url)).ok
+    assert client.circuit_state(url) is CircuitState.OPEN
+
+
+async def test_repeated_4xx_responses_do_not_open_circuit() -> None:
+    async def attempt(url: str) -> _Response:
+        return _Response(url, status_code=404)
+
+    client = _PolicyClient(
+        HttpClientConfig(circuit_breaker_failure_threshold=2), attempt
+    )
+    url = "https://breaker-status.example/item"
+
+    results = [await client.get(url) for _ in range(5)]
+
+    assert all(result.ok for result in results)
+    assert client.circuit_state(url) is CircuitState.CLOSED
+
+
+async def test_retryable_500_counts_once_after_retries_exhausted() -> None:
+    attempts = 0
+
+    async def attempt(url: str) -> _Response:
+        nonlocal attempts
+        attempts += 1
+        return _Response(url, status_code=500)
+
+    client = _PolicyClient(
+        HttpClientConfig(
+            retries=2,
+            retry_on_status=frozenset({500}),
+            circuit_breaker_failure_threshold=2,
+        ),
+        attempt,
+    )
+    url = "https://breaker-status.example/item"
+
+    first = await client.get(url)
+    assert not first.ok
+    assert isinstance(first.error, RateLimitedError)
+    assert first.meta["attempts"] == 3
+    assert attempts == 3
+    assert client.circuit_state(url) is CircuitState.CLOSED
+
+    second = await client.get(url)
+    assert not second.ok
+    assert isinstance(second.error, RateLimitedError)
+    assert attempts == 6
+    assert client.circuit_state(url) is CircuitState.OPEN
+
+
+async def test_retry_sequence_settling_on_5xx_counts_once() -> None:
+    statuses = iter([503, 503, 500, 500])
+    attempts = 0
+
+    async def attempt(url: str) -> _Response:
+        nonlocal attempts
+        attempts += 1
+        return _Response(url, status_code=next(statuses))
+
+    client = _PolicyClient(
+        HttpClientConfig(
+            retries=2,
+            retry_on_status=frozenset({503}),
+            circuit_breaker_failure_threshold=2,
+        ),
+        attempt,
+    )
+    url = "https://breaker-status.example/item"
+
+    first = await client.get(url)
+    assert first.ok
+    assert first.value is not None
+    assert first.value.status_code == 500
+    assert first.meta["attempts"] == 3
+    assert attempts == 3
+    assert client.circuit_state(url) is CircuitState.CLOSED
+
+    assert (await client.get(url)).ok
+    assert attempts == 4
+    assert client.circuit_state(url) is CircuitState.OPEN
 
 
 async def test_same_host_concurrent_requests_reserve_spaced_slots() -> None:

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -9,10 +9,22 @@ from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest
+import requests
 
 from ladon.networking.circuit_breaker import CircuitBreaker, CircuitState
 from ladon.networking.client import HttpClient
 from ladon.networking.config import HttpClientConfig
+from ladon.networking.errors import RateLimitedError
+
+
+def _response(status_code: int) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = str(status_code).encode()
+    response.url = "http://breaker-status.example/item"
+    response.reason = str(status_code)
+    return response
+
 
 # ---------------------------------------------------------------------------
 # Unit — CircuitBreaker state machine
@@ -201,11 +213,123 @@ def cb_client(cb_config: HttpClientConfig) -> Generator[HttpClient, None, None]:
 
 
 class TestHttpClientCircuitBreaker:
+    def test_repeated_5xx_responses_open_circuit_at_threshold(self) -> None:
+        config = HttpClientConfig(circuit_breaker_failure_threshold=2)
+        url = "http://breaker-status.example/item"
+
+        with (
+            HttpClient(config) as client,
+            patch(
+                "requests.Session.get",
+                side_effect=[_response(500), _response(500)],
+            ),
+        ):
+            first = client.get(url)
+            assert first.ok
+            assert client.circuit_state(url) is CircuitState.CLOSED
+
+            second = client.get(url)
+            assert second.ok
+            assert client.circuit_state(url) is CircuitState.OPEN
+
+    def test_2xx_response_resets_accumulated_5xx_failures(self) -> None:
+        config = HttpClientConfig(circuit_breaker_failure_threshold=2)
+        url = "http://breaker-status.example/item"
+
+        with (
+            HttpClient(config) as client,
+            patch(
+                "requests.Session.get",
+                side_effect=[
+                    _response(500),
+                    _response(200),
+                    _response(500),
+                    _response(500),
+                ],
+            ),
+        ):
+            assert client.get(url).ok
+            assert client.get(url).ok
+            assert client.get(url).ok
+            assert client.circuit_state(url) is CircuitState.CLOSED
+
+            assert client.get(url).ok
+            assert client.circuit_state(url) is CircuitState.OPEN
+
+    def test_repeated_4xx_responses_do_not_open_circuit(self) -> None:
+        config = HttpClientConfig(circuit_breaker_failure_threshold=2)
+        url = "http://breaker-status.example/item"
+
+        with (
+            HttpClient(config) as client,
+            patch(
+                "requests.Session.get",
+                side_effect=[_response(404) for _ in range(5)],
+            ),
+        ):
+            results = [client.get(url) for _ in range(5)]
+
+            assert all(result.ok for result in results)
+            assert client.circuit_state(url) is CircuitState.CLOSED
+
+    def test_retryable_500_counts_once_after_retries_exhausted(self) -> None:
+        config = HttpClientConfig(
+            retries=2,
+            retry_on_status=frozenset({500}),
+            circuit_breaker_failure_threshold=2,
+        )
+        url = "http://breaker-status.example/item"
+
+        with (
+            HttpClient(config) as client,
+            patch(
+                "requests.Session.get",
+                side_effect=[_response(500) for _ in range(6)],
+            ),
+        ):
+            first = client.get(url)
+            assert not first.ok
+            assert isinstance(first.error, RateLimitedError)
+            assert first.meta["attempts"] == 3
+            assert client.circuit_state(url) is CircuitState.CLOSED
+
+            second = client.get(url)
+            assert not second.ok
+            assert isinstance(second.error, RateLimitedError)
+            assert client.circuit_state(url) is CircuitState.OPEN
+
+    def test_retry_sequence_settling_on_5xx_counts_once(self) -> None:
+        config = HttpClientConfig(
+            retries=2,
+            retry_on_status=frozenset({503}),
+            circuit_breaker_failure_threshold=2,
+        )
+        url = "http://breaker-status.example/item"
+
+        with (
+            HttpClient(config) as client,
+            patch(
+                "requests.Session.get",
+                side_effect=[
+                    _response(503),
+                    _response(503),
+                    _response(500),
+                    _response(500),
+                ],
+            ),
+        ):
+            first = client.get(url)
+            assert first.ok
+            assert first.meta["attempts"] == 3
+            assert first.meta["status_code"] == 500
+            assert client.circuit_state(url) is CircuitState.CLOSED
+
+            assert client.get(url).ok
+            assert client.circuit_state(url) is CircuitState.OPEN
+
     def test_circuit_opens_after_threshold_failures(
         self, cb_client: HttpClient
     ) -> None:
-        import requests
-
         from ladon.networking.errors import CircuitOpenError
 
         url = "http://failing.example.com/resource"
@@ -233,8 +357,6 @@ class TestHttpClientCircuitBreaker:
         )
 
     def test_circuit_state_reflects_open(self, cb_client: HttpClient) -> None:
-        import requests
-
         url = "http://state-check.example.com/res"
         exc = requests.exceptions.ConnectionError("refused")
 
@@ -246,8 +368,6 @@ class TestHttpClientCircuitBreaker:
 
     def test_circuit_tracks_per_host(self, cb_client: HttpClient) -> None:
         """Failures on host A must not open the circuit for host B."""
-        import requests
-
         from ladon.networking.errors import CircuitOpenError
 
         url_a = "http://failing-a.example.com/res"
@@ -272,8 +392,6 @@ class TestHttpClientCircuitBreaker:
     def test_circuit_recovers_after_success(
         self, cb_client: HttpClient
     ) -> None:
-        import requests
-
         url = "http://recovering.example.com/res"
         exc = requests.exceptions.ConnectionError("refused")
 
@@ -307,8 +425,6 @@ class TestHttpClientCircuitBreaker:
         distinguish 'circuit blocked before any attempt' from 'tried and
         failed'.
         """
-        import requests
-
         from ladon.networking.errors import CircuitOpenError
 
         url = "http://zero-attempts.example.com/res"
@@ -331,8 +447,6 @@ class TestHttpClientCircuitBreaker:
         Callers surfacing circuit state to dashboards need to observe this
         intermediate state.
         """
-        import requests
-
         url = "http://half-open.example.com/res"
         exc = requests.exceptions.ConnectionError("refused")
 


### PR DESCRIPTION
## Summary

Fixes #165.

Both `_sync_policy_base.py` and `_async_policy_base.py` treated any response not in `retry_on_status` (default `{429, 503}`) as a circuit-breaker success — including plain 500/502 responses. Per ADR-002 the client still correctly returns `Ok(bytes)` for these (unchanged); this fix only changes the separate origin-health accounting (ADR-007), so a host returning 500 on every request now actually trips the breaker instead of staying CLOSED forever.

- Sync and async success-path branches now record a circuit-breaker failure when `status_code >= 500`, success otherwise (4xx unaffected)
- The async fix goes through the existing generation-safe `_record_circuit_outcome()` helper from #160/#176 — does not bypass that concurrency protection
- ADR-007 gets a dated amendment (matching the #160 amendment's style); ADR-002 gets a one-line cross-reference noting `Ok(...)` wrapping doesn't prevent breaker accounting

## Verification

Independently re-verified, not just trusted:
- New tests (46 total across sync/async) run 3x with no flakiness; full suite (713 tests) run twice, stable
- The trickiest test (`test_retry_sequence_settling_on_5xx_counts_once`) verifies a mixed sequence — retries exhaust on a *configured* retry status (503), landing on an *unconfigured* 500 — counts as exactly one breaker failure, not double-counted
- Real `pre-commit run --all-files` and `mkdocs build --strict` both clean
- Ran a real (non-mocked) local server returning 500 against a fresh `HttpClient`: requests stayed `Ok` while the breaker correctly opened at the configured threshold, and the next request was correctly blocked with `CircuitOpenError`