### PR TITLE
fix(runner): isolate non-fatal Phase-3 leaf exceptions in both runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Consistent runner leaf-exception semantics** — sync crawls now record an
+  unexpected non-fatal `Sink.consume()` exception and continue with remaining
+  leaves instead of aborting and losing the partial result. Async crawls now
+  propagate leaf cancellation instead of silently counting it as a failure.
+  Consequently, the CLI now exits with code 2 for an ordinary
+  `Sink.consume()` exception recorded as a partial leaf failure; exit code 1
+  remains reserved for exceptions the runner does not isolate.
 - **Circuit-breaker HTTP 5xx accounting** — returned 5xx responses now count
   as origin-health failures without changing their `Ok(...)` result contract;
   non-retryable 4xx responses remain successful breaker outcomes.

--- a/docs/decisions/adr-004-ses-protocol-design.md
+++ b/docs/decisions/adr-004-ses-protocol-design.md
@@ -272,11 +272,29 @@ where exceptions carry semantic meaning that drives control flow:
 
 | Exception | Raised by | Runner behaviour |
 |---|---|---|
-| `ExpansionNotReadyError` | Any Expander | Re-raise — run is globally premature; caller retries on next schedule |
-| `PartialExpansionError` | Expander | First expander: re-raise. Non-first: isolate branch, record in `errors` |
-| `ChildListUnavailableError` | Expander | First expander: re-raise. Non-first: isolate branch, record in `errors` |
+| `ExpansionNotReadyError` | Any Expander or Sink | Re-raise — run is globally premature; caller retries on next schedule |
+| `PartialExpansionError` | Expander or Sink | First expander: re-raise. Non-first: isolate branch, record in `errors`. Always fatal from the Sink (no branch to isolate). |
+| `ChildListUnavailableError` | Expander or Sink | First expander: re-raise. Non-first: isolate branch, record in `errors`. Always fatal from the Sink (no branch to isolate). |
 | `LeafUnavailableError` | Sink | Skip leaf; increment `leaves_failed`; run continues |
 | `AssetDownloadError` | Sink or Expander | Fatal — propagates to caller; run aborts. Plugins needing non-fatal asset handling must catch it internally before returning. |
+
+### Phase-3 leaf-exception isolation amendment (2026-08-11, Issue #164)
+
+An unclassified `Exception` raised by `Sink.consume()` now receives the same
+non-fatal treatment as `LeafUnavailableError`: it is recorded in `errors`,
+counted in `leaves_failed`, and the run continues. A crawl over many independent
+leaves should not lose already-fetched results because one leaf exposes a
+parsing bug, and preserving the exception text in `RunResult.errors` keeps the
+failure visible instead of silently masking it. The Decision Driver against
+catch-all exception handling is therefore addressed through visibility rather
+than aborting during Phase 3. That driver continues to apply unchanged to
+orchestrator-level Phase 1 and Phase 2 expansion handling; this amendment
+narrows its scope rather than retracting it.
+
+`ExpansionNotReadyError`, `PartialExpansionError`, and
+`ChildListUnavailableError` retain their documented behaviour whether raised
+by an Expander or the Sink. Phase 3 has no branch into which a Sink call can be
+isolated, so each exception propagates unchanged when raised there.
 
 The first-expander vs non-first-expander distinction reflects the **Bulkhead
 pattern**: a failure in one branch of the tree does not abort sibling

--- a/docs/guides/authoring-plugins.md
+++ b/docs/guides/authoring-plugins.md
@@ -65,13 +65,13 @@ class MyExpander:
         ...
 ```
 
-Exceptions that halt expansion:
+Expansion exception handling depends on where the failure occurs:
 
 | Exception | Meaning |
 |---|---|
 | `ExpansionNotReadyError` | Data not ready; abort the entire run — caller retries later |
-| `PartialExpansionError` | Some children unavailable; runner logs and continues |
-| `ChildListUnavailableError` | Child list fetch failed; runner logs and continues |
+| `PartialExpansionError` | Some children unavailable; abort from the first Expander, otherwise record and skip only the failing branch |
+| `ChildListUnavailableError` | Child list fetch failed; abort from the first Expander, otherwise record and skip only the failing branch |
 
 ### Sink
 
@@ -85,7 +85,13 @@ class MySink:
 ```
 
 `LeafUnavailableError` signals that the leaf is temporarily unavailable;
-the runner records the failure and moves on.
+the runner records the failure and moves on. Unexpected exceptions from a
+Sink are recorded the same way so other independent leaves still run; their
+text remains visible in `RunResult.errors`. Cancellation and explicitly fatal
+`AssetDownloadError` propagate instead of being counted as leaf failures.
+Expansion exceptions also retain their typed contract when raised by a Sink:
+`ExpansionNotReadyError`, `PartialExpansionError`, and
+`ChildListUnavailableError` propagate unchanged.
 
 ### CrawlPlugin
 

--- a/docs/guides/concepts.md
+++ b/docs/guides/concepts.md
@@ -40,7 +40,7 @@ Its counters describe separate parts of the pipeline:
 |---|---|
 | `leaves_consumed` | Leaves whose `Sink.consume()` completed successfully, even if `on_leaf` later failed. |
 | `leaves_persisted` | Leaves for which both `Sink.consume()` and `on_leaf` completed. Without an `on_leaf` callback, this equals `leaves_consumed`. |
-| `leaves_failed` | Leaves whose `Sink.consume()` raised `LeafUnavailableError`. Callback failures are not included; find their count with `leaves_consumed - leaves_persisted`. |
+| `leaves_failed` | Leaves whose `Sink.consume()` raised a non-fatal exception, whether a classified `LeafUnavailableError` or an unexpected exception. Callback failures are not included; find their count with `leaves_consumed - leaves_persisted`. |
 
 After `RunConfig.leaf_limit` is applied, the runner always maintains:
 
@@ -63,16 +63,22 @@ parsing logs.
 
 ## Plugin errors: typed recovery signals
 
-The runner catches only the plugin exceptions whose recovery meaning it knows.
-That is intentional: a broad `except Exception` would turn programming bugs
-and unexpected failures into a misleading partial result.
+Expansion exceptions retain typed recovery meanings because a failed branch
+can affect the shape or completeness of the whole crawl. Phase 3 has a
+different boundary: a crawl may process thousands of independent leaves, so
+one leaf's unexpected exception should not discard records already fetched or
+prevent the remaining leaves from being attempted. The runner therefore
+records ordinary `Exception` values raised by `Sink.consume()` in
+`RunResult.errors`, increments `leaves_failed`, and continues. The exception's
+text is preserved in the `ref[N] consume failed: ...` diagnostic rather than
+being silently dropped.
 
 | Exception | Raise it when | Runner behaviour |
 |---|---|---|
 | `ExpansionNotReadyError` | The resource is not ready to expand, such as content that is not live. | Re-raises from any Expander and aborts the run. Retry on a later schedule, not within the same run. |
 | `PartialExpansionError` | A valid response says the child list is incomplete. | From the first Expander, re-raises. From a later Expander, records the branch error and continues with siblings. |
 | `ChildListUnavailableError` | The child list cannot be retrieved or parsed into a usable list. | From the first Expander, re-raises. From a later Expander, records the branch error and continues with siblings. |
-| `LeafUnavailableError` | One leaf cannot be fetched or parsed. | Records a leaf error, increments `leaves_failed`, and continues with the next leaf. |
+| `LeafUnavailableError` | One leaf cannot be fetched or parsed. | Records a leaf error, increments `leaves_failed`, and continues with the next leaf, as for other non-fatal `Exception` values from `Sink.consume()`. |
 
 The first Expander produces the crawl root, so it has no sibling branch for
 the runner to isolate. At deeper levels, isolating a failed branch preserves
@@ -81,9 +87,13 @@ the rest of the tree. `PartialExpansionError` and
 was valid but incomplete, while the latter says there is no usable child list.
 
 `AssetDownloadError` is deliberately outside this recovery taxonomy. The
-runner does not catch it: it propagates and aborts the run. If an asset failure
-should be non-fatal for a plugin, catch it inside that plugin before returning
-from its Expander or Sink.
+runner does not recover from it: it propagates and aborts the run. If an asset
+failure should be non-fatal for a plugin, catch it inside that plugin before
+returning from its Expander or Sink.
+
+Cancellation and other non-`Exception` `BaseException` subclasses also
+propagate unchanged. In particular, an async leaf cancellation is never
+reported as a completed crawl with that leaf counted as failed.
 
 For the scheduling-boundary pattern, see [Resume a not-ready or partial crawl](cookbook.md#resume-a-not-ready-or-partial-crawl).
 

--- a/docs/guides/cookbook.md
+++ b/docs/guides/cookbook.md
@@ -64,9 +64,11 @@ at later levels the runner skips only that branch and adds its message to
 --8<-- "examples/cookbook/resume_partial_crawl.py:example"
 ```
 
-`LeafUnavailableError` is different: the runner records it in `result.errors`,
-increments `leaves_failed`, and continues with other leaves. Make persistence
-idempotent so a scheduled retry can safely revisit successful leaves too.
+Leaf failures are different: the runner records `LeafUnavailableError` and
+other non-fatal exceptions from `Sink.consume()` in `result.errors`, increments
+`leaves_failed`, and continues with other leaves. Make persistence idempotent
+so a scheduled retry can safely revisit successful leaves too. Cancellation
+and explicitly fatal `AssetDownloadError` still propagate.
 
 ## Async leaf processing for high throughput
 

--- a/docs/guides/how-ladon-works.md
+++ b/docs/guides/how-ladon-works.md
@@ -112,10 +112,14 @@ specific meaning that tells the runner exactly what to do:
 | `ExpansionNotReadyError` | Resource not ready yet | Abort the run; retry next schedule |
 | `PartialExpansionError` | Child list incomplete | **First expander:** abort the run (re-raised to caller). **Non-first expander:** log and skip the branch. |
 | `ChildListUnavailableError` | Child list unreachable | **First expander:** abort the run (re-raised to caller). **Non-first expander:** log and skip the branch. |
-| `LeafUnavailableError` | Leaf fetch failed | Log, skip this leaf, continue |
+| `LeafUnavailableError` | Leaf fetch failed | Log, record the failure, and continue, as for other non-fatal Sink exceptions |
 
-Your plugin raises the right exception; the runner decides what to do with it.
-No catch-all `except Exception` that masks real bugs.
+Your plugin raises the right typed exception when it can. During leaf
+processing, the runner also records unexpected `Exception` text in
+`RunResult.errors` and continues with independent leaves, so a single bad leaf
+does not discard the rest of the crawl. Explicitly fatal
+`AssetDownloadError`, cancellation, and other `BaseException` subclasses still
+propagate to the caller.
 
 ## Persistence is injected, not built in
 

--- a/src/ladon/async_runner.py
+++ b/src/ladon/async_runner.py
@@ -19,12 +19,13 @@ The plan/execute split (v0.3):
 the sync runner: when any expander raises it, the coroutine raises immediately
 and the caller must schedule a retry.
 
-``LeafUnavailableError`` is isolated per leaf: a single failed ``consume()``
-call does not cancel other in-flight leaf tasks.
+Ordinary exceptions from a leaf ``consume()`` call are isolated per leaf and
+recorded in ``RunResult.errors``. ``AssetDownloadError`` retains its explicitly
+fatal contract, while cancellation and other ``BaseException`` subclasses
+propagate unchanged.
 
-``asyncio.gather(return_exceptions=True)`` is used deliberately so that an
-unexpected exception in one leaf task does not cancel the others.  Unexpected
-exceptions are recorded in ``RunResult.errors`` as leaf failures.
+``asyncio.gather(return_exceptions=True)`` is used deliberately so sibling
+leaf tasks finish before a fatal exception or cancellation is propagated.
 """
 
 from __future__ import annotations
@@ -32,8 +33,8 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-import warnings
 from collections.abc import Awaitable, Callable
+from typing import cast
 
 from ladon.networking.async_client import AsyncHttpClient
 from ladon.plugins.async_protocol import AsyncCrawlPlugin
@@ -44,13 +45,41 @@ from ladon.plugins.errors import (
     PartialExpansionError,
 )
 from ladon.runner import (
+    FATAL_PLUGIN_ERRORS,
     CrawlPlan,
     PluginRunResult,
     RunConfig,
     RunResult,
+    log_leaf_exception,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _raise_first_fatal_outcome(
+    outcomes: list[tuple[bool, bool, list[str]] | BaseException],
+    *,
+    plugin_name: str,
+) -> list[tuple[bool, bool, list[str]]]:
+    """Log every fatal leaf outcome, then propagate the highest priority."""
+    first_exception: Exception | None = None
+    first_base_exception: BaseException | None = None
+    for i, outcome in enumerate(outcomes):
+        if not isinstance(outcome, BaseException):
+            continue
+        log_leaf_exception(outcome, i, plugin_name)
+        if isinstance(outcome, Exception):
+            if first_exception is None:
+                first_exception = outcome
+        elif first_base_exception is None:
+            first_base_exception = outcome
+
+    if first_base_exception is not None:
+        raise first_base_exception
+    if first_exception is not None:
+        raise first_exception
+
+    return cast(list[tuple[bool, bool, list[str]]], outcomes)
 
 
 async def async_run_crawl(
@@ -74,11 +103,16 @@ async def async_run_crawl(
         RunResult with counts and any per-leaf error messages.
 
     Raises:
-        ExpansionNotReadyError:     Any expander raised this. The ref is not
-                                    yet ready. Caller should retry on the next
-                                    scheduled run.
-        PartialExpansionError:      Raised only from the first expander.
-        ChildListUnavailableError:  Raised only from the first expander.
+        ExpansionNotReadyError:     Any expander or the Sink raised this. The
+                                    ref is not yet ready; retry on the next run.
+        PartialExpansionError:      Raised from the first expander or Sink.
+        ChildListUnavailableError:  Raised from the first expander or Sink.
+        AssetDownloadError:         Raised from the Sink or an Expander. This
+                                    explicitly fatal plugin error propagates.
+        asyncio.CancelledError:     A leaf consume or ``on_leaf`` callback was
+                                    cancelled.
+        BaseException:              Other fatal BaseException subclasses raised
+                                    by a leaf task propagate unchanged.
         ValueError:                 Plugin has no expanders configured.
     """
     if not plugin.expanders:
@@ -138,7 +172,7 @@ async def async_run_crawl(
 
     async def _process_leaf(
         i: int, leaf_ref: object, parent_record: object
-    ) -> tuple[bool, bool, list[str]]:
+    ) -> tuple[bool, bool, list[str]] | BaseException:
         """Returns (consumed, persisted, leaf_errors).
 
         consumed=True  when sink.consume() succeeded.
@@ -165,6 +199,17 @@ async def async_run_crawl(
                     },
                 )
                 return (False, False, [f"ref[{i}] consume failed: {exc}"])
+            except FATAL_PLUGIN_ERRORS:
+                raise
+            except Exception as exc:
+                log_leaf_exception(exc, i, plugin.name)
+                return (False, False, [f"ref[{i}] consume failed: {exc}"])
+            except BaseException as exc:
+                # Any non-Exception BaseException that escapes a Task can be
+                # mangled or crash the event loop through CPython's Task
+                # machinery. Return it as a value so the caller receives the
+                # original exception unchanged.
+                return exc
 
             if on_leaf is not None:
                 try:
@@ -183,6 +228,12 @@ async def async_run_crawl(
                         },
                     )
                     return (True, False, [f"ref[{i}] callback failed: {exc}"])
+                except BaseException as exc:
+                    # Any non-Exception BaseException that escapes a Task can be
+                    # mangled or crash the event loop through CPython's Task
+                    # machinery. Return it as a value so the caller receives the
+                    # original exception unchanged.
+                    return exc
 
             return (True, True, [])
 
@@ -198,25 +249,18 @@ async def async_run_crawl(
     leaves_persisted = 0
     leaves_failed = 0
 
-    for i, outcome in enumerate(outcomes):
-        if isinstance(outcome, BaseException):
-            leaves_failed += 1
-            errors.append(f"ref[{i}]: unexpected error: {outcome}")
-            logger.error(
-                "unexpected leaf error — ref[%d]: %s",
-                i,
-                outcome,
-                extra={"plugin": plugin.name, "ref_index": i},
-            )
+    leaf_outcomes = _raise_first_fatal_outcome(
+        outcomes, plugin_name=plugin.name
+    )
+
+    for consumed, persisted, leaf_errors in leaf_outcomes:
+        if consumed:
+            leaves_consumed += 1
         else:
-            consumed, persisted, leaf_errors = outcome
-            if consumed:
-                leaves_consumed += 1
-            else:
-                leaves_failed += 1
-            if persisted:
-                leaves_persisted += 1
-            errors.extend(leaf_errors)
+            leaves_failed += 1
+        if persisted:
+            leaves_persisted += 1
+        errors.extend(leaf_errors)
 
     logger.info(
         "async_run_crawl finished",
@@ -255,6 +299,19 @@ async def async_run_plugin(
     than being converted into a partial aggregate. Earlier roots may already
     have invoked ``on_leaf`` when a later root aborts, so callbacks must be
     idempotent if the caller retries the plugin.
+
+    Raises:
+        ExpansionNotReadyError: Propagates unchanged from a per-root
+            :func:`async_run_crawl` invocation.
+        PartialExpansionError: Propagates unchanged from a per-root
+            :func:`async_run_crawl` invocation.
+        ChildListUnavailableError: Propagates unchanged from a per-root
+            :func:`async_run_crawl` invocation, per that function's own
+            ``Raises:`` contract.
+        AssetDownloadError: A Sink or Expander raised this explicitly fatal
+            plugin error while processing a discovered root.
+        BaseException: Cancellation and other fatal errors from a per-root
+            :func:`async_run_crawl` invocation propagate unchanged.
     """
 
     top_refs = tuple(await plugin.source.discover(client))
@@ -364,19 +421,37 @@ async def execute_plan(
                      (success or failure).  Called from inside concurrent leaf
                      tasks — order matches completion order, not input order.
                      Async callables are not supported; passing an ``async def``
-                     raises ``TypeError`` at call time because the coroutine
-                     object is not awaited.  Exceptions raised by this callback
-                     are logged and swallowed.
+                     raises ``TypeError`` before leaf processing begins.
+                     Ordinary ``Exception`` subclasses raised by this callback
+                     are logged and swallowed.  A ``BaseException`` propagates
+                     instead, pre-empting a pending fatal plugin exception under
+                     the severity-tier convention while preserving it in
+                     ``__context__``.
 
     Returns:
         RunResult with counts and any per-leaf error messages.  Phase 1
         errors from the plan are carried forward into ``RunResult.errors``.
+
+    Raises:
+        ExpansionNotReadyError: Raised from the Sink and propagates.
+        PartialExpansionError: Raised from the Sink and propagates.
+        ChildListUnavailableError: Raised from the Sink and propagates.
+        AssetDownloadError:     Raised from the Sink. This explicitly fatal
+                                plugin error propagates.
+        TypeError:               ``on_progress`` is an async callable; only
+                                synchronous callables are supported.
+        asyncio.CancelledError: A leaf consume or ``on_leaf`` callback, or an
+                                ``on_progress`` callback, was cancelled.
+        BaseException:          Other fatal BaseException subclasses raised
+                                by a leaf task propagate unchanged.
     """
-    if on_progress is not None and inspect.iscoroutinefunction(on_progress):
-        warnings.warn(
-            "on_progress must be a synchronous callable; async callables are "
-            "not supported and the coroutine will not be awaited.",
-            stacklevel=2,
+    if on_progress is not None and (
+        inspect.iscoroutinefunction(on_progress)
+        or inspect.iscoroutinefunction(type(on_progress).__call__)
+    ):
+        raise TypeError(
+            "on_progress must be a synchronous callable; async callables "
+            "are not supported"
         )
     leaves = plan.leaves
     if config.leaf_limit > 0:
@@ -395,7 +470,7 @@ async def execute_plan(
 
     async def _process_leaf(
         i: int, leaf_ref: object
-    ) -> tuple[bool, bool, list[str]]:
+    ) -> tuple[bool, bool, list[str]] | BaseException:
         """Returns (consumed, persisted, leaf_errors).
 
         consumed=True  when sink.consume() succeeded.
@@ -404,7 +479,7 @@ async def execute_plan(
         """
         nonlocal done_count
 
-        def _fire_progress() -> None:
+        def _fire_progress() -> BaseException | None:
             if on_progress is not None:
                 try:
                     on_progress(done_count, total)
@@ -415,6 +490,12 @@ async def execute_plan(
                         _exc,
                         extra={"plugin": plugin.name, "ref_index": i},
                     )
+                except BaseException as _exc:
+                    # A CancelledError escaping a Task is replaced by gather
+                    # with a fresh, empty instance. Return every BaseException
+                    # as a value so identity and diagnostic text survive.
+                    return _exc
+            return None
 
         async with semaphore:
             try:
@@ -431,14 +512,36 @@ async def execute_plan(
                     },
                 )
                 done_count += 1
-                _fire_progress()
+                if (progress_error := _fire_progress()) is not None:
+                    return progress_error
                 return (False, False, [f"ref[{i}] consume failed: {exc}"])
+            except FATAL_PLUGIN_ERRORS:
+                done_count += 1
+                if (progress_error := _fire_progress()) is not None:
+                    return progress_error
+                raise
+            except Exception as exc:
+                log_leaf_exception(exc, i, plugin.name)
+                done_count += 1
+                if (progress_error := _fire_progress()) is not None:
+                    return progress_error
+                return (False, False, [f"ref[{i}] consume failed: {exc}"])
+            except BaseException as exc:
+                done_count += 1
+                if (progress_error := _fire_progress()) is not None:
+                    return progress_error
+                # Any non-Exception BaseException that escapes a Task can be
+                # mangled or crash the event loop through CPython's Task
+                # machinery. Return it as a value so the caller receives the
+                # original exception unchanged.
+                return exc
 
             if on_leaf is not None:
                 try:
                     await on_leaf(leaf_record, leaf_ref)
                     done_count += 1
-                    _fire_progress()
+                    if (progress_error := _fire_progress()) is not None:
+                        return progress_error
                     return (True, True, [])
                 except Exception as exc:
                     logger.warning(
@@ -452,11 +555,22 @@ async def execute_plan(
                         },
                     )
                     done_count += 1
-                    _fire_progress()
+                    if (progress_error := _fire_progress()) is not None:
+                        return progress_error
                     return (True, False, [f"ref[{i}] callback failed: {exc}"])
+                except BaseException as exc:
+                    done_count += 1
+                    if (progress_error := _fire_progress()) is not None:
+                        return progress_error
+                    # Any non-Exception BaseException that escapes a Task can be
+                    # mangled or crash the event loop through CPython's Task
+                    # machinery. Return it as a value so the caller receives the
+                    # original exception unchanged.
+                    return exc
 
             done_count += 1
-            _fire_progress()
+            if (progress_error := _fire_progress()) is not None:
+                return progress_error
             return (True, True, [])
 
     outcomes = await asyncio.gather(
@@ -468,36 +582,18 @@ async def execute_plan(
     leaves_persisted = 0
     leaves_failed = 0
 
-    for i, outcome in enumerate(outcomes):
-        if isinstance(outcome, BaseException):
-            leaves_failed += 1
-            errors.append(f"ref[{i}]: unexpected error: {outcome}")
-            logger.error(
-                "unexpected leaf error — ref[%d]: %s",
-                i,
-                outcome,
-                extra={"plugin": plugin.name, "ref_index": i},
-            )
-            if on_progress is not None:
-                done_count += 1
-                try:
-                    on_progress(done_count, total)
-                except Exception as _exc:
-                    logger.warning(
-                        "on_progress callback raised — ref[%d]: %s",
-                        i,
-                        _exc,
-                        extra={"plugin": plugin.name, "ref_index": i},
-                    )
+    leaf_outcomes = _raise_first_fatal_outcome(
+        outcomes, plugin_name=plugin.name
+    )
+
+    for consumed, persisted, leaf_errors in leaf_outcomes:
+        if consumed:
+            leaves_consumed += 1
         else:
-            consumed, persisted, leaf_errors = outcome
-            if consumed:
-                leaves_consumed += 1
-            else:
-                leaves_failed += 1
-            if persisted:
-                leaves_persisted += 1
-            errors.extend(leaf_errors)
+            leaves_failed += 1
+        if persisted:
+            leaves_persisted += 1
+        errors.extend(leaf_errors)
 
     logger.info(
         "execute_plan finished",

--- a/src/ladon/cli.py
+++ b/src/ladon/cli.py
@@ -115,8 +115,11 @@ def _cmd_run(args: argparse.Namespace) -> None:
     Exit codes
     ----------
     0 — all leaves fetched successfully
-    1 — unrecoverable error (bad plugin specifier, import failure, run exception)
-    2 — run completed with partial failures (``leaves_failed > 0`` or errors)
+    1 — unrecoverable error (bad plugin specifier, import failure, or an
+        exception ``run_crawl`` does not isolate, such as
+        ``AssetDownloadError`` or a failure outside Phase 3 leaf processing)
+    2 — run completed with partial failures (``leaves_failed > 0`` or errors,
+        including ordinary exceptions raised by ``Sink.consume()``)
     3 — ``ExpansionNotReadyError``: data not yet available; caller should retry later
     """
     from ladon.networking.client import HttpClient

--- a/src/ladon/plugins/errors.py
+++ b/src/ladon/plugins/errors.py
@@ -1,8 +1,8 @@
 """Error taxonomy for Ladon house plugins.
 
-Each exception maps to a specific runner behaviour. Keeping these
-distinct prevents the catch-all except-Exception pattern that masked
-real failures in pre-Ladon crawlers.
+Each exception maps to a specific runner behaviour. Expansion signals remain
+typed because they describe tree completeness; non-fatal Phase-3 exceptions
+are recorded independently so one bad leaf does not discard the rest of a run.
 """
 
 
@@ -25,7 +25,8 @@ class PartialExpansionError(PluginError):
 
     Runner behaviour: non-fatal for non-first expanders — the affected
     branch is isolated and recorded in ``RunResult.errors``. Propagates
-    unchanged from the first expander.
+    unchanged from the first expander. Always fatal from a Sink because
+    Phase 3 has no branch to isolate.
 
     Raise this instead of ``ChildListUnavailableError`` when the HTTP
     response was valid but the payload signals an incomplete result.
@@ -39,6 +40,7 @@ class ChildListUnavailableError(PluginError):
 
     Fatal for this ref's run. Raised when the network request succeeded
     but the response cannot be parsed into a usable child list.
+    Always fatal from a Sink because Phase 3 has no branch to isolate.
     """
 
 
@@ -51,9 +53,9 @@ class LeafUnavailableError(PluginError):
 
 
 # ---------------------------------------------------------------------------
-# Plugin-use errors NOT caught by the runner
+# Plugin-use errors NOT recovered from by the runner
 # ---------------------------------------------------------------------------
-# Unlike the errors above, AssetDownloadError is not handled by run_crawl().
+# Unlike the errors above, the runners do not recover from AssetDownloadError.
 # If raised from a Sink or Expander it propagates as a fatal error and aborts
 # the entire run.  Plugins that need non-fatal asset download handling must
 # catch it internally before returning.
@@ -63,7 +65,7 @@ class LeafUnavailableError(PluginError):
 class AssetDownloadError(PluginError):
     """An asset download failed.
 
-    **Not caught by the runner** — propagates as a fatal error that aborts
-    the run.  Plugins requiring non-fatal handling must catch this exception
-    internally before returning from the Sink or Expander.
+    **Not recovered from by the runner** — propagates as a fatal error that
+    aborts the run. Plugins requiring non-fatal handling must catch this
+    exception internally before returning from the Sink or Expander.
     """

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -34,6 +34,7 @@ from typing import Callable
 
 from ladon.networking.client import HttpClient
 from ladon.plugins.errors import (
+    AssetDownloadError,
     ChildListUnavailableError,
     ExpansionNotReadyError,
     LeafUnavailableError,
@@ -42,6 +43,35 @@ from ladon.plugins.errors import (
 from ladon.plugins.protocol import CrawlPlugin
 
 logger = logging.getLogger(__name__)
+
+FATAL_PLUGIN_ERRORS = (
+    AssetDownloadError,
+    ExpansionNotReadyError,
+    PartialExpansionError,
+    ChildListUnavailableError,
+)
+
+
+def log_leaf_exception(
+    exc: BaseException, ref_index: int, plugin_name: str
+) -> None:
+    """Log an unclassified or fatal leaf exception consistently."""
+    message = (
+        "leaf consume failed — ref[%d] error=%s"
+        if isinstance(exc, Exception)
+        else "leaf task did not complete — ref[%d] error=%s"
+    )
+    logger.error(
+        message,
+        ref_index,
+        exc,
+        extra={
+            "plugin": plugin_name,
+            "ref_index": ref_index,
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+        },
+    )
 
 
 @dataclass(frozen=True)
@@ -124,20 +154,21 @@ class RunResult:
     without raising.  When no callback is supplied, ``leaves_persisted``
     equals ``leaves_consumed`` (the pipeline trivially succeeds after consume).
 
-    ``leaves_failed`` counts leaves for which ``sink.consume()`` failed.
-    Callback failures are NOT included here — derive them from
-    ``leaves_consumed - leaves_persisted``.
+    ``leaves_failed`` counts leaves for which ``sink.consume()`` raised a
+    non-fatal exception. Callback failures are NOT included here — derive them
+    from ``leaves_consumed - leaves_persisted``.
 
     The following invariant always holds::
 
         leaves_consumed + leaves_failed == total leaves passed to Phase 3
                                           (after leaf_limit is applied)
 
-    ``errors`` accumulates both expander branch failures (Phase 1, format
-    ``"expander branch '...': ..."`` ) and leaf-level failures (Phase 3,
-    format ``"ref[N]: ..."`` ).  A result with ``leaves_failed == 0`` may
-    still contain branch errors — always inspect ``errors`` for a complete
-    picture of what went wrong.
+    ``errors`` accumulates expander branch failures (Phase 1, format
+    ``"expander branch '...': ..."``) and leaf-level failures (Phase 3,
+    formats ``"ref[N] consume failed: ..."`` and
+    ``"ref[N] callback failed: ..."``). A result with ``leaves_failed == 0``
+    may still contain branch or callback errors — always inspect ``errors``
+    for a complete picture of what went wrong.
     """
 
     record: object
@@ -215,17 +246,21 @@ def run_crawl(
         RunResult with counts and any per-leaf error messages.
 
     Raises:
-        ExpansionNotReadyError:     Raised from any expander. The ref (or
-                                    an intermediate ref) is not yet ready.
+        ExpansionNotReadyError:     Raised from any expander or the Sink. The
+                                    ref (or an intermediate ref) is not ready.
                                     Caller should record the event and
                                     move on; retry on the next scheduled run.
-        PartialExpansionError:      Raised only from the first expander.
+        PartialExpansionError:      Raised from the first expander or Sink.
                                     From non-first expanders the failing
                                     branch is isolated and recorded in
                                     RunResult.errors instead.
-        ChildListUnavailableError:  Raised only from the first expander.
+        ChildListUnavailableError:  Raised from the first expander or Sink.
                                     Same isolation rule applies to non-first
                                     expanders as for PartialExpansionError.
+        AssetDownloadError:         Raised from the Sink or an Expander. This
+                                    explicitly fatal plugin error propagates.
+        BaseException:              KeyboardInterrupt and other fatal errors
+                                    propagate unchanged.
         ValueError:                 Plugin has no expanders configured.
     """
     if not plugin.expanders:
@@ -316,6 +351,17 @@ def run_crawl(
                 },
             )
             continue
+        except FATAL_PLUGIN_ERRORS as exc:
+            log_leaf_exception(exc, i, plugin.name)
+            raise
+        except Exception as exc:
+            leaves_failed += 1
+            errors.append(f"ref[{i}] consume failed: {exc}")
+            log_leaf_exception(exc, i, plugin.name)
+            continue
+        except BaseException as exc:
+            log_leaf_exception(exc, i, plugin.name)
+            raise
 
         leaves_consumed += 1
 
@@ -336,6 +382,9 @@ def run_crawl(
                         "error": str(exc),
                     },
                 )
+            except BaseException as exc:
+                log_leaf_exception(exc, i, plugin.name)
+                raise
         else:
             leaves_persisted += 1
 
@@ -385,11 +434,22 @@ def run_plugin(
         A PluginRunResult containing source-order per-root outcomes and totals.
 
     Raises:
-        Exception: Propagates exceptions from ``source.discover`` and
-            :func:`run_crawl`. Globally fatal expansion errors are never
-            converted into a partial aggregate. Roots completed before a later
-            fatal error may already have invoked ``on_leaf``; callbacks must
-            therefore be idempotent when the caller retries the whole plugin.
+        ExpansionNotReadyError: Propagates unchanged from a per-root
+            :func:`run_crawl` invocation.
+        PartialExpansionError: Propagates unchanged from a per-root
+            :func:`run_crawl` invocation.
+        ChildListUnavailableError: Propagates unchanged from a per-root
+            :func:`run_crawl` invocation. Per that function's own ``Raises:``
+            contract, globally fatal expansion errors are never converted into
+            a partial aggregate. Roots completed before a later fatal error may
+            already have invoked ``on_leaf``; callbacks must therefore be
+            idempotent when the caller retries the whole plugin.
+        AssetDownloadError: A Sink or Expander raised this explicitly fatal
+            plugin error while processing a discovered root.
+        Exception: Propagates ordinary exceptions from ``source.discover`` and
+            :func:`run_crawl`.
+        BaseException: KeyboardInterrupt and other fatal errors from a per-root
+            :func:`run_crawl` invocation propagate unchanged.
     """
 
     top_refs = tuple(plugin.source.discover(client))
@@ -490,12 +550,25 @@ def execute_plan_sync(
                      after each successful consume.  Note: second argument is the
                      **leaf ref**, not a parent record (see ADR-011).
         on_progress: Optional callback receiving ``(leaves_done, total_leaves)``
-                     after each leaf attempt (success or failure).  Exceptions
-                     raised by this callback are logged and swallowed.
+                     after each leaf attempt (success or failure).  Ordinary
+                     ``Exception`` subclasses raised by this callback are logged
+                     and swallowed.  A ``BaseException`` propagates instead,
+                     pre-empting a pending fatal plugin exception under the
+                     severity-tier convention while preserving it in
+                     ``__context__``.
 
     Returns:
         RunResult with counts and any per-leaf error messages.  Phase 1
         errors from the plan are carried forward into ``RunResult.errors``.
+
+    Raises:
+        ExpansionNotReadyError: Raised from the Sink and propagates.
+        PartialExpansionError: Raised from the Sink and propagates.
+        ChildListUnavailableError: Raised from the Sink and propagates.
+        AssetDownloadError: Raised from the Sink. This explicitly fatal
+                            plugin error propagates.
+        BaseException:      KeyboardInterrupt and other fatal errors raised by
+                            the Sink or ``on_leaf`` propagate unchanged.
     """
     leaves = plan.leaves
     if config.leaf_limit > 0:
@@ -513,6 +586,21 @@ def execute_plan_sync(
     leaves_failed = 0
     errors: list[str] = list(plan.errors)
 
+    def _fire_progress(done: int, ref_index: int) -> None:
+        if on_progress is not None:
+            try:
+                on_progress(done, total)
+            except Exception as _exc:
+                logger.warning(
+                    "on_progress callback raised — ref[%d]: %s",
+                    ref_index,
+                    _exc,
+                    extra={
+                        "plugin": plugin.name,
+                        "ref_index": ref_index,
+                    },
+                )
+
     for i, leaf_ref in enumerate(leaves):
         try:
             leaf_record = plugin.sink.consume(leaf_ref, client)
@@ -529,17 +617,24 @@ def execute_plan_sync(
                     "error": str(exc),
                 },
             )
-            if on_progress is not None:
-                try:
-                    on_progress(leaves_consumed + leaves_failed, total)
-                except Exception as _exc:
-                    logger.warning(
-                        "on_progress callback raised — ref[%d]: %s",
-                        i,
-                        _exc,
-                        extra={"plugin": plugin.name, "ref_index": i},
-                    )
+            _fire_progress(leaves_consumed + leaves_failed, i)
             continue
+        except FATAL_PLUGIN_ERRORS as exc:
+            log_leaf_exception(exc, i, plugin.name)
+            # Progress includes the current attempt even though it aborts the run.
+            _fire_progress(leaves_consumed + leaves_failed + 1, i)
+            raise
+        except Exception as exc:
+            leaves_failed += 1
+            errors.append(f"ref[{i}] consume failed: {exc}")
+            log_leaf_exception(exc, i, plugin.name)
+            _fire_progress(leaves_consumed + leaves_failed, i)
+            continue
+        except BaseException as exc:
+            log_leaf_exception(exc, i, plugin.name)
+            # Progress includes the current attempt even though it aborts the run.
+            _fire_progress(leaves_consumed + leaves_failed + 1, i)
+            raise
 
         leaves_consumed += 1
 
@@ -559,19 +654,16 @@ def execute_plan_sync(
                         "error": str(exc),
                     },
                 )
+            except BaseException as exc:
+                # The consume completed, but this leaf's callback attempt is
+                # still complete for progress purposes before propagation.
+                log_leaf_exception(exc, i, plugin.name)
+                _fire_progress(leaves_consumed + leaves_failed, i)
+                raise
         else:
             leaves_persisted += 1
 
-        if on_progress is not None:
-            try:
-                on_progress(leaves_consumed + leaves_failed, total)
-            except Exception as _exc:
-                logger.warning(
-                    "on_progress callback raised — ref[%d]: %s",
-                    i,
-                    _exc,
-                    extra={"plugin": plugin.name, "ref_index": i},
-                )
+        _fire_progress(leaves_consumed + leaves_failed, i)
 
     logger.info(
         "execute_plan_sync finished",

--- a/tests/test_async_plugin_runner.py
+++ b/tests/test_async_plugin_runner.py
@@ -17,7 +17,11 @@ from ladon.plugins.async_protocol import (
     AsyncSink,
     AsyncSource,
 )
-from ladon.plugins.errors import ExpansionNotReadyError, LeafUnavailableError
+from ladon.plugins.errors import (
+    AssetDownloadError,
+    ExpansionNotReadyError,
+    LeafUnavailableError,
+)
 from ladon.plugins.models import Expansion, Ref
 from ladon.runner import PluginRunResult, RunConfig
 
@@ -214,6 +218,33 @@ async def test_globally_fatal_root_errors_propagate() -> None:
             cast(AsyncHttpClient, None),
             RunConfig(),
         )
+
+
+async def test_asset_download_error_from_root_sink_propagates() -> None:
+    class _FatalSink:
+        async def consume(
+            self, ref: object, client: AsyncHttpClient
+        ) -> _Record:
+            raise AssetDownloadError("asset host unavailable")
+
+    plugin = _AsyncPlugin(_refs())
+    plugin.sink = _FatalSink()
+
+    with pytest.raises(AssetDownloadError, match="asset host unavailable"):
+        await async_run_plugin(
+            cast(AsyncCrawlPlugin, plugin),
+            cast(AsyncHttpClient, None),
+            RunConfig(),
+        )
+
+
+def test_async_run_plugin_documents_fatal_root_errors() -> None:
+    assert async_run_plugin.__doc__ is not None
+    assert "Raises:" in async_run_plugin.__doc__
+    assert "AssetDownloadError" in async_run_plugin.__doc__
+    assert "ExpansionNotReadyError" in async_run_plugin.__doc__
+    assert "PartialExpansionError" in async_run_plugin.__doc__
+    assert "ChildListUnavailableError" in async_run_plugin.__doc__
 
 
 async def test_later_fatal_root_preserves_earlier_callback_side_effects() -> (

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -23,6 +23,7 @@ import pytest
 
 from ladon.async_runner import async_run_crawl, execute_plan, plan_crawl
 from ladon.plugins.errors import (
+    AssetDownloadError,
     ChildListUnavailableError,
     ExpansionNotReadyError,
     LeafUnavailableError,
@@ -74,6 +75,14 @@ class _MockAsyncSink:
         return _make_leaf(leaf_id=r.url.split("/")[-1], url=r.url)
 
 
+class _TypedAsyncExpansionFailureSink:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    async def consume(self, ref: object, client: object) -> object:
+        raise self._error
+
+
 class _MockAsyncPlugin:
     def __init__(self, child_refs: list[Ref]) -> None:
         self.expanders: list[Any] = [_MockAsyncExpander(child_refs)]
@@ -115,6 +124,46 @@ def config() -> RunConfig:
 @pytest.fixture()
 def top_ref() -> Ref:
     return Ref(url="https://demo.example.com/top/1")
+
+
+@pytest.mark.parametrize("entry_point", ["async_run_crawl", "execute_plan"])
+@pytest.mark.parametrize("interrupt_index", [0, 1])
+async def test_non_exception_base_exception_outranks_fatal_exception(
+    entry_point: str,
+    interrupt_index: int,
+    top_ref: Ref,
+) -> None:
+    refs = [
+        Ref(url="https://demo.example.com/leaf/asset"),
+        Ref(url="https://demo.example.com/leaf/interrupt"),
+    ]
+    if interrupt_index == 0:
+        refs.reverse()
+
+    interruption = KeyboardInterrupt("stop now")
+
+    class _ConcurrentFatalSink:
+        async def consume(self, ref: object, client: object) -> object:
+            assert isinstance(ref, Ref)
+            if ref.url.endswith("/asset"):
+                raise AssetDownloadError("asset failed")
+            await asyncio.sleep(0.01)
+            raise interruption
+
+    plugin = _MockAsyncPlugin(refs)
+    plugin.sink = _ConcurrentFatalSink()
+    config = RunConfig(async_concurrency=2)
+
+    with pytest.raises(KeyboardInterrupt, match="stop now") as exc_info:
+        if entry_point == "async_run_crawl":
+            await async_run_crawl(top_ref, plugin, None, config)  # type: ignore[arg-type]
+        else:
+            plan = CrawlPlan(
+                record=_make_record(), leaves=tuple(refs), errors=()
+            )
+            await execute_plan(plan, plugin, None, config)  # type: ignore[arg-type]
+
+    assert exc_info.value is interruption
 
 
 # ---------------------------------------------------------------------------
@@ -250,6 +299,11 @@ class TestAsyncRunnerHappyPath:
 
 
 class TestAsyncRunnerErrors:
+    def test_async_run_crawl_documents_fatal_exceptions(self) -> None:
+        assert async_run_crawl.__doc__ is not None
+        assert "Raises:" in async_run_crawl.__doc__
+        assert "BaseException" in async_run_crawl.__doc__
+
     async def test_empty_expanders_raises_value_error(
         self,
         top_ref: Ref,
@@ -333,6 +387,219 @@ class TestAsyncRunnerErrors:
         assert result.leaves_failed == 1
         assert len(result.errors) == 1
         assert "consume failed" in result.errors[0]
+
+    async def test_unexpected_consume_exception_is_recorded_and_run_continues(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        config: RunConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class _UnexpectedFailureSink:
+            async def consume(self, ref: object, client: object) -> object:
+                assert isinstance(ref, Ref)
+                if ref.url.endswith("/2"):
+                    raise RuntimeError("parser bug")
+                return _make_leaf(leaf_id=ref.url.split("/")[-1], url=ref.url)
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _UnexpectedFailureSink()
+
+        with caplog.at_level(logging.ERROR, logger="ladon.async_runner"):
+            result = await async_run_crawl(top_ref, plugin, None, config)  # type: ignore[arg-type]
+
+        assert result.leaves_consumed == 2
+        assert result.leaves_persisted == 2
+        assert result.leaves_failed == 1
+        assert result.errors == ("ref[1] consume failed: parser bug",)
+        assert caplog.records[0].getMessage() == (
+            "leaf consume failed — ref[1] error=parser bug"
+        )
+        assert caplog.records[0].error_type == "RuntimeError"  # type: ignore[attr-defined]
+
+    async def test_asset_download_error_from_consume_propagates(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        config: RunConfig,
+    ) -> None:
+        class _AssetFailureSink:
+            async def consume(self, ref: object, client: object) -> object:
+                raise AssetDownloadError("asset unavailable")
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _AssetFailureSink()
+
+        with pytest.raises(AssetDownloadError, match="asset unavailable"):
+            await async_run_crawl(top_ref, plugin, None, config)  # type: ignore[arg-type]
+
+    async def test_expansion_not_ready_from_consume_propagates(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        config: RunConfig,
+    ) -> None:
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _TypedAsyncExpansionFailureSink(
+            ExpansionNotReadyError("not ready yet")
+        )
+
+        with pytest.raises(ExpansionNotReadyError, match="not ready yet"):
+            await async_run_crawl(top_ref, plugin, None, config)  # type: ignore[arg-type]
+
+    async def test_all_fatal_batch_outcomes_are_logged_before_first_propagates(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        config: RunConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class _AssetFailureSink:
+            async def consume(self, ref: object, client: object) -> object:
+                assert isinstance(ref, Ref)
+                raise AssetDownloadError(f"asset unavailable: {ref.url}")
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _AssetFailureSink()
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ladon.async_runner"),
+            pytest.raises(
+                AssetDownloadError, match="asset unavailable: .*/leaf/1"
+            ),
+        ):
+            await async_run_crawl(top_ref, plugin, None, config)  # type: ignore[arg-type]
+
+        fatal_logs = [
+            record
+            for record in caplog.records
+            if getattr(record, "error_type", None) == "AssetDownloadError"
+        ]
+        assert [record.ref_index for record in fatal_logs] == [0, 1, 2]  # type: ignore[attr-defined]
+        assert [record.error for record in fatal_logs] == [  # type: ignore[attr-defined]
+            f"asset unavailable: {ref.url}" for ref in child_refs
+        ]
+
+    async def test_cancelled_consume_propagates(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        config: RunConfig,
+    ) -> None:
+        cancellation = asyncio.CancelledError("cancel leaf 2")
+
+        class _CancelledSink:
+            async def consume(self, ref: object, client: object) -> object:
+                assert isinstance(ref, Ref)
+                if ref.url.endswith("/2"):
+                    raise cancellation
+                return _make_leaf(leaf_id=ref.url.split("/")[-1], url=ref.url)
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _CancelledSink()
+
+        with pytest.raises(
+            asyncio.CancelledError, match="cancel leaf 2"
+        ) as exc_info:
+            await async_run_crawl(top_ref, plugin, None, config)  # type: ignore[arg-type]
+
+        assert exc_info.value is cancellation
+
+    async def test_cancelled_callback_propagates_original_exception(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        config: RunConfig,
+    ) -> None:
+        plugin = _MockAsyncPlugin(child_refs)
+        cancellation = asyncio.CancelledError("cancel persistence")
+
+        async def cancelled_callback(record: object, parent: object) -> None:
+            raise cancellation
+
+        with pytest.raises(
+            asyncio.CancelledError, match="cancel persistence"
+        ) as exc_info:
+            await async_run_crawl(
+                top_ref,
+                plugin,
+                None,  # type: ignore[arg-type]
+                config,
+                on_leaf=cancelled_callback,
+            )
+
+        assert exc_info.value is cancellation
+        assert async_run_crawl.__doc__ is not None
+        assert "consume or ``on_leaf``" in async_run_crawl.__doc__
+
+    async def test_keyboard_interrupt_from_consume_propagates_original(
+        self,
+        top_ref: Ref,
+        config: RunConfig,
+    ) -> None:
+        interruption = KeyboardInterrupt("interrupt async consume")
+
+        class _InterruptingSink:
+            async def consume(self, ref: object, client: object) -> object:
+                raise interruption
+
+        plugin = _MockAsyncPlugin(
+            [Ref(url="https://demo.example.com/leaf/interrupt")]
+        )
+        plugin.sink = _InterruptingSink()
+
+        with pytest.raises(
+            KeyboardInterrupt, match="interrupt async consume"
+        ) as exc_info:
+            await async_run_crawl(top_ref, plugin, None, config)  # type: ignore[arg-type]
+
+        assert exc_info.value is interruption
+
+    async def test_keyboard_interrupt_from_callback_propagates_original(
+        self,
+        top_ref: Ref,
+        config: RunConfig,
+    ) -> None:
+        interruption = KeyboardInterrupt("interrupt async callback")
+
+        async def interrupting_callback(record: object, parent: object) -> None:
+            raise interruption
+
+        plugin = _MockAsyncPlugin(
+            [Ref(url="https://demo.example.com/leaf/interrupt")]
+        )
+
+        with pytest.raises(
+            KeyboardInterrupt, match="interrupt async callback"
+        ) as exc_info:
+            await async_run_crawl(
+                top_ref,
+                plugin,
+                None,  # type: ignore[arg-type]
+                config,
+                on_leaf=interrupting_callback,
+            )
+
+        assert exc_info.value is interruption
+
+    async def test_non_exception_base_exception_from_consume_propagates(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        config: RunConfig,
+    ) -> None:
+        class _LeafAbort(BaseException):
+            pass
+
+        class _AbortingSink:
+            async def consume(self, ref: object, client: object) -> object:
+                raise _LeafAbort("abort leaf task")
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _AbortingSink()
+
+        with pytest.raises(_LeafAbort, match="abort leaf task"):
+            await async_run_crawl(top_ref, plugin, None, config)  # type: ignore[arg-type]
 
     async def test_all_leaves_fail_returns_result_not_exception(
         self,
@@ -894,6 +1161,269 @@ class TestExecutePlan:
         assert result.leaves_failed == 1
         assert result.leaves_consumed + result.leaves_failed == 3
 
+    async def test_unexpected_consume_exception_is_recorded_and_run_continues(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class _UnexpectedFailureSink:
+            async def consume(self, ref: object, client: object) -> object:
+                assert isinstance(ref, Ref)
+                if ref.url.endswith("/2"):
+                    raise RuntimeError("parser bug")
+                return _make_leaf(leaf_id=ref.url.split("/")[-1], url=ref.url)
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _UnexpectedFailureSink()
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+
+        with caplog.at_level(logging.ERROR, logger="ladon.async_runner"):
+            result = await execute_plan(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert result.leaves_consumed == 2
+        assert result.leaves_persisted == 2
+        assert result.leaves_failed == 1
+        assert result.errors == ("ref[1] consume failed: parser bug",)
+        assert sorted(progress_calls) == [(1, 3), (2, 3), (3, 3)]
+        assert caplog.records[0].getMessage() == (
+            "leaf consume failed — ref[1] error=parser bug"
+        )
+        assert caplog.records[0].error_type == "RuntimeError"  # type: ignore[attr-defined]
+
+    async def test_asset_download_error_from_consume_propagates(
+        self, top_ref: Ref, child_refs: list[Ref]
+    ) -> None:
+        class _AssetFailureSink:
+            async def consume(self, ref: object, client: object) -> object:
+                raise AssetDownloadError("asset unavailable")
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _AssetFailureSink()
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+
+        with pytest.raises(AssetDownloadError, match="asset unavailable"):
+            await execute_plan(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(leaf_limit=1),
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert progress_calls == [(1, 1)]
+
+    async def test_child_list_unavailable_from_consume_propagates(
+        self, child_refs: list[Ref]
+    ) -> None:
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _TypedAsyncExpansionFailureSink(
+            ChildListUnavailableError("child list unavailable")
+        )
+        plan = CrawlPlan(
+            record=_make_record(), leaves=tuple(child_refs), errors=()
+        )
+        progress_calls: list[tuple[int, int]] = []
+
+        with pytest.raises(
+            ChildListUnavailableError, match="child list unavailable"
+        ):
+            await execute_plan(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(leaf_limit=1),
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert progress_calls == [(1, 1)]
+
+    async def test_execute_plan_logs_every_fatal_batch_outcome(
+        self,
+        child_refs: list[Ref],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class _AssetFailureSink:
+            async def consume(self, ref: object, client: object) -> object:
+                assert isinstance(ref, Ref)
+                raise AssetDownloadError(f"asset unavailable: {ref.url}")
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _AssetFailureSink()
+        plan = CrawlPlan(
+            record=_make_record(), leaves=tuple(child_refs), errors=()
+        )
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ladon.async_runner"),
+            pytest.raises(
+                AssetDownloadError, match="asset unavailable: .*/leaf/1"
+            ),
+        ):
+            await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+
+        fatal_logs = [
+            record
+            for record in caplog.records
+            if getattr(record, "error_type", None) == "AssetDownloadError"
+        ]
+        assert [record.ref_index for record in fatal_logs] == [0, 1, 2]  # type: ignore[attr-defined]
+
+    def test_execute_plan_documents_fatal_exceptions(self) -> None:
+        assert execute_plan.__doc__ is not None
+        assert "Raises:" in execute_plan.__doc__
+        assert "AssetDownloadError" in execute_plan.__doc__
+        assert "asyncio.CancelledError" in execute_plan.__doc__
+        assert "BaseException" in execute_plan.__doc__
+
+    async def test_cancelled_consume_propagates(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        cancellation = asyncio.CancelledError("cancel leaf 2")
+
+        class _CancelledSink:
+            async def consume(self, ref: object, client: object) -> object:
+                assert isinstance(ref, Ref)
+                if ref.url.endswith("/2"):
+                    raise cancellation
+                return _make_leaf(leaf_id=ref.url.split("/")[-1], url=ref.url)
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _CancelledSink()
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ladon.async_runner"),
+            pytest.raises(
+                asyncio.CancelledError, match="cancel leaf 2"
+            ) as exc_info,
+        ):
+            await execute_plan(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert exc_info.value is cancellation
+        assert progress_calls == [(1, 3), (2, 3), (3, 3)]
+        cancellation_logs = [
+            record
+            for record in caplog.records
+            if getattr(record, "error_type", None) == "CancelledError"
+        ]
+        assert len(cancellation_logs) == 1
+        assert "failed" not in cancellation_logs[0].getMessage()
+
+    async def test_non_exception_base_exception_from_consume_propagates(
+        self, top_ref: Ref, child_refs: list[Ref]
+    ) -> None:
+        class _LeafAbort(BaseException):
+            pass
+
+        class _AbortingSink:
+            async def consume(self, ref: object, client: object) -> object:
+                raise _LeafAbort("abort leaf task")
+
+        plugin = _MockAsyncPlugin(child_refs)
+        plugin.sink = _AbortingSink()
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+
+        with pytest.raises(_LeafAbort, match="abort leaf task"):
+            await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+
+    async def test_keyboard_interrupt_from_consume_propagates_original(
+        self,
+    ) -> None:
+        interruption = KeyboardInterrupt("interrupt planned consume")
+
+        class _InterruptingSink:
+            async def consume(self, ref: object, client: object) -> object:
+                raise interruption
+
+        leaf_ref = Ref(url="https://demo.example.com/leaf/interrupt")
+        plugin = _MockAsyncPlugin([leaf_ref])
+        plugin.sink = _InterruptingSink()
+        plan = CrawlPlan(record=_make_record(), leaves=(leaf_ref,), errors=())
+
+        with pytest.raises(
+            KeyboardInterrupt, match="interrupt planned consume"
+        ) as exc_info:
+            await execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+
+        assert exc_info.value is interruption
+
+    async def test_keyboard_interrupt_from_callback_propagates_original(
+        self,
+    ) -> None:
+        interruption = KeyboardInterrupt("interrupt planned callback")
+
+        async def interrupting_callback(record: object, ref: object) -> None:
+            raise interruption
+
+        leaf_ref = Ref(url="https://demo.example.com/leaf/interrupt")
+        plugin = _MockAsyncPlugin([leaf_ref])
+        plan = CrawlPlan(record=_make_record(), leaves=(leaf_ref,), errors=())
+
+        with pytest.raises(
+            KeyboardInterrupt, match="interrupt planned callback"
+        ) as exc_info:
+            await execute_plan(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_leaf=interrupting_callback,
+            )
+
+        assert exc_info.value is interruption
+
+    async def test_cancelling_executor_still_cancels_gather(self) -> None:
+        sink_started = asyncio.Event()
+
+        class _BlockingSink:
+            async def consume(self, ref: object, client: object) -> object:
+                sink_started.set()
+                await asyncio.Event().wait()
+
+        plugin = _MockAsyncPlugin([])
+        plugin.sink = _BlockingSink()
+        plan = CrawlPlan(
+            record=_make_record(),
+            leaves=(Ref(url="https://demo.example.com/leaf/1"),),
+            errors=(),
+        )
+        execution = asyncio.create_task(
+            execute_plan(plan, plugin, None, RunConfig())  # type: ignore[arg-type]
+        )
+        await sink_started.wait()
+
+        execution.cancel("cancel executor")
+
+        with pytest.raises(asyncio.CancelledError):
+            await execution
+
     async def test_on_leaf_callback_failure_counted(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
@@ -980,16 +1510,23 @@ class TestExecutePlan:
         )
         assert calls == []
 
-    async def test_warns_when_on_progress_is_async(
+    async def test_rejects_async_on_progress_before_leaf_processing(
         self, plugin: _MockAsyncPlugin
     ) -> None:
-        plan = CrawlPlan(record=_make_record(), leaves=(), errors=())
+        assert execute_plan.__doc__ is not None
+        assert "TypeError" in execute_plan.__doc__
+
+        plan = CrawlPlan(
+            record=_make_record(),
+            leaves=(Ref(url="https://demo.example.com/leaf/1"),),
+            errors=(),
+        )
 
         async def async_callback(done: int, total: int) -> None:
             pass
 
-        with pytest.warns(
-            UserWarning, match="on_progress must be a synchronous callable"
+        with pytest.raises(
+            TypeError, match="on_progress must be a synchronous callable"
         ):
             await execute_plan(
                 plan,
@@ -997,6 +1534,30 @@ class TestExecutePlan:
                 None,  # type: ignore[arg-type]
                 RunConfig(),
                 on_progress=async_callback,
+            )
+
+    async def test_rejects_async_callable_object_as_on_progress(
+        self, plugin: _MockAsyncPlugin
+    ) -> None:
+        plan = CrawlPlan(
+            record=_make_record(),
+            leaves=(Ref(url="https://demo.example.com/leaf/1"),),
+            errors=(),
+        )
+
+        class _AsyncProgress:
+            async def __call__(self, done: int, total: int) -> None:
+                pass
+
+        with pytest.raises(
+            TypeError, match="on_progress must be a synchronous callable"
+        ):
+            await execute_plan(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_progress=_AsyncProgress(),
             )
 
     async def test_on_progress_called_after_sink_failure(
@@ -1041,6 +1602,37 @@ class TestExecutePlan:
         )
         assert progress_calls == [(1, 1)]
 
+    async def test_on_progress_called_before_fatal_on_leaf_propagates(
+        self, top_ref: Ref
+    ) -> None:
+        refs = [Ref(url="https://demo.example.com/leaf/1")]
+        plugin = _MockAsyncPlugin(refs)
+        plan = await plan_crawl(top_ref, plugin, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+        cancellation = asyncio.CancelledError("cancel persistence")
+
+        async def cancelled_callback(record: object, ref: object) -> None:
+            raise cancellation
+
+        with pytest.raises(
+            asyncio.CancelledError, match="cancel persistence"
+        ) as exc_info:
+            await execute_plan(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_leaf=cancelled_callback,
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert exc_info.value is cancellation
+        assert progress_calls == [(1, 1)]
+        assert execute_plan.__doc__ is not None
+        assert "consume or ``on_leaf``" in execute_plan.__doc__
+
     async def test_plan_crawl_then_execute_plan_roundtrip(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
@@ -1049,10 +1641,10 @@ class TestExecutePlan:
         result = await execute_plan(filtered, plugin, None, RunConfig())  # type: ignore[arg-type]
         assert result.leaves_consumed == 2
 
-    async def test_on_progress_fired_for_base_exception_leaves(
+    async def test_on_progress_fired_for_unexpected_exception_leaves(
         self, top_ref: Ref
     ) -> None:
-        """BaseException escaping _process_leaf must still trigger on_progress."""
+        """Recorded consume exceptions still count as completed attempts."""
 
         class _ExplodingSink:
             async def consume(self, ref: object, client: object) -> object:
@@ -1073,10 +1665,8 @@ class TestExecutePlan:
             RunConfig(),
             on_progress=lambda d, t: progress_calls.append((d, t)),
         )
-        # The RuntimeError is not LeafUnavailableError, so it escapes
-        # _process_leaf and is caught by gather(return_exceptions=True).
-        # on_progress must still fire so callers can reach total.
         assert result.leaves_failed == 1
+        assert result.errors == ("ref[0] consume failed: unexpected kaboom",)
         assert len(progress_calls) == 1
         assert progress_calls[0] == (1, 1)
 
@@ -1092,6 +1682,64 @@ class TestExecutePlan:
             plan, plugin, None, RunConfig(), on_progress=exploding_progress  # type: ignore[arg-type]
         )
         assert result.leaves_consumed == 3
+
+    async def test_cancelled_on_progress_propagates_original(self) -> None:
+        cancellation = asyncio.CancelledError("cancel progress reporting")
+
+        def cancelled_progress(done: int, total: int) -> None:
+            raise cancellation
+
+        leaf_ref = Ref(url="https://demo.example.com/leaf/1")
+        plugin = _MockAsyncPlugin([leaf_ref])
+        plan = CrawlPlan(record=_make_record(), leaves=(leaf_ref,), errors=())
+
+        with pytest.raises(
+            asyncio.CancelledError, match="cancel progress reporting"
+        ) as exc_info:
+            await execute_plan(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_progress=cancelled_progress,
+            )
+
+        assert exc_info.value is cancellation
+
+    def test_on_progress_base_exception_preempts_fatal_consume_error(
+        self,
+    ) -> None:
+        asset_error = AssetDownloadError("asset failed")
+
+        class _FailingSink:
+            async def consume(self, ref: object, client: object) -> object:
+                raise asset_error
+
+        interruption = KeyboardInterrupt("progress bar died")
+
+        def interrupting_progress(done: int, total: int) -> None:
+            raise interruption
+
+        leaf_ref = Ref(url="https://demo.example.com/leaf/1")
+        plugin = _MockAsyncPlugin([leaf_ref])
+        plugin.sink = _FailingSink()
+        plan = CrawlPlan(record=_make_record(), leaves=(leaf_ref,), errors=())
+
+        with pytest.raises(
+            KeyboardInterrupt, match="progress bar died"
+        ) as exc_info:
+            asyncio.run(
+                execute_plan(
+                    plan,
+                    plugin,
+                    None,  # type: ignore[arg-type]
+                    RunConfig(),
+                    on_progress=interrupting_progress,
+                )
+            )
+
+        assert exc_info.value is interruption
+        assert exc_info.value.__context__ is asset_error
 
     async def test_plan_importable_from_ladon(self) -> None:
         from ladon import execute_plan as _ep

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false
 # pyright: reportUnknownParameterType=false
 """Tests for the ladon CLI (ladon.cli)."""
 
@@ -8,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ladon.cli import build_parser, load_plugin_class, main
+from ladon.cli import _cmd_run, build_parser, load_plugin_class, main
 
 # ---------------------------------------------------------------------------
 # load_plugin_class
@@ -305,3 +306,91 @@ class TestMainDispatch:
             with pytest.raises(SystemExit) as exc_info:
                 main()
         assert exc_info.value.code == 2
+
+    def test_run_exits_2_on_real_sink_consume_exception(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from ladon.plugins.models import Expansion
+
+        class _Expander:
+            def expand(self, ref: object, client: object) -> Expansion:
+                return Expansion(record=object(), child_refs=("leaf-1",))
+
+        class _Sink:
+            def consume(self, ref: object, client: object) -> object:
+                raise RuntimeError("leaf parser exploded")
+
+        class _Plugin:
+            name = "cli-test-plugin"
+            source = object()
+
+            def __init__(self, *, client: object) -> None:
+                self.expanders = (_Expander(),)
+                self.sink = _Sink()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "ladon",
+                    "run",
+                    "--plugin",
+                    "pkg:Cls",
+                    "--ref",
+                    "http://x.com",
+                ],
+            ),
+            patch("ladon.cli.load_plugin_class", return_value=_Plugin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+
+        assert exc_info.value.code == 2
+        assert "leaf parser exploded" in capsys.readouterr().out
+
+    def test_run_exits_1_on_real_sink_asset_download_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from ladon.plugins.errors import AssetDownloadError
+        from ladon.plugins.models import Expansion
+
+        class _Expander:
+            def expand(self, ref: object, client: object) -> Expansion:
+                return Expansion(record=object(), child_refs=("leaf-1",))
+
+        class _Sink:
+            def consume(self, ref: object, client: object) -> object:
+                raise AssetDownloadError("asset download failed")
+
+        class _Plugin:
+            name = "cli-test-plugin"
+            source = object()
+
+            def __init__(self, *, client: object) -> None:
+                self.expanders = (_Expander(),)
+                self.sink = _Sink()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "ladon",
+                    "run",
+                    "--plugin",
+                    "pkg:Cls",
+                    "--ref",
+                    "http://x.com",
+                ],
+            ),
+            patch("ladon.cli.load_plugin_class", return_value=_Plugin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+
+        assert exc_info.value.code == 1
+        assert "asset download failed" in capsys.readouterr().err
+
+    def test_run_docstring_distinguishes_partial_leaf_failures(self) -> None:
+        assert _cmd_run.__doc__ is not None
+        assert "including ordinary exceptions" in _cmd_run.__doc__
+        assert "exception ``run_crawl`` does not isolate" in _cmd_run.__doc__

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,34 @@
+"""Regression tests for behavior-defining project documentation."""
+
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).parents[1]
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_adr_004_contains_phase_3_exception_isolation_amendment() -> None:
+    adr = (
+        _PROJECT_ROOT / "docs/decisions/adr-004-ses-protocol-design.md"
+    ).read_text(encoding="utf-8")
+
+    assert _normalize_whitespace(
+        "### Phase-3 leaf-exception isolation amendment "
+        "(2026-08-11, Issue #164)"
+    ) in _normalize_whitespace(adr)
+
+
+def test_changelog_documents_cli_partial_failure_exit_code() -> None:
+    changelog = (_PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    normalized_changelog = _normalize_whitespace(changelog)
+    assert (
+        _normalize_whitespace("CLI now exits with code 2")
+        in normalized_changelog
+    )
+    assert (
+        _normalize_whitespace("ordinary `Sink.consume()` exception")
+        in normalized_changelog
+    )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 
 from ladon.plugins.errors import (
+    AssetDownloadError,
     ChildListUnavailableError,
     ExpansionNotReadyError,
     LeafUnavailableError,
@@ -28,6 +29,8 @@ from ladon.runner import (
     RunResult,
     execute_plan_sync,
     plan_crawl_sync,
+    run_crawl,
+    run_plugin,
 )
 
 # ---------------------------------------------------------------------------
@@ -101,6 +104,154 @@ def plugin(child_refs: list[Ref]) -> _MockPlugin:
 @pytest.fixture()
 def top_ref() -> Ref:
     return Ref(url="https://demo.example.com/top/1")
+
+
+class _UnexpectedFailureSink:
+    def consume(self, ref: object, client: object) -> _DemoLeafRecord:
+        r = ref if isinstance(ref, Ref) else Ref(url=str(ref))
+        if r.url.endswith("/2"):
+            raise RuntimeError("parser bug")
+        return _DemoLeafRecord(leaf_id=r.url.split("/")[-1], url=r.url)
+
+
+class _KeyboardInterruptSink:
+    def consume(self, ref: object, client: object) -> object:
+        raise KeyboardInterrupt("stop now")
+
+
+class _AssetDownloadFailureSink:
+    def consume(self, ref: object, client: object) -> object:
+        raise AssetDownloadError("asset unavailable")
+
+
+class _TypedExpansionFailureSink:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def consume(self, ref: object, client: object) -> object:
+        raise self._error
+
+
+# ---------------------------------------------------------------------------
+# run_crawl — Phase 3 exception semantics
+# ---------------------------------------------------------------------------
+
+
+class TestRunCrawlExceptionSemantics:
+    def test_run_result_documents_both_phase_3_error_formats(self) -> None:
+        assert RunResult.__doc__ is not None
+        assert '"ref[N] consume failed: ..."' in RunResult.__doc__
+        assert '"ref[N] callback failed: ..."' in RunResult.__doc__
+
+    def test_run_crawl_documents_fatal_exceptions(self) -> None:
+        assert run_crawl.__doc__ is not None
+        assert "Raises:" in run_crawl.__doc__
+        assert "BaseException" in run_crawl.__doc__
+
+    def test_run_plugin_documents_fatal_exceptions(self) -> None:
+        assert run_plugin.__doc__ is not None
+        assert "Raises:" in run_plugin.__doc__
+        assert "AssetDownloadError" in run_plugin.__doc__
+        assert "ExpansionNotReadyError" in run_plugin.__doc__
+        assert "PartialExpansionError" in run_plugin.__doc__
+        assert "ChildListUnavailableError" in run_plugin.__doc__
+        assert "BaseException" in run_plugin.__doc__
+
+    def test_unexpected_consume_exception_is_recorded_and_run_continues(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plugin = _MockPlugin(child_refs)
+        plugin.sink = _UnexpectedFailureSink()
+
+        with caplog.at_level(logging.ERROR, logger="ladon.runner"):
+            result = run_crawl(top_ref, plugin, None, RunConfig())  # type: ignore[arg-type]
+
+        assert result.leaves_consumed == 2
+        assert result.leaves_persisted == 2
+        assert result.leaves_failed == 1
+        assert result.errors == ("ref[1] consume failed: parser bug",)
+        assert caplog.records[0].getMessage() == (
+            "leaf consume failed — ref[1] error=parser bug"
+        )
+        assert caplog.records[0].error_type == "RuntimeError"  # type: ignore[attr-defined]
+
+    def test_asset_download_error_from_consume_propagates(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plugin = _MockPlugin(child_refs)
+        plugin.sink = _AssetDownloadFailureSink()
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ladon.runner"),
+            pytest.raises(AssetDownloadError, match="asset unavailable"),
+        ):
+            run_crawl(top_ref, plugin, None, RunConfig())  # type: ignore[arg-type]
+
+        assert caplog.records[0].ref_index == 0  # type: ignore[attr-defined]
+        assert caplog.records[0].error_type == "AssetDownloadError"  # type: ignore[attr-defined]
+
+    def test_expansion_not_ready_from_consume_propagates(
+        self, top_ref: Ref, child_refs: list[Ref]
+    ) -> None:
+        plugin = _MockPlugin(child_refs)
+        plugin.sink = _TypedExpansionFailureSink(
+            ExpansionNotReadyError("not ready yet")
+        )
+
+        with pytest.raises(ExpansionNotReadyError, match="not ready yet"):
+            run_crawl(top_ref, plugin, None, RunConfig())  # type: ignore[arg-type]
+
+    def test_keyboard_interrupt_from_consume_propagates(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plugin = _MockPlugin(child_refs)
+        plugin.sink = _KeyboardInterruptSink()
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ladon.runner"),
+            pytest.raises(KeyboardInterrupt, match="stop now"),
+        ):
+            run_crawl(top_ref, plugin, None, RunConfig())  # type: ignore[arg-type]
+
+        assert "failed" not in caplog.records[0].getMessage()
+        assert caplog.records[0].ref_index == 0  # type: ignore[attr-defined]
+        assert caplog.records[0].error_type == "KeyboardInterrupt"  # type: ignore[attr-defined]
+
+    def test_keyboard_interrupt_from_callback_is_logged_and_propagates(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plugin = _MockPlugin(child_refs)
+
+        def cancelled_callback(record: object, parent: object) -> None:
+            raise KeyboardInterrupt("cancel persistence")
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ladon.runner"),
+            pytest.raises(KeyboardInterrupt, match="cancel persistence"),
+        ):
+            run_crawl(
+                top_ref,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_leaf=cancelled_callback,
+            )
+
+        assert caplog.records[0].ref_index == 0  # type: ignore[attr-defined]
+        assert caplog.records[0].error_type == "KeyboardInterrupt"  # type: ignore[attr-defined]
+        assert "failed" not in caplog.records[0].getMessage()
 
 
 # ---------------------------------------------------------------------------
@@ -401,6 +552,130 @@ class TestExecutePlanSync:
         assert len(result.errors) == 1
         assert "consume failed" in result.errors[0]
 
+    def test_unexpected_consume_exception_is_recorded_and_run_continues(
+        self,
+        top_ref: Ref,
+        child_refs: list[Ref],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plugin = _MockPlugin(child_refs)
+        plugin.sink = _UnexpectedFailureSink()
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+
+        with caplog.at_level(logging.ERROR, logger="ladon.runner"):
+            result = execute_plan_sync(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert result.leaves_consumed == 2
+        assert result.leaves_persisted == 2
+        assert result.leaves_failed == 1
+        assert result.errors == ("ref[1] consume failed: parser bug",)
+        assert progress_calls == [(1, 3), (2, 3), (3, 3)]
+        assert caplog.records[0].getMessage() == (
+            "leaf consume failed — ref[1] error=parser bug"
+        )
+        assert caplog.records[0].error_type == "RuntimeError"  # type: ignore[attr-defined]
+
+    def test_asset_download_error_from_consume_propagates(
+        self, child_refs: list[Ref], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        plugin = _MockPlugin(child_refs)
+        plugin.sink = _AssetDownloadFailureSink()
+        plan = CrawlPlan(
+            record=_DemoRecord(), leaves=tuple(child_refs), errors=()
+        )
+        progress_calls: list[tuple[int, int]] = []
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ladon.runner"),
+            pytest.raises(AssetDownloadError, match="asset unavailable"),
+        ):
+            execute_plan_sync(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(leaf_limit=1),
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert progress_calls == [(1, 1)]
+        assert caplog.records[0].ref_index == 0  # type: ignore[attr-defined]
+        assert caplog.records[0].error_type == "AssetDownloadError"  # type: ignore[attr-defined]
+
+    def test_partial_expansion_error_from_consume_propagates(
+        self, child_refs: list[Ref]
+    ) -> None:
+        plugin = _MockPlugin(child_refs)
+        plugin.sink = _TypedExpansionFailureSink(
+            PartialExpansionError("partial expansion")
+        )
+        plan = CrawlPlan(
+            record=_DemoRecord(), leaves=tuple(child_refs), errors=()
+        )
+        progress_calls: list[tuple[int, int]] = []
+
+        with pytest.raises(PartialExpansionError, match="partial expansion"):
+            execute_plan_sync(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(leaf_limit=1),
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert progress_calls == [(1, 1)]
+
+    def test_execute_plan_sync_documents_asset_download_error(self) -> None:
+        assert execute_plan_sync.__doc__ is not None
+        assert "Raises:" in execute_plan_sync.__doc__
+        assert "AssetDownloadError" in execute_plan_sync.__doc__
+
+    def test_execute_plan_sync_documents_fatal_exceptions(self) -> None:
+        assert execute_plan_sync.__doc__ is not None
+        assert "Raises:" in execute_plan_sync.__doc__
+        assert "BaseException" in execute_plan_sync.__doc__
+
+    def test_keyboard_interrupt_from_consume_propagates(
+        self, child_refs: list[Ref], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        plugin = _MockPlugin(child_refs)
+        plugin.sink = _KeyboardInterruptSink()
+        plan = CrawlPlan(
+            record=_DemoRecord(), leaves=tuple(child_refs), errors=()
+        )
+        progress_calls: list[tuple[int, int]] = []
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ladon.runner"),
+            pytest.raises(KeyboardInterrupt, match="stop now"),
+        ):
+            execute_plan_sync(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert progress_calls == [(1, 3)]
+        assert "failed" not in caplog.records[0].getMessage()
+        assert caplog.records[0].ref_index == 0  # type: ignore[attr-defined]
+        assert caplog.records[0].error_type == "KeyboardInterrupt"  # type: ignore[attr-defined]
+
     def test_on_leaf_callback_failure_counted(
         self, top_ref: Ref, plugin: _MockPlugin
     ) -> None:
@@ -530,6 +805,39 @@ class TestExecutePlanSync:
         )
         assert progress_calls == [(1, 1)]
 
+    def test_on_progress_called_before_fatal_on_leaf_propagates(
+        self, top_ref: Ref, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        refs = [Ref(url="https://x.example.com/leaf/1")]
+        plugin = _MockPlugin(refs)
+        plan = plan_crawl_sync(top_ref, plugin, None)  # type: ignore[arg-type]
+        progress_calls: list[tuple[int, int]] = []
+
+        def cancelled_callback(record: object, ref: object) -> None:
+            raise KeyboardInterrupt("cancel persistence")
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ladon.runner"),
+            pytest.raises(KeyboardInterrupt, match="cancel persistence"),
+        ):
+            execute_plan_sync(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_leaf=cancelled_callback,
+                on_progress=lambda done, total: progress_calls.append(
+                    (done, total)
+                ),
+            )
+
+        assert progress_calls == [(1, 1)]
+        assert caplog.records[0].ref_index == 0  # type: ignore[attr-defined]
+        assert caplog.records[0].error_type == "KeyboardInterrupt"  # type: ignore[attr-defined]
+        assert "failed" not in caplog.records[0].getMessage()
+        assert execute_plan_sync.__doc__ is not None
+        assert "Sink or ``on_leaf``" in execute_plan_sync.__doc__
+
     def test_on_progress_exception_is_swallowed(
         self, top_ref: Ref, plugin: _MockPlugin
     ) -> None:
@@ -542,6 +850,39 @@ class TestExecutePlanSync:
             plan, plugin, None, RunConfig(), on_progress=exploding_progress  # type: ignore[arg-type]
         )
         assert result.leaves_consumed == 3
+
+    def test_on_progress_base_exception_preempts_fatal_consume_error(
+        self,
+    ) -> None:
+        asset_error = AssetDownloadError("asset failed")
+
+        class _FailingSink:
+            def consume(self, ref: object, client: object) -> object:
+                raise asset_error
+
+        interruption = KeyboardInterrupt("progress bar died")
+
+        def interrupting_progress(done: int, total: int) -> None:
+            raise interruption
+
+        leaf_ref = Ref(url="https://x.example.com/leaf/1")
+        plugin = _MockPlugin([leaf_ref])
+        plugin.sink = _FailingSink()
+        plan = CrawlPlan(record=_DemoRecord(), leaves=(leaf_ref,), errors=())
+
+        with pytest.raises(
+            KeyboardInterrupt, match="progress bar died"
+        ) as exc_info:
+            execute_plan_sync(
+                plan,
+                plugin,
+                None,  # type: ignore[arg-type]
+                RunConfig(),
+                on_progress=interrupting_progress,
+            )
+
+        assert exc_info.value is interruption
+        assert exc_info.value.__context__ is asset_error
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Sync runner Phase-3 (`run_crawl`, `execute_plan_sync`) aborted the whole run and discarded all accumulated counts/errors on any exception from `sink.consume()` other than `LeafUnavailableError`.
- Async runner Phase-3 (`async_run_crawl`, `execute_plan`) did the opposite (record-and-continue via `gather(return_exceptions=True)`), but the same code path also mislabeled `asyncio.CancelledError` as a counted leaf failure instead of letting cancellation propagate.
- Both runners now record-and-continue on ordinary `Exception` from `sink.consume()` (visible in `RunResult.errors`, never silently dropped); `AssetDownloadError` keeps its existing fatal/propagate contract; `CancelledError` and other non-`Exception` `BaseException` subclasses propagate unchanged instead of being counted as failures.
- Docs (`concepts.md`, `how-ladon-works.md`, `cookbook.md`, `authoring-plugins.md`) and `CHANGELOG.md` updated to match the settled contract.

## Test plan

- [x] `pytest tests/` — 727 passed
- [x] `pre-commit run --all-files` — clean (black, ruff, isort, pyright)
- [x] New tests cover: mixed leaf failures (unexpected exception doesn't abort the run) for all four Phase-3 loops, `AssetDownloadError` still propagates in all four, sync `KeyboardInterrupt` propagates, async `CancelledError` propagates, `on_progress` fires once per attempt on the new path

Fixes #164