### PR TITLE
fix(networking): enforce polite retry pacing on every attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Polite retry pacing** — retries now enforce per-host rate limits, including
+  robots.txt `Crawl-delay` overrides, on every attempt and merge that wait with
+  Retry-After or backoff into one sleep. The default backoff is now a safe
+  `0.5` seconds; explicitly setting zero with retries enabled emits a warning.
 - **Consistent runner leaf-exception semantics** — sync crawls now record an
   unexpected non-fatal `Sink.consume()` exception and continue with remaining
   leaves instead of aborting and losing the partial result. Async crawls now

--- a/docs/decisions/adr-007-circuit-breaker.md
+++ b/docs/decisions/adr-007-circuit-breaker.md
@@ -3,7 +3,7 @@ status: accepted
 date: 2026-03-18
 decision-makers: [Maintainers]
 informed: [Contributors]
-refs: [ADR-001, ADR-002, "Issue #38", "Issue #160", "Issue #165"]
+refs: [ADR-001, ADR-002, "Issue #38", "Issue #160", "Issue #165", "Issue #167"]
 ---
 
 # ADR-007 — Per-Host Circuit Breaker
@@ -96,6 +96,20 @@ independent of ADR-002's result contract: a 5xx response can remain `Ok(...)`
 for caller-owned status interpretation while still contributing one failure
 for the logical call sequence. Statuses handled by `retry_on_status`, including
 4xx statuses such as 429, record one failure only after retries are exhausted.
+
+### Polite retry pacing amendment (2026-08-12, Issue #167)
+
+The default exponential-backoff base is `0.5` seconds so a retryable response
+without a `Retry-After` header cannot immediately re-fire under default
+configuration. Setting `backoff_base_seconds=0.0` remains supported as an
+explicit opt-out and emits `UserWarning` when retries are enabled.
+
+Every retry attempt re-evaluates its host's politeness interval, including any
+robots.txt `Crawl-delay` override. Retry-After or exponential backoff and the
+remaining per-host interval are merged by taking their maximum, producing one
+sleep between attempts. Async clients perform this merged wait and timestamp
+reservation while holding the existing per-host lock, preserving staggered
+starts for concurrent callers.
 
 ## Consequences
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ the config is immutable after construction.
 |---|---|---|
 | `user_agent` | `None` | Custom `User-Agent` header |
 | `retries` | `0` | Number of retry attempts after the first failure |
-| `backoff_base_seconds` | `0.0` | Exponential backoff base (disabled if 0) |
+| `backoff_base_seconds` | `0.5` | Exponential backoff base (set to 0 for an explicit unpaced-retry opt-out) |
 | `timeout_seconds` | `30.0` | Request timeout in seconds |
 | `connect_timeout_seconds` | `None` | Separate connect timeout (set both or neither) |
 | `read_timeout_seconds` | `None` | Separate read timeout (set both or neither) |

--- a/src/ladon/networking/_async_policy_base.py
+++ b/src/ladon/networking/_async_policy_base.py
@@ -112,15 +112,13 @@ class AsyncPolicyBase(ABC):
         """Return the total number of attempts for one request."""
         return 1 + max(0, self._config.retries)
 
-    async def _sleep_between_attempts(self, attempt: int) -> None:
-        """Sleep between retry attempts using exponential backoff."""
+    def _backoff_delay(self, attempt: int) -> float:
+        """Compute exponential backoff before the next retry attempt."""
         backoff_base = self._config.backoff_base_seconds
         if backoff_base <= 0:
-            return
+            return 0.0
         cap = backoff_base * (2 ** max(0, attempt - 1))
-        await asyncio.sleep(
-            uniform(0.0, cap) if self._config.backoff_jitter else cap
-        )
+        return uniform(0.0, cap) if self._config.backoff_jitter else cap
 
     @staticmethod
     def _parse_retry_after(response: Any) -> float | None:
@@ -139,17 +137,11 @@ class AsyncPolicyBase(ABC):
         except Exception:
             return None
 
-    async def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        """Sleep before a retry triggered by a rate-limiting HTTP response."""
+    def _retry_delay(self, retry_after: float | None, attempt: int) -> float:
+        """Compute the delay for a rate-limiting HTTP response retry."""
         if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            await asyncio.sleep(
-                max(capped, self._config.min_request_interval_seconds)
-            )
-        else:
-            await self._sleep_between_attempts(attempt)
+            return min(retry_after, self._config.max_retry_after_seconds)
+        return self._backoff_delay(attempt)
 
     def _merge_params(
         self, params: Mapping[str, str] | None
@@ -161,7 +153,9 @@ class AsyncPolicyBase(ABC):
         merged = {**dp, **(params or {})}
         return merged if merged else None
 
-    async def _enforce_rate_limit(self, host: str) -> None:
+    async def _enforce_rate_limit(
+        self, host: str, extra_delay: float = 0.0
+    ) -> None:
         """Enforce per-host politeness delay before issuing a request.
 
         Concurrent callers reserve start slots while holding a host-specific
@@ -174,12 +168,14 @@ class AsyncPolicyBase(ABC):
         ``async with`` block releases the lock for the next waiter.
         """
         if not host:
+            if extra_delay > 0:
+                await asyncio.sleep(extra_delay)
             return
         interval = max(
             self._config.min_request_interval_seconds,
             self._crawl_delay_overrides.get(host, 0.0),
         )
-        if interval <= 0:
+        if interval <= 0 and extra_delay <= 0:
             return
 
         lock = self._rate_limit_locks.get(host)
@@ -187,12 +183,14 @@ class AsyncPolicyBase(ABC):
             lock = asyncio.Lock()
             self._rate_limit_locks[host] = lock
         async with lock:
+            interval_remaining = 0.0
             last = self._last_request_time.get(host)
             if last is not None:
                 elapsed = monotonic() - last
-                remaining = interval - elapsed
-                if remaining > 0:
-                    await asyncio.sleep(remaining)
+                interval_remaining = max(0.0, interval - elapsed)
+            wait = max(interval_remaining, extra_delay)
+            if wait > 0:
+                await asyncio.sleep(wait)
             self._last_request_time[host] = monotonic()
 
     def _get_circuit_breaker(self, host: str) -> CircuitBreaker | None:
@@ -366,11 +364,16 @@ class AsyncPolicyBase(ABC):
             last_error: Exception | None = None
             last_blocked_response: Any = None
             last_blocked_retry_after: float | None = None
+            retry_delay = 0.0
             current_proxy: Mapping[str, str] | None = None
             if pool is not None:
                 current_proxy = pool.next_proxy()
 
             for _ in range(self._max_attempts()):
+                if attempts > 0:
+                    await self._enforce_rate_limit(
+                        host, extra_delay=retry_delay
+                    )
                 attempts += 1
                 try:
                     response = await self._execute_attempt(
@@ -389,7 +392,7 @@ class AsyncPolicyBase(ABC):
                             if pool is not None:
                                 pool.mark_failure(current_proxy)
                                 current_proxy = pool.next_proxy()
-                            await self._sleep_for_retry_after(
+                            retry_delay = self._retry_delay(
                                 last_blocked_retry_after, attempts
                             )
                             continue
@@ -443,7 +446,7 @@ class AsyncPolicyBase(ABC):
                     if pool is not None:
                         pool.mark_failure(current_proxy)
                         current_proxy = pool.next_proxy()
-                    await self._sleep_between_attempts(attempts)
+                    retry_delay = self._backoff_delay(attempts)
                 finally:
                     if host:
                         self._last_request_time[host] = monotonic()

--- a/src/ladon/networking/_sync_policy_base.py
+++ b/src/ladon/networking/_sync_policy_base.py
@@ -121,13 +121,13 @@ class SyncPolicyBase(ABC):
         """Return the total number of attempts for one request."""
         return 1 + max(0, self._config.retries)
 
-    def _sleep_between_attempts(self, attempt: int) -> None:
-        """Sleep between retry attempts using exponential backoff."""
+    def _backoff_delay(self, attempt: int) -> float:
+        """Compute exponential backoff before the next retry attempt."""
         backoff_base = self._config.backoff_base_seconds
         if backoff_base <= 0:
-            return
+            return 0.0
         cap = backoff_base * (2 ** max(0, attempt - 1))
-        sleep(uniform(0.0, cap) if self._config.backoff_jitter else cap)
+        return uniform(0.0, cap) if self._config.backoff_jitter else cap
 
     @staticmethod
     def _parse_retry_after(response: Any) -> float | None:
@@ -154,22 +154,16 @@ class SyncPolicyBase(ABC):
         except Exception:  # fail-open: treat any unparseable date as absent
             return None
 
-    def _sleep_for_retry_after(
-        self, retry_after: float | None, attempt: int
-    ) -> None:
-        """Sleep before a retry triggered by a rate-limiting HTTP response.
+    def _retry_delay(self, retry_after: float | None, attempt: int) -> float:
+        """Compute the delay for a rate-limiting HTTP response retry.
 
-        When *retry_after* is not ``None``: caps it at
-        ``max_retry_after_seconds``, then takes the longer of the capped value
-        and ``min_request_interval_seconds`` so the client's own politeness
-        policy is never violated.  Falls back to ``_sleep_between_attempts``
-        when *retry_after* is ``None``.
+        A supplied value is capped at ``max_retry_after_seconds``. An absent
+        value falls back to exponential backoff. Per-host politeness is merged
+        with this delay immediately before the next attempt.
         """
         if retry_after is not None:
-            capped = min(retry_after, self._config.max_retry_after_seconds)
-            sleep(max(capped, self._config.min_request_interval_seconds))
-        else:
-            self._sleep_between_attempts(attempt)
+            return min(retry_after, self._config.max_retry_after_seconds)
+        return self._backoff_delay(attempt)
 
     def _apply_proxy(self, proxy: Mapping[str, str] | None) -> None:
         """Update session proxy to *proxy*, clearing any previous setting."""
@@ -238,20 +232,25 @@ class SyncPolicyBase(ABC):
         No-op when ``min_request_interval_seconds`` is zero (the default)
         or when *host* is empty.
         """
+        wait = self._rate_limit_wait_seconds(host)
+        if wait > 0:
+            sleep(wait)
+
+    def _rate_limit_wait_seconds(self, host: str) -> float:
+        """Compute the remaining per-host politeness delay without sleeping."""
         if not host:
-            return
+            return 0.0
         interval = max(
             self._config.min_request_interval_seconds,
             self._crawl_delay_overrides.get(host, 0.0),
         )
         if interval <= 0:
-            return
+            return 0.0
         last = self._last_request_time.get(host)
-        if last is not None:
-            elapsed = monotonic() - last
-            remaining = interval - elapsed
-            if remaining > 0:
-                sleep(remaining)
+        if last is None:
+            return 0.0
+        elapsed = monotonic() - last
+        return max(0.0, interval - elapsed)
 
     def _build_meta(
         self,
@@ -387,11 +386,16 @@ class SyncPolicyBase(ABC):
         last_error: Exception | None = None
         last_blocked_response: Any = None
         last_blocked_retry_after: float | None = None
+        retry_delay = 0.0
         current_proxy: Mapping[str, str] | None = None
         if pool is not None:
             current_proxy = pool.next_proxy()
             self._apply_proxy(current_proxy)
         for _ in range(self._max_attempts()):
+            if attempts > 0:
+                wait = max(retry_delay, self._rate_limit_wait_seconds(host))
+                if wait > 0:
+                    sleep(wait)
             attempts += 1
             try:
                 response = request_fn()
@@ -407,7 +411,7 @@ class SyncPolicyBase(ABC):
                             pool.mark_failure(current_proxy)
                             current_proxy = pool.next_proxy()
                             self._apply_proxy(current_proxy)
-                        self._sleep_for_retry_after(
+                        retry_delay = self._retry_delay(
                             last_blocked_retry_after, attempts
                         )
                         continue
@@ -456,7 +460,7 @@ class SyncPolicyBase(ABC):
                     pool.mark_failure(current_proxy)
                     current_proxy = pool.next_proxy()
                     self._apply_proxy(current_proxy)
-                self._sleep_between_attempts(attempts)
+                retry_delay = self._backoff_delay(attempts)
             finally:
                 if host:
                     self._last_request_time[host] = monotonic()

--- a/src/ladon/networking/config.py
+++ b/src/ladon/networking/config.py
@@ -115,7 +115,7 @@ class HttpClientConfig:
     verify_tls: bool = True
     connect_timeout_seconds: float | None = None
     read_timeout_seconds: float | None = None
-    backoff_base_seconds: float = 0.0
+    backoff_base_seconds: float = 0.5
     timeout_seconds: float = 30.0
     min_request_interval_seconds: float = 0.0
     # Threshold counts *call sequences*, not individual HTTP attempts.
@@ -161,6 +161,13 @@ class HttpClientConfig:
             raise ValueError("retries must be >= 0")
         if self.backoff_base_seconds < 0:
             raise ValueError("backoff_base_seconds must be >= 0")
+        if self.backoff_base_seconds == 0.0 and self.retries > 0:
+            warnings.warn(
+                "backoff_base_seconds=0.0 disables retry pacing and is an "
+                "explicit opt-out",
+                UserWarning,
+                stacklevel=3,
+            )
         if self.min_request_interval_seconds < 0:
             raise ValueError("min_request_interval_seconds must be >= 0")
         if (

--- a/tests/test_async_policy_concurrency.py
+++ b/tests/test_async_policy_concurrency.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from time import monotonic
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -232,6 +233,46 @@ async def test_same_host_concurrent_requests_reserve_spaced_slots() -> None:
         later - earlier >= interval * 0.8
         for earlier, later in zip(starts, starts[1:], strict=False)
     )
+
+
+async def test_retry_merges_crawl_delay_into_one_locked_sleep() -> None:
+    responses = iter(
+        [
+            _Response(
+                "https://retry.example/item",
+                status_code=429,
+                headers={"Retry-After": "5"},
+            ),
+            _Response("https://retry.example/item"),
+        ]
+    )
+
+    async def attempt(url: str) -> _Response:
+        return next(responses)
+
+    client = _PolicyClient(
+        HttpClientConfig(
+            retries=1,
+            min_request_interval_seconds=1.0,
+        ),
+        attempt,
+    )
+    client.set_crawl_delay("retry.example", 10.0)
+
+    with (
+        patch(
+            "ladon.networking._async_policy_base.monotonic",
+            side_effect=[90.0, 100.0, 100.0, 110.0, 110.0],
+        ),
+        patch(
+            "ladon.networking._async_policy_base.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as mock_sleep,
+    ):
+        result = await client.get("https://retry.example/item")
+
+    assert result.ok
+    mock_sleep.assert_awaited_once_with(10.0)
 
 
 async def test_different_hosts_do_not_share_a_rate_limit_lock() -> None:

--- a/tests/test_backoff_jitter.py
+++ b/tests/test_backoff_jitter.py
@@ -4,6 +4,7 @@
 
 from unittest.mock import Mock, call, patch
 
+import pytest
 import requests
 
 from ladon.networking.client import HttpClient
@@ -64,9 +65,10 @@ class TestJitterDisabled:
     def test_zero_base_no_sleep_no_uniform(
         self, mock_get, mock_uniform, mock_sleep
     ):
-        config = HttpClientConfig(
-            timeout_seconds=5.0, retries=1, backoff_base_seconds=0.0
-        )
+        with pytest.warns(UserWarning, match="explicit opt-out"):
+            config = HttpClientConfig(
+                timeout_seconds=5.0, retries=1, backoff_base_seconds=0.0
+            )
         client = HttpClient(config)
         mock_get.side_effect = requests.exceptions.Timeout("t/o")
 
@@ -132,12 +134,13 @@ class TestJitterEnabled:
     @patch("ladon.networking._sync_policy_base.uniform")
     @patch("requests.Session.get")
     def test_jitter_zero_base_is_noop(self, mock_get, mock_uniform, mock_sleep):
-        config = HttpClientConfig(
-            timeout_seconds=5.0,
-            retries=1,
-            backoff_base_seconds=0.0,
-            backoff_jitter=True,
-        )
+        with pytest.warns(UserWarning, match="explicit opt-out"):
+            config = HttpClientConfig(
+                timeout_seconds=5.0,
+                retries=1,
+                backoff_base_seconds=0.0,
+                backoff_jitter=True,
+            )
         client = HttpClient(config)
         mock_get.side_effect = requests.exceptions.Timeout("t/o")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,6 @@
 # pyright: reportUnknownMemberType=false
+import warnings
+
 import pytest
 
 from ladon.networking.config import HttpClientConfig
@@ -13,7 +15,7 @@ def test_config_defaults_are_stable():
     assert config.verify_tls is True
     assert config.connect_timeout_seconds is None
     assert config.read_timeout_seconds is None
-    assert config.backoff_base_seconds == 0.0
+    assert config.backoff_base_seconds == 0.5
     assert config.timeout_seconds == 30.0
     assert config.min_request_interval_seconds == 0.0
     assert config.circuit_breaker_failure_threshold is None
@@ -68,6 +70,17 @@ def test_config_rejects_negative_retries():
 def test_config_rejects_negative_backoff():
     with pytest.raises(ValueError):
         HttpClientConfig(backoff_base_seconds=-0.1)
+
+
+def test_config_zero_backoff_with_retries_warns():
+    with pytest.warns(UserWarning, match="explicit opt-out"):
+        HttpClientConfig(retries=1, backoff_base_seconds=0.0)
+
+
+def test_config_zero_backoff_without_retries_does_not_warn():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        HttpClientConfig(retries=0, backoff_base_seconds=0.0)
 
 
 def test_config_rejects_non_positive_timeouts():

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -197,6 +197,22 @@ class TestRetryAfterBehavior:
 
     @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")
+    def test_get_429_no_retry_after_uses_safe_default_backoff(
+        self, mock_get, mock_sleep
+    ):
+        client = HttpClient(HttpClientConfig(timeout_seconds=5.0, retries=1))
+        mock_get.side_effect = [
+            _mock_response(status=429),
+            _mock_response(status=200, content=b"ok"),
+        ]
+
+        result = client.get("http://example.com")
+
+        assert result.ok
+        mock_sleep.assert_called_once_with(0.5)
+
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("requests.Session.get")
     def test_get_429_exhausts_retries_returns_rate_limited_error(
         self, mock_get, mock_sleep
     ):
@@ -316,9 +332,10 @@ class TestRetryAfterBehavior:
         assert result.meta["method"] == "GET"
 
     @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
     @patch("requests.Session.get")
     def test_retry_after_below_min_interval_sleeps_min_interval(
-        self, mock_get, mock_sleep
+        self, mock_get, mock_monotonic, mock_sleep
     ):
         # Retry-After (5s) < min_request_interval (60s): politeness floor wins.
         config = HttpClientConfig(
@@ -331,11 +348,37 @@ class TestRetryAfterBehavior:
             _mock_response(status=429, headers={"Retry-After": "5"}),
             _mock_response(status=200, content=b"ok"),
         ]
+        mock_monotonic.side_effect = [100.0, 100.0, 160.0]
 
         result = client.get("http://example.com")
 
         assert result.ok
         mock_sleep.assert_called_once_with(60.0)
+
+    @patch("ladon.networking._sync_policy_base.sleep")
+    @patch("ladon.networking._sync_policy_base.monotonic")
+    @patch("requests.Session.get")
+    def test_retry_merges_crawl_delay_into_one_sleep(
+        self, mock_get, mock_monotonic, mock_sleep
+    ):
+        client = HttpClient(
+            HttpClientConfig(
+                timeout_seconds=5.0,
+                retries=1,
+                min_request_interval_seconds=1.0,
+            )
+        )
+        client.set_crawl_delay("example.com", 10.0)
+        mock_get.side_effect = [
+            _mock_response(status=429, headers={"Retry-After": "5"}),
+            _mock_response(status=200, content=b"ok"),
+        ]
+        mock_monotonic.side_effect = [100.0, 100.0, 110.0]
+
+        result = client.get("http://example.com")
+
+        assert result.ok
+        mock_sleep.assert_called_once_with(10.0)
 
     @patch("ladon.networking._sync_policy_base.sleep")
     @patch("requests.Session.get")


### PR DESCRIPTION
## Summary

- `backoff_base_seconds` defaulted to `0.0`, so a retryable response with no `Retry-After` header fell through to exponential backoff and slept for zero seconds — an unpaced retry storm against a host that just asked to be throttled. The per-host politeness interval didn't save it either: `_enforce_rate_limit` ran once before the retry loop started, so retries inside that loop never rechecked `min_request_interval_seconds` or a robots.txt `Crawl-delay` override.
- Default `backoff_base_seconds` is now `0.5s`; explicit `backoff_base_seconds=0.0` with retries enabled still works but now warns, since silently disabling retry pacing is easy to do by accident via a stale config default.
- Every attempt after the first now merges the retry/backoff delay with a freshly computed per-host rate-limit wait (max of the two, one sleep), so a retry can never be faster than the client's own politeness policy, including crawl-delay overrides. The async side merges this wait inside the existing per-host `asyncio.Lock` from #160 rather than as a lockless peek, since a lockless check would let concurrent retries against the same host race past the lock's staggering guarantee.

Fixes #167

## Test plan

- [x] `pytest tests/` — 769 passed
- [x] `pyright` — 0 errors, 0 warnings
- [x] `pre-commit run --all-files` — all hooks passed
- [x] New regression coverage: safe-default backoff on 429 without `Retry-After`, explicit-zero-with-retries warning (and no warning when `retries=0`), retry-floor now reflects crawl-delay overrides (not just the static config field), sync/async parity on the merged-wait-single-sleep behavior

https://claude.ai/code/session_01FMqLunsgCtArSyVMioDDmf