### PR TITLE
fix(resolution): narrow multi-source error handling and evaluate predicates once

### DIFF
--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -12,7 +12,10 @@ The loop pattern
     for source in sources (ordered best-first):
         if not _should_try_source(source, ref):   # tier-skip, guards
             continue
-        data = _fetch_from_source(source, ref, client)
+        try:
+            data = _fetch_from_source(source, ref, client)
+        except recoverable source error:
+            continue                              # unexpected errors propagate
         if not data:
             continue                               # source returned nothing / empty bytes
         if _is_better_candidate(data, ...):        # update best-seen fallback
@@ -36,7 +39,9 @@ from datetime import datetime, timezone
 from typing import Any, Protocol, Sequence, runtime_checkable
 
 from ..networking.client import HttpClient
+from ..networking.errors import HttpClientError
 from ..observability import DecisionEvent, DecisionTracker, NullDecisionTracker
+from .errors import LeafUnavailableError
 from .models import Ref
 
 logger = logging.getLogger(__name__)
@@ -97,6 +102,12 @@ class MultiSourceSink:
         Fallback selection. Default: first non-empty result wins. Override for
         domain-specific ranking (e.g., prefer wider images when multiple
         below-threshold results exist).
+
+    ``_all_predicates_pass(data, ref) → bool``
+        Acceptance customization when at least one predicate is registered.
+        Default: all registered predicates must accept. Override to add
+        criteria beyond the registered predicates. The predicate-free fast
+        path accepts the first non-empty result without calling this hook.
 
     ``_fetch_from_source(source, ref, client) → bytes | None``
         Calls the source's native interface. Must be overridden; there is no
@@ -177,9 +188,24 @@ class MultiSourceSink:
     # Loop
     # ------------------------------------------------------------------
 
+    def _first_failing_predicate(
+        self, data: bytes, ref: Ref
+    ) -> FetchPredicate | None:
+        """Return the first registered predicate that rejects *data*, evaluating
+        each predicate at most once. Returns None if every predicate accepts
+        (or none are registered)."""
+        for p in self._ms_predicates:
+            if not p.accepts(data, ref):
+                return p
+        return None
+
     def _all_predicates_pass(self, data: bytes, ref: Ref) -> bool:
-        """Return True if *data* satisfies every registered predicate."""
-        return all(p.accepts(data, ref) for p in self._ms_predicates)
+        """Return True if *data* satisfies every registered predicate.
+
+        Override to add acceptance criteria beyond registered predicates.
+        This hook is not called when no predicates are registered.
+        """
+        return self._first_failing_predicate(data, ref) is None
 
     def resolve_multi(
         self, ref: Ref, client: HttpClient, *, run_id: str = ""
@@ -195,13 +221,12 @@ class MultiSourceSink:
         correlation; omit it to get a fresh UUID scoped to this resolution.
 
         .. note::
-            Exceptions raised by :meth:`_fetch_from_source` (other than
-            :exc:`NotImplementedError`) are caught, recorded as a
-            ``source_failed`` event, and the loop continues to the next
-            source. :exc:`NotImplementedError` is re-raised immediately so
-            the "subclass must override" contract is preserved. This differs
-            from the pre-tracker behaviour, where all exceptions propagated
-            to the caller.
+            :class:`~ladon.networking.errors.HttpClientError` and
+            :class:`~ladon.plugins.errors.LeafUnavailableError` raised by
+            :meth:`_fetch_from_source` are recorded as ``source_failed`` and
+            the loop continues to the next source. Other exceptions propagate;
+            :exc:`NotImplementedError` is re-raised immediately so the
+            "subclass must override" contract is preserved.
         """
         _run_id = run_id or str(uuid.uuid4())
         best_data: bytes | None = None
@@ -232,7 +257,7 @@ class MultiSourceSink:
                 data = self._fetch_from_source(source, ref, client)
             except NotImplementedError:
                 raise
-            except Exception as exc:
+            except (HttpClientError, LeafUnavailableError) as exc:
                 self._tracker.record(
                     DecisionEvent(
                         run_id=_run_id,
@@ -299,7 +324,32 @@ class MultiSourceSink:
                     )
                 )
 
-            if not self._ms_predicates or self._all_predicates_pass(data, ref):
+            if not self._ms_predicates:
+                accepted, failing = True, None
+            else:
+                predicate_check = self._all_predicates_pass
+                if (
+                    getattr(predicate_check, "__func__", None)
+                    is MultiSourceSink._all_predicates_pass
+                ):
+                    # Default path: one evaluation pass serves both the accept
+                    # decision and (on rejection) the failing predicate's identity
+                    # for metadata.
+                    failing = self._first_failing_predicate(data, ref)
+                    accepted = failing is None
+                else:
+                    # A dynamically resolved _all_predicates_pass override has
+                    # logic we can't introspect; call it for the decision. Only
+                    # re-scan registered predicates (a second, unavoidable pass)
+                    # to attribute the rejection if it rejects.
+                    accepted = predicate_check(data, ref)
+                    failing = (
+                        None
+                        if accepted
+                        else self._first_failing_predicate(data, ref)
+                    )
+
+            if accepted:
                 self._tracker.record(
                     DecisionEvent(
                         run_id=_run_id,
@@ -318,13 +368,8 @@ class MultiSourceSink:
                 )
                 return data, source
 
-            # Find the first registered predicate that rejects the data.
-            # If none is found (failing is None), the rejection came from a
+            # If failing is None, the rejection came from an
             # _all_predicates_pass override rather than a registered predicate.
-            failing = next(
-                (p for p in self._ms_predicates if not p.accepts(data, ref)),
-                None,
-            )
             predicate_name = (
                 type(failing).__name__
                 if failing is not None

--- a/tests/plugins/test_resolution.py
+++ b/tests/plugins/test_resolution.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from ladon.plugins.errors import AssetDownloadError
 from ladon.plugins.models import Ref
 from ladon.plugins.resolution import (
     FetchPredicate,
@@ -167,6 +168,37 @@ class TestMultiSourceSinkLoop:
         assert src is None
         assert s.calls == 0
 
+    @pytest.mark.parametrize("error_type", [AttributeError, TypeError])
+    def test_programmer_error_from_fetch_propagates(
+        self, error_type: type[Exception]
+    ) -> None:
+        class _BrokenSink(_SimpleSink):
+            def _fetch_from_source(
+                self,
+                source: _SimpleSource,
+                ref: Ref,
+                client: object,  # noqa: ARG002
+            ) -> bytes | None:
+                raise error_type("broken override")
+
+        sink = _BrokenSink(sources=[_SimpleSource("a", b"DATA")])
+        with pytest.raises(error_type, match="broken override"):
+            sink.resolve_multi(_ref(), MagicMock())
+
+    def test_asset_download_error_from_fetch_propagates(self) -> None:
+        class _BrokenSink(_SimpleSink):
+            def _fetch_from_source(
+                self,
+                source: _SimpleSource,
+                ref: Ref,
+                client: object,  # noqa: ARG002
+            ) -> bytes | None:
+                raise AssetDownloadError("fatal download failure")
+
+        sink = _BrokenSink(sources=[_SimpleSource("a", b"DATA")])
+        with pytest.raises(AssetDownloadError, match="fatal download failure"):
+            sink.resolve_multi(_ref(), MagicMock())
+
 
 # ---------------------------------------------------------------------------
 # MultiSourceSink — predicate integration
@@ -237,6 +269,23 @@ class TestMultiSourceSinkPredicates:
         _, src = sink.resolve_multi(_ref(), MagicMock())
         assert src is s1
         assert s2.calls == 0
+
+    def test_rejecting_predicate_is_called_once_per_source(self) -> None:
+        class _CountingPredicate:
+            def __init__(self) -> None:
+                self.call_count = 0
+
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                self.call_count += 1
+                return False
+
+        predicate = _CountingPredicate()
+        sink = _SimpleSink(
+            sources=[_SimpleSource("a", b"DATA")],
+            predicates=[predicate],
+        )
+        sink.resolve_multi(_ref(), MagicMock())
+        assert predicate.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_resolution_tracker.py
+++ b/tests/plugins/test_resolution_tracker.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
+from ladon.networking.errors import TransientNetworkError
 from ladon.observability import DecisionEvent
+from ladon.plugins.errors import LeafUnavailableError
 from ladon.plugins.models import Ref
 from ladon.plugins.resolution import MultiSourceSink
 
@@ -126,7 +128,7 @@ class TestSourceFailedEvent:
                 ref: Ref,
                 client: object,  # noqa: ARG002
             ) -> bytes | None:
-                raise ValueError("network error")
+                raise TransientNetworkError("network error")
 
         tracker = _CapturingTracker()
         sink = _FailingSink(
@@ -138,7 +140,7 @@ class TestSourceFailedEvent:
         failed = tracker.by_event("source_failed")
         assert len(failed) == 1
         assert failed[0].source == "bad_source"
-        assert failed[0].metadata["exception_type"] == "ValueError"
+        assert failed[0].metadata["exception_type"] == "TransientNetworkError"
 
     def test_source_failed_continues_to_next_source(self) -> None:
         class _PartialFailSink(_SimpleSink):
@@ -149,7 +151,7 @@ class TestSourceFailedEvent:
                 client: object,  # noqa: ARG002
             ) -> bytes | None:
                 if source.name == "fail":
-                    raise RuntimeError("oops")
+                    raise TransientNetworkError("oops")
                 return source.fetch()
 
         tracker = _CapturingTracker()
@@ -164,6 +166,35 @@ class TestSourceFailedEvent:
         assert data == b"GOOD"
         assert src.name == "ok"  # type: ignore[union-attr]
         assert "source_failed" in tracker.event_names()
+
+    def test_leaf_unavailable_continues_to_next_source(self) -> None:
+        class _PartialFailSink(_SimpleSink):
+            def _fetch_from_source(
+                self,
+                source: _SimpleSource,
+                ref: Ref,
+                client: object,  # noqa: ARG002
+            ) -> bytes | None:
+                if source.name == "fail":
+                    raise LeafUnavailableError("leaf unavailable")
+                return source.fetch()
+
+        tracker = _CapturingTracker()
+        sink = _PartialFailSink(
+            sources=[
+                _SimpleSource("fail", b"irrelevant"),
+                _SimpleSource("ok", b"GOOD"),
+            ],
+            tracker=tracker,
+        )
+        data, src = sink.resolve_multi(_ref(), MagicMock())
+
+        assert data == b"GOOD"
+        assert src.name == "ok"  # type: ignore[union-attr]
+        failed = tracker.by_event("source_failed")
+        assert len(failed) == 1
+        assert failed[0].source == "fail"
+        assert failed[0].metadata["exception_type"] == "LeafUnavailableError"
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +300,32 @@ class TestPredicateRejectedEvent:
             tracker=tracker,
         )
         sink.resolve_multi(_ref(), MagicMock())
+        ev = tracker.by_event("predicate_rejected")[0]
+        assert ev.metadata["predicate_name"] == "<subclass-override>"
+
+    def test_predicate_name_honors_dynamically_dispatched_override(
+        self,
+    ) -> None:
+        """Instance dispatch of the existing override hook remains supported."""
+
+        class _DynamicOverrideSink(_SimpleSink):
+            def __getattribute__(self, name: str) -> Any:
+                if name == "_all_predicates_pass":
+
+                    def _reject(data: bytes, ref: Ref) -> bool:  # noqa: ARG001
+                        return False
+
+                    return _reject
+                return super().__getattribute__(name)
+
+        tracker = _CapturingTracker()
+        sink = _DynamicOverrideSink(
+            sources=[_SimpleSource("a", b"DATA")],
+            predicates=[_MinLengthPredicate(1)],
+            tracker=tracker,
+        )
+        sink.resolve_multi(_ref(), MagicMock())
+
         ev = tracker.by_event("predicate_rejected")[0]
         assert ev.metadata["predicate_name"] == "<subclass-override>"
 
@@ -411,6 +468,39 @@ class TestNullTrackerDefault:
 
 
 class TestRejectionInfoMetadata:
+    def test_only_rejecting_predicate_diagnostics_run_once(self) -> None:
+        class _DiagnosticPredicate:
+            def __init__(self, accepted: bool) -> None:
+                self.accepted = accepted
+                self.accepts_calls = 0
+                self.rejection_info_calls = 0
+
+            def accepts(self, data: bytes, ref: Ref) -> bool:  # noqa: ARG002
+                self.accepts_calls += 1
+                return self.accepted
+
+            def rejection_info(self) -> dict[str, Any]:
+                self.rejection_info_calls += 1
+                return {"detail": "rejected"}
+
+        passing = _DiagnosticPredicate(accepted=True)
+        rejecting = _DiagnosticPredicate(accepted=False)
+        tracker = _CapturingTracker()
+        sink = _SimpleSink(
+            sources=[_SimpleSource("a", b"DATA")],
+            predicates=[passing, rejecting],
+            tracker=tracker,
+        )
+        sink.resolve_multi(_ref(), MagicMock())
+
+        assert passing.accepts_calls == 1
+        assert passing.rejection_info_calls == 0
+        assert rejecting.accepts_calls == 1
+        assert rejecting.rejection_info_calls == 1
+        ev = tracker.by_event("predicate_rejected")[0]
+        assert ev.metadata["predicate_name"] == "_DiagnosticPredicate"
+        assert ev.metadata["detail"] == "rejected"
+
     def test_rejection_info_merged_into_predicate_rejected_metadata(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- `resolve_multi`'s per-source `try` block caught bare `Exception` (everything except `NotImplementedError`), so a subclass bug in `_fetch_from_source` — an `AttributeError` from a typo, a `TypeError` from a bad override — was silently swallowed and reported as a routine `source_failed` event, identical to a legitimate network hiccup. The catch is now `HttpClientError | LeafUnavailableError` only: `LeafUnavailableError` is already documented and treated elsewhere (`runner.py`, `async_runner.py`) as leaf-scoped and non-fatal, while `AssetDownloadError` is explicitly documented as never recovered from and must propagate — catching it here would have silently downgraded a documented-fatal error into a routine fallback attempt. Everything else (programmer bugs) now propagates uncaught.
- `_all_predicates_pass()`'s `all()` short-circuited at the first failing predicate, then a second `next()` scan re-evaluated the same predicates again to identify which one failed for event metadata — a stateful or expensive predicate (image analysis, invocation counters) ran twice per rejection instead of once. `_first_failing_predicate()` now does that scan exactly once; the default `_all_predicates_pass` delegates to it.
- The existing `_all_predicates_pass` override hook still works for subclasses that customize acceptance beyond registered predicates. Override detection resolves `self._all_predicates_pass` through the instance rather than comparing `type(self)._all_predicates_pass` against the base class, since a class-level comparison misses a subclass producing the override dynamically (e.g. via `__getattribute__`, a mixin, or an instance attribute) — a real edge case found and fixed during review, with a regression test.

Fixes #169

## Test plan

- [x] `pytest tests/` — 776 passed
- [x] `pyright` — 0 errors, 0 warnings
- [x] `pre-commit run --all-files` — all hooks passed
- [x] New regression coverage: `AttributeError`/`TypeError`/`AssetDownloadError` propagate uncaught, `LeafUnavailableError` is caught and continues to the next source, a rejecting predicate is called exactly once per source (direct regression test for the double-evaluation bug), `rejection_info()` invoked once and only for the actually-rejecting predicate, the existing `_all_predicates_pass` override still works — plus a new test for the dynamic-dispatch override-detection edge case found during the review loop

https://claude.ai/code/session_01FMqLunsgCtArSyVMioDDmf