### PR TITLE
fix(typing): add backend-agnostic HTTP client protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`SyncHttpClientProtocol` / `AsyncHttpClientProtocol`** — public structural
+  HTTP client contracts implemented by both native and curl-cffi backends.
 - **`run_plugin()` / `async_run_plugin()`** — source-driven whole-plugin
   entry points. They discover roots once, preserve one `RunResult` per root,
   and return aggregate counts and source-indexed errors in `PluginRunResult`.
@@ -20,6 +22,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Backend-agnostic adapter and runner typing** — `Source`, `Expander`,
+  `Sink`, their async counterparts, and runner signatures now accept either
+  native or curl-cffi factory results under strict type checking.
 - **Polite retry pacing** — retries now enforce per-host rate limits, including
   robots.txt `Crawl-delay` overrides, on every attempt and merge that wait with
   Retry-After or backoff into one sleep. The default backoff is now a safe

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -30,7 +30,8 @@ root processing ordered, while each root's leaf work uses `async_concurrency`.
 ## Async protocols
 
 The async protocols mirror the sync ones exactly but use `async def`
-methods and accept `AsyncHttpClient` instead of `HttpClient`.
+methods and accept `AsyncHttpClientProtocol` instead of
+`SyncHttpClientProtocol`.
 
 ::: ladon.plugins.async_protocol
 

--- a/docs/decisions/adr-003-plugin-adapter-interface.md
+++ b/docs/decisions/adr-003-plugin-adapter-interface.md
@@ -8,6 +8,10 @@ decision-makers:
 
 # ADR-003 — Plugin / Adapter Interface
 
+> **Historical note:** ADR-014 supersedes the concrete `HttpClient`
+> annotations shown in this record. Current sync adapter and runner boundaries
+> use `SyncHttpClientProtocol`.
+
 ## Context and Problem Statement
 
 Ladon's networking core (`HttpClient`) is implemented and stable. The next

--- a/docs/decisions/adr-004-ses-protocol-design.md
+++ b/docs/decisions/adr-004-ses-protocol-design.md
@@ -8,6 +8,10 @@ decision-makers:
 
 # ADR-004 — Source / Expander / Sink Protocol Design
 
+> **Historical note:** ADR-014 supersedes the concrete `HttpClient`
+> annotations shown in this record. Current sync adapter and runner boundaries
+> use `SyncHttpClientProtocol`.
+
 ## Context and Problem Statement
 
 Ladon is a generic crawling framework. Its networking core (`HttpClient`,

--- a/docs/decisions/adr-014-http-client-protocols.md
+++ b/docs/decisions/adr-014-http-client-protocols.md
@@ -1,0 +1,84 @@
+---
+status: accepted
+date: 2026-08-12
+decision-makers: [Maintainers]
+informed: [Contributors]
+refs: [ADR-004, ADR-011, ADR-012, Issue #161]
+---
+
+# ADR-014 — Structural HTTP Client Protocols
+
+## Context and Problem Statement
+
+`make_http_client()` returns `HttpClient | CurlHttpClient`, and
+`make_async_http_client()` returns `AsyncHttpClient | AsyncCurlHttpClient`.
+The plugin adapter protocols and runners previously accepted only the native
+concrete class. Runtime backend substitution worked because each backend has
+the same request-policy surface, but strict Pyright rejected passing a factory
+result to those APIs.
+
+This is the public-facing analogue of ADR-012's private session boundary. The
+client contract must express the capabilities adapters and runners need without
+coupling them to one transport implementation.
+
+## Decision Drivers
+
+* Adapters and runners must accept either backend without strict-Pyright errors.
+* The fix must preserve all four shipped concrete classes and their different
+  constructors.
+* The public contract should include only capabilities needed by adapters.
+* The design should follow Ladon's existing structural `Source`, `Expander`,
+  `Sink`, and `FetchPredicate` protocol pattern.
+
+## Considered Options
+
+* **A — Backend-agnostic structural protocols (chosen)**
+* **B — Retrofit a shared abstract base class across all four clients**
+* **C — Type every consumer against the concrete backend unions**
+
+## Decision Outcome
+
+**Chosen: Option A — backend-agnostic structural protocols.**
+
+Ladon exposes `SyncHttpClientProtocol` and `AsyncHttpClientProtocol` as
+runtime-checkable structural contracts. Both native and curl-cffi clients
+satisfy the corresponding protocol without inheritance. Their surface is
+limited to `get`, `head`, `post`, `download`, close (`close` or `aclose`), and
+sync or async context-manager behavior.
+
+The explicit `Protocol` suffix and symmetric names avoid colliding with the
+already-public concrete `AsyncHttpClient` class.
+
+`download()` returns `Result[Any, Exception]` in both protocols. Native sync
+and async backends return response types from `requests` and `httpx`, while
+curl-cffi has its own response type and currently exposes it as `Any`. There is
+no meaningful common response base class, so narrowing this return would make
+one or more existing backends fail the contract.
+
+Methods such as `circuit_state()` and `set_crawl_delay()` are deliberately
+excluded. They are policy implementation capabilities, not part of the minimal
+adapter-facing HTTP contract.
+
+### Consequences
+
+* **Good**: Factory results can be passed directly to adapters and runners
+  under strict Pyright.
+* **Good**: Third-party clients can conform structurally without inheriting
+  from Ladon internals.
+* **Good**: Concrete classes remain available for construction and
+  backend-specific configuration.
+* **Neutral**: `download()` consumers receive an `Any` response value and must
+  handle backend-specific response behavior themselves.
+* **Bad**: Runtime protocol checks verify member presence only; strict static
+  checking remains responsible for signature compatibility.
+
+## Rejected Options
+
+**B — Shared abstract base class:** More invasive than structural typing. It
+would retrofit inheritance across four shipped classes with different
+constructors and conflict with the protocol-based extension pattern already
+used for Ladon's plugin boundaries.
+
+**C — Concrete unions at every boundary:** This would fix today's two
+backends, but duplicate transport knowledge across public signatures and
+require every consumer annotation to change whenever another backend is added.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -19,6 +19,7 @@ chosen over the alternatives.
 | [ADR-010](adr-010-dual-license-model.md) | Dual-License Model (AGPL-3.0-only + Commercial) | Accepted |
 | [ADR-011](adr-011-curl-cffi-cloudflare-bypass.md) | curl-cffi as the Cloudflare-Bypass HTTP Backend | Accepted |
 | [ADR-012](adr-012-session-contract-boundary.md) | Session Contract Boundary in `SyncPolicyBase` | Accepted |
+| [ADR-014](adr-014-http-client-protocols.md) | Structural HTTP Client Protocols | Accepted |
 
 ## Format
 

--- a/docs/guides/authoring-plugins.md
+++ b/docs/guides/authoring-plugins.md
@@ -32,8 +32,10 @@ attributes set in `__init__` satisfy the protocol at runtime, so the common
 pattern is:
 
 ```python
+from ladon import SyncHttpClientProtocol
+
 class MyPlugin:
-    def __init__(self, client: HttpClient) -> None:
+    def __init__(self, client: SyncHttpClientProtocol) -> None:
         self.name = "my_plugin"
         self.source = MySource()
         self.expanders = [MyExpander()]
@@ -51,10 +53,13 @@ An `Expander` turns one ref into an `Expansion` — the current node's record
 plus the child refs to process next (e.g. catalog record + product URLs):
 
 ```python
+from ladon import SyncHttpClientProtocol
 from ladon.plugins.models import Expansion
 
 class MyExpander:
-    def expand(self, ref: object, client: HttpClient) -> Expansion:
+    def expand(
+        self, ref: object, client: SyncHttpClientProtocol
+    ) -> Expansion:
         """Fetch ref; return its record and child refs.
 
         Raises:
@@ -78,8 +83,12 @@ Expansion exception handling depends on where the failure occurs:
 A `Sink` processes each leaf ref (e.g. downloads a product page):
 
 ```python
+from ladon import SyncHttpClientProtocol
+
 class MySink:
-    def consume(self, ref: object, client: HttpClient) -> object:
+    def consume(
+        self, ref: object, client: SyncHttpClientProtocol
+    ) -> object:
         """Fetch and process the leaf; return a record for on_leaf callback."""
         ...
 ```
@@ -98,10 +107,10 @@ Expansion exceptions also retain their typed contract when raised by a Sink:
 Combine expanders and sink into a plugin:
 
 ```python
-from ladon.networking.client import HttpClient
+from ladon import SyncHttpClientProtocol
 
 class ShopPlugin:
-    def __init__(self, client: HttpClient) -> None:
+    def __init__(self, client: SyncHttpClientProtocol) -> None:
         self.name = "shop_example"
         self.source = CatalogSource()
         self.expanders = [CategoryExpander(), ProductExpander()]
@@ -152,11 +161,11 @@ callback). For production use write a Python script that usually calls
 
 For high-concurrency crawls implement `AsyncCrawlPlugin` and call
 `async_run_plugin()` instead. The async protocols mirror the sync ones with
-`async def` methods and `AsyncHttpClient` as the client parameter.
+`async def` methods and `AsyncHttpClientProtocol` as the client parameter.
 
 ```python
+from ladon import AsyncHttpClientProtocol
 from ladon.plugins.async_protocol import AsyncCrawlPlugin, AsyncExpander, AsyncSink, AsyncSource
-from ladon.networking.async_client import AsyncHttpClient
 
 class AsyncShopPlugin:
     def __init__(self) -> None:
@@ -167,7 +176,9 @@ class AsyncShopPlugin:
 
 
 class AsyncProductSink:
-    async def consume(self, ref: object, client: AsyncHttpClient) -> object:
+    async def consume(
+        self, ref: object, client: AsyncHttpClientProtocol
+    ) -> object:
         result = await client.get(str(ref))
         if not result.ok:
             from ladon.plugins.errors import LeafUnavailableError

--- a/docs/guides/cookbook.md
+++ b/docs/guides/cookbook.md
@@ -73,8 +73,9 @@ and explicitly fatal `AssetDownloadError` still propagate.
 ## Async leaf processing for high throughput
 
 Implement the async protocols (`async def expand` and `async def consume`) and
-pass an `AsyncHttpClient`. Expanders are awaited in tree order; leaf
-`consume()` calls run concurrently up to `async_concurrency`.
+pass an `AsyncHttpClientProtocol` implementation. Expanders are awaited in
+tree order; leaf `consume()` calls run concurrently up to
+`async_concurrency`.
 
 ```python
 --8<-- "examples/cookbook/async_crawl.py:example"

--- a/examples/cookbook/async_crawl.py
+++ b/examples/cookbook/async_crawl.py
@@ -12,6 +12,7 @@ from typing import cast
 from ladon import (
     AsyncCrawlPlugin,
     AsyncHttpClient,
+    AsyncHttpClientProtocol,
     Expansion,
     HttpClientConfig,
     LeafUnavailableError,
@@ -55,7 +56,9 @@ def build_mock_server() -> tuple[ThreadingHTTPServer, Thread]:
 
 
 class ListingExpander:
-    async def expand(self, ref: Ref, client: AsyncHttpClient) -> Expansion:
+    async def expand(
+        self, ref: Ref, client: AsyncHttpClientProtocol
+    ) -> Expansion:
         response = await client.get(ref.url)
         if not response.ok or response.value is None:
             raise LeafUnavailableError(f"listing failed: {response.error}")
@@ -68,7 +71,7 @@ class ListingExpander:
 
 class ItemSink:
     async def consume(
-        self, ref: Ref, client: AsyncHttpClient
+        self, ref: Ref, client: AsyncHttpClientProtocol
     ) -> dict[str, object]:
         response = await client.get(ref.url)
         if not response.ok or response.value is None:
@@ -77,7 +80,7 @@ class ItemSink:
 
 
 class LocalSource:
-    async def discover(self, client: AsyncHttpClient) -> Sequence[Ref]:
+    async def discover(self, client: AsyncHttpClientProtocol) -> Sequence[Ref]:
         return ()
 
 

--- a/examples/cookbook/flat_crawl.py
+++ b/examples/cookbook/flat_crawl.py
@@ -16,12 +16,13 @@ from ladon import (
     PluginRunResult,
     Ref,
     RunConfig,
+    SyncHttpClientProtocol,
     run_plugin,
 )
 
 
 class GitHubIssuesSource:
-    def discover(self, client: HttpClient) -> Sequence[Ref]:
+    def discover(self, client: SyncHttpClientProtocol) -> Sequence[Ref]:
         return [
             Ref(
                 "https://api.github.com/repos/psf/requests/issues?per_page=5"
@@ -33,7 +34,7 @@ class GitHubIssuesSource:
 
 
 class IssueList:
-    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+    def expand(self, ref: Ref, client: SyncHttpClientProtocol) -> Expansion:
         response = client.get(ref.url)
         if not response.ok or response.value is None:
             raise ChildListUnavailableError(f"listing failed: {response.error}")
@@ -44,7 +45,9 @@ class IssueList:
 
 
 class IssueSink:
-    def consume(self, ref: Ref, client: HttpClient) -> dict[str, object]:
+    def consume(
+        self, ref: Ref, client: SyncHttpClientProtocol
+    ) -> dict[str, object]:
         response = client.get(ref.url)
         if not response.ok or response.value is None:
             raise LeafUnavailableError(f"issue failed: {response.error}")

--- a/examples/cookbook/ref_raw_context.py
+++ b/examples/cookbook/ref_raw_context.py
@@ -18,6 +18,7 @@ from ladon import (
     Ref,
     RunConfig,
     RunResult,
+    SyncHttpClientProtocol,
     run_crawl,
 )
 
@@ -61,7 +62,7 @@ def build_mock_server() -> tuple[ThreadingHTTPServer, Thread]:
 
 
 class ProductList:
-    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+    def expand(self, ref: Ref, client: SyncHttpClientProtocol) -> Expansion:
         response = client.get(ref.url)
         if not response.ok or response.value is None:
             raise ChildListUnavailableError(f"listing failed: {response.error}")
@@ -77,14 +78,16 @@ class ProductList:
 
 
 class ProductSink:
-    def consume(self, ref: Ref, client: HttpClient) -> dict[str, object]:
+    def consume(
+        self, ref: Ref, client: SyncHttpClientProtocol
+    ) -> dict[str, object]:
         if "sku" not in ref.raw:
             raise LeafUnavailableError("listing did not provide a SKU")
         return {"sku": ref.raw["sku"], "price": ref.raw["price"]}
 
 
 class ProductSource:
-    def discover(self, client: HttpClient) -> Sequence[Ref]:
+    def discover(self, client: SyncHttpClientProtocol) -> Sequence[Ref]:
         return ()
 
 

--- a/examples/cookbook/resume_partial_crawl.py
+++ b/examples/cookbook/resume_partial_crawl.py
@@ -21,6 +21,7 @@ from ladon import (
     Ref,
     RunConfig,
     RunResult,
+    SyncHttpClientProtocol,
     run_crawl,
 )
 
@@ -61,7 +62,7 @@ def build_mock_server() -> tuple[ThreadingHTTPServer, Thread]:
     return server, thread
 
 
-def load_json(ref: Ref, client: HttpClient) -> dict[str, object]:
+def load_json(ref: Ref, client: SyncHttpClientProtocol) -> dict[str, object]:
     response = client.get(ref.url)
     if not response.ok or response.value is None:
         raise ChildListUnavailableError(f"request failed: {response.error}")
@@ -69,7 +70,7 @@ def load_json(ref: Ref, client: HttpClient) -> dict[str, object]:
 
 
 class CategoryList:
-    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+    def expand(self, ref: Ref, client: SyncHttpClientProtocol) -> Expansion:
         payload = load_json(ref, client)
         status = cast(str, payload["status"])
         if status == "not-ready":
@@ -86,7 +87,7 @@ class CategoryList:
 
 
 class ItemList:
-    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+    def expand(self, ref: Ref, client: SyncHttpClientProtocol) -> Expansion:
         payload = load_json(ref, client)
         if payload["status"] == "partial":
             raise PartialExpansionError("category still has another page")
@@ -97,7 +98,9 @@ class ItemList:
 
 
 class ItemSink:
-    def consume(self, ref: Ref, client: HttpClient) -> dict[str, object]:
+    def consume(
+        self, ref: Ref, client: SyncHttpClientProtocol
+    ) -> dict[str, object]:
         response = client.get(ref.url)
         if not response.ok or response.value is None:
             raise LeafUnavailableError(f"item failed: {response.error}")
@@ -105,7 +108,7 @@ class ItemSink:
 
 
 class LocalSource:
-    def discover(self, client: HttpClient) -> Sequence[Ref]:
+    def discover(self, client: SyncHttpClientProtocol) -> Sequence[Ref]:
         return ()
 
 
@@ -118,7 +121,7 @@ class LocalCatalogPlugin:
 
 
 def crawl_one(
-    top_ref: Ref, plugin: LocalCatalogPlugin, client: HttpClient
+    top_ref: Ref, plugin: LocalCatalogPlugin, client: SyncHttpClientProtocol
 ) -> RunResult | None:
     try:
         result = run_crawl(

--- a/examples/cookbook/robots_txt.py
+++ b/examples/cookbook/robots_txt.py
@@ -19,6 +19,7 @@ from ladon import (
     RobotsBlockedError,
     RunConfig,
     RunResult,
+    SyncHttpClientProtocol,
     run_crawl,
 )
 
@@ -57,7 +58,7 @@ class PublicPageSource:
     def __init__(self, base_url: str) -> None:
         self._base_url = base_url
 
-    def discover(self, client: HttpClient) -> Sequence[Ref]:
+    def discover(self, client: SyncHttpClientProtocol) -> Sequence[Ref]:
         return [
             Ref(f"{self._base_url}/allowed"),
             Ref(f"{self._base_url}/blocked"),
@@ -65,7 +66,7 @@ class PublicPageSource:
 
 
 class PublicPage:
-    def expand(self, ref: Ref, client: HttpClient) -> Expansion:
+    def expand(self, ref: Ref, client: SyncHttpClientProtocol) -> Expansion:
         response = client.get(ref.url)
         if isinstance(response.error, RobotsBlockedError):
             raise response.error
@@ -79,7 +80,9 @@ class PublicPage:
 
 
 class PublicPageSink:
-    def consume(self, ref: Ref, client: HttpClient) -> dict[str, object]:
+    def consume(
+        self, ref: Ref, client: SyncHttpClientProtocol
+    ) -> dict[str, object]:
         response = client.get(ref.url)
         if not response.ok or response.value is None:
             raise LeafUnavailableError(f"item failed: {response.error}")

--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -24,6 +24,10 @@ from .networking.errors import (
     RobotsBlockedError,
     TransientNetworkError,
 )
+from .networking.protocols import (
+    AsyncHttpClientProtocol,
+    SyncHttpClientProtocol,
+)
 from .networking.proxy_pool import ProxyPool, RoundRobinProxyPool
 from .networking.types import Result
 from .observability import DecisionEvent, DecisionTracker, NullDecisionTracker
@@ -113,6 +117,8 @@ __all__ = [
     "AsyncHttpClient",
     "CurlHttpClient",
     "AsyncCurlHttpClient",
+    "SyncHttpClientProtocol",
+    "AsyncHttpClientProtocol",
     "make_http_client",
     "make_async_http_client",
     "HttpClientConfig",

--- a/src/ladon/async_runner.py
+++ b/src/ladon/async_runner.py
@@ -36,7 +36,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import cast
 
-from ladon.networking.async_client import AsyncHttpClient
+from ladon.networking.protocols import AsyncHttpClientProtocol
 from ladon.plugins.async_protocol import AsyncCrawlPlugin
 from ladon.plugins.errors import (
     ChildListUnavailableError,
@@ -85,7 +85,7 @@ def _raise_first_fatal_outcome(
 async def async_run_crawl(
     top_ref: object,
     plugin: AsyncCrawlPlugin,
-    client: AsyncHttpClient,
+    client: AsyncHttpClientProtocol,
     config: RunConfig,
     on_leaf: Callable[[object, object], Awaitable[None]] | None = None,
 ) -> RunResult:
@@ -94,7 +94,7 @@ async def async_run_crawl(
     Args:
         top_ref:  Reference to the resource to expand.
         plugin:   Async crawl plugin providing expanders and sink.
-        client:   Configured AsyncHttpClient instance.
+        client:   Configured asynchronous HTTP client protocol implementation.
         config:   Run-level configuration (limits, concurrency).
         on_leaf:  Optional async callback invoked after each successful leaf
                   consume. Receives (leaf_record, parent_record).
@@ -283,7 +283,7 @@ async def async_run_crawl(
 
 async def async_run_plugin(
     plugin: AsyncCrawlPlugin,
-    client: AsyncHttpClient,
+    client: AsyncHttpClientProtocol,
     config: RunConfig,
     on_leaf: Callable[[object, object], Awaitable[None]] | None = None,
 ) -> PluginRunResult:
@@ -328,7 +328,7 @@ async def async_run_plugin(
 async def plan_crawl(
     top_ref: object,
     plugin: AsyncCrawlPlugin,
-    client: AsyncHttpClient,
+    client: AsyncHttpClientProtocol,
 ) -> CrawlPlan:
     """Run Phase 1 (tree traversal) asynchronously and return a CrawlPlan.
 
@@ -398,7 +398,7 @@ async def plan_crawl(
 async def execute_plan(
     plan: CrawlPlan,
     plugin: AsyncCrawlPlugin,
-    client: AsyncHttpClient,
+    client: AsyncHttpClientProtocol,
     config: RunConfig,
     on_leaf: Callable[[object, object], Awaitable[None]] | None = None,
     on_progress: Callable[[int, int], None] | None = None,
@@ -408,7 +408,7 @@ async def execute_plan(
     Args:
         plan:        Plan produced by ``plan_crawl()``.
         plugin:      Async crawl plugin whose sink consumes each leaf.
-        client:      Configured AsyncHttpClient instance.
+        client:      Configured asynchronous HTTP client protocol implementation.
         config:      Run-level configuration (leaf_limit, async_concurrency).
                      If the plan was already narrowed with ``CrawlPlan.limited_to()``,
                      both that cap and ``config.leaf_limit`` apply independently —

--- a/src/ladon/networking/__init__.py
+++ b/src/ladon/networking/__init__.py
@@ -16,6 +16,7 @@ from .errors import (
     RobotsBlockedError,
     TransientNetworkError,
 )
+from .protocols import AsyncHttpClientProtocol, SyncHttpClientProtocol
 from .proxy_pool import ProxyPool, RoundRobinProxyPool, validate_proxy
 from .types import Result
 
@@ -66,6 +67,7 @@ def make_async_http_client(
 __all__ = [
     "AsyncCurlHttpClient",
     "AsyncHttpClient",
+    "AsyncHttpClientProtocol",
     "CircuitOpenError",
     "CircuitState",
     "CurlHttpClient",
@@ -82,4 +84,5 @@ __all__ = [
     "Result",
     "RobotsBlockedError",
     "TransientNetworkError",
+    "SyncHttpClientProtocol",
 ]

--- a/src/ladon/networking/protocols.py
+++ b/src/ladon/networking/protocols.py
@@ -1,0 +1,127 @@
+"""Backend-agnostic structural contracts for Ladon HTTP clients.
+
+The native and curl-cffi implementations satisfy these protocols without
+inheritance.  Consequently, the union values returned by
+``make_http_client()`` and ``make_async_http_client()`` are directly usable
+anywhere Ladon accepts an HTTP client.  See ADR-014.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol, Self, runtime_checkable
+
+from .types import Result
+
+
+@runtime_checkable
+class SyncHttpClientProtocol(Protocol):
+    """Minimal public contract shared by synchronous HTTP backends."""
+
+    def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[bytes, Exception]: ...
+
+    def head(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[Mapping[str, Any], Exception]: ...
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        data: Any | None = None,
+        json: Any | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[bytes, Exception]: ...
+
+    def download(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[Any, Exception]: ...
+
+    def close(self) -> None: ...
+
+    def __enter__(self) -> Self: ...
+
+    def __exit__(self, *_: object) -> None: ...
+
+
+@runtime_checkable
+class AsyncHttpClientProtocol(Protocol):
+    """Minimal public contract shared by asynchronous HTTP backends."""
+
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[bytes, Exception]: ...
+
+    async def head(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[Mapping[str, Any], Exception]: ...
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        data: Any | None = None,
+        json: Any | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[bytes, Exception]: ...
+
+    async def download(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        context: Mapping[str, Any] | None = None,
+    ) -> Result[Any, Exception]: ...
+
+    async def aclose(self) -> None: ...
+
+    async def __aenter__(self) -> Self: ...
+
+    async def __aexit__(self, *_: object) -> None: ...

--- a/src/ladon/plugins/async_protocol.py
+++ b/src/ladon/plugins/async_protocol.py
@@ -3,8 +3,10 @@
 Async adapters implement these protocols by structural subtyping — no
 inheritance from this module is required.
 
-All async adapters receive a configured AsyncHttpClient instance. They
-must not construct their own HTTP sessions or import ``httpx`` directly.
+All async adapters receive an object satisfying ``AsyncHttpClientProtocol``:
+either the native ``AsyncHttpClient`` or curl-cffi ``AsyncCurlHttpClient``
+implementation. They must not construct their own HTTP sessions or import
+``httpx`` directly.
 
 The three-layer pipeline is:
 
@@ -18,19 +20,19 @@ returns a final record. ``AsyncCrawlPlugin`` bundles all three.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
+from ..networking.protocols import AsyncHttpClientProtocol
 from .models import Expansion
-
-if TYPE_CHECKING:
-    from ..networking.async_client import AsyncHttpClient
 
 
 @runtime_checkable
 class AsyncSource(Protocol):
     """Discover top-level refs from an external source, asynchronously."""
 
-    async def discover(self, client: AsyncHttpClient) -> Sequence[object]:
+    async def discover(
+        self, client: AsyncHttpClientProtocol
+    ) -> Sequence[object]:
         """Return all discoverable top-level references."""
         ...
 
@@ -39,7 +41,9 @@ class AsyncSource(Protocol):
 class AsyncExpander(Protocol):
     """Expand one ref into a record plus child refs, asynchronously."""
 
-    async def expand(self, ref: object, client: AsyncHttpClient) -> Expansion:
+    async def expand(
+        self, ref: object, client: AsyncHttpClientProtocol
+    ) -> Expansion:
         """Fetch ref, return its record and the child refs to process next.
 
         Raises:
@@ -54,7 +58,9 @@ class AsyncExpander(Protocol):
 class AsyncSink(Protocol):
     """Consume a leaf ref and return its final record, asynchronously."""
 
-    async def consume(self, ref: object, client: AsyncHttpClient) -> object:
+    async def consume(
+        self, ref: object, client: AsyncHttpClientProtocol
+    ) -> object:
         """Fetch and parse one leaf ref, returning a complete record.
 
         Context for the leaf flows through ``ref.raw`` — no parent-record

--- a/src/ladon/plugins/protocol.py
+++ b/src/ladon/plugins/protocol.py
@@ -4,8 +4,9 @@ Adapters implement these protocols by structural subtyping — no
 inheritance from this module is required. This keeps third-party
 plugins decoupled from Ladon internals.
 
-All adapters receive a configured HttpClient instance. They must not
-construct their own HTTP sessions or import ``requests`` directly.
+All adapters receive an object satisfying ``SyncHttpClientProtocol``: either
+the native ``HttpClient`` or curl-cffi ``CurlHttpClient`` implementation. They
+must not construct their own HTTP sessions or import ``requests`` directly.
 
 The three-layer pipeline is:
 
@@ -21,7 +22,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
-from ..networking.client import HttpClient
+from ..networking.protocols import SyncHttpClientProtocol
 from .models import Expansion
 
 
@@ -29,7 +30,7 @@ from .models import Expansion
 class Source(Protocol):
     """Discover top-level refs from an external source."""
 
-    def discover(self, client: HttpClient) -> Sequence[object]:
+    def discover(self, client: SyncHttpClientProtocol) -> Sequence[object]:
         """Return all discoverable top-level references."""
         ...
 
@@ -38,7 +39,7 @@ class Source(Protocol):
 class Expander(Protocol):
     """Expand one ref into a record plus child refs."""
 
-    def expand(self, ref: object, client: HttpClient) -> Expansion:
+    def expand(self, ref: object, client: SyncHttpClientProtocol) -> Expansion:
         """Fetch ref, return its record and the child refs to process next.
 
         Raises:
@@ -53,7 +54,7 @@ class Expander(Protocol):
 class Sink(Protocol):
     """Consume a leaf ref and return its final record."""
 
-    def consume(self, ref: object, client: HttpClient) -> object:
+    def consume(self, ref: object, client: SyncHttpClientProtocol) -> object:
         """Fetch and parse one leaf ref, returning a complete record.
 
         Context for the leaf (e.g. parent data) flows through

--- a/src/ladon/plugins/resolution.py
+++ b/src/ladon/plugins/resolution.py
@@ -38,8 +38,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Protocol, Sequence, runtime_checkable
 
-from ..networking.client import HttpClient
 from ..networking.errors import HttpClientError
+from ..networking.protocols import SyncHttpClientProtocol
 from ..observability import DecisionEvent, DecisionTracker, NullDecisionTracker
 from .errors import LeafUnavailableError
 from .models import Ref
@@ -147,7 +147,7 @@ class MultiSourceSink:
     # ------------------------------------------------------------------
 
     def _fetch_from_source(
-        self, _source: Any, _ref: Ref, _client: HttpClient
+        self, _source: Any, _ref: Ref, _client: SyncHttpClientProtocol
     ) -> bytes | None:
         """Fetch raw bytes from *source* for *ref*. Must be overridden."""
         raise NotImplementedError(
@@ -208,7 +208,7 @@ class MultiSourceSink:
         return self._first_failing_predicate(data, ref) is None
 
     def resolve_multi(
-        self, ref: Ref, client: HttpClient, *, run_id: str = ""
+        self, ref: Ref, client: SyncHttpClientProtocol, *, run_id: str = ""
     ) -> tuple[bytes | None, Any | None]:
         """Try sources in priority order; return the best accepted result.
 

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -32,7 +32,7 @@ import logging
 from dataclasses import dataclass
 from typing import Callable
 
-from ladon.networking.client import HttpClient
+from ladon.networking.protocols import SyncHttpClientProtocol
 from ladon.plugins.errors import (
     AssetDownloadError,
     ChildListUnavailableError,
@@ -227,7 +227,7 @@ class PluginRunResult:
 def run_crawl(
     top_ref: object,
     plugin: CrawlPlugin,
-    client: HttpClient,
+    client: SyncHttpClientProtocol,
     config: RunConfig,
     on_leaf: Callable[[object, object], None] | None = None,
 ) -> RunResult:
@@ -236,7 +236,7 @@ def run_crawl(
     Args:
         top_ref:  Reference to the resource to expand.
         plugin:   Crawl plugin providing source, expanders, and sink.
-        client:   Configured HttpClient instance.
+        client:   Configured synchronous HTTP client protocol implementation.
         config:   Run-level configuration (limits, flags).
         on_leaf:  Optional callback invoked after each successful leaf
                   consume. Use this hook for DB writes, serialization,
@@ -409,7 +409,7 @@ def run_crawl(
 
 def run_plugin(
     plugin: CrawlPlugin,
-    client: HttpClient,
+    client: SyncHttpClientProtocol,
     config: RunConfig,
     on_leaf: Callable[[object, object], None] | None = None,
 ) -> PluginRunResult:
@@ -426,7 +426,7 @@ def run_plugin(
 
     Args:
         plugin:  Crawl plugin providing a source, expanders, and sink.
-        client:  Configured HttpClient instance.
+        client:  Configured synchronous HTTP client protocol implementation.
         config:  Run configuration forwarded to each discovered root.
         on_leaf: Optional callback forwarded to each :func:`run_crawl` call.
 
@@ -463,7 +463,7 @@ def run_plugin(
 def plan_crawl_sync(
     top_ref: object,
     plugin: CrawlPlugin,
-    client: HttpClient,
+    client: SyncHttpClientProtocol,
 ) -> CrawlPlan:
     """Run Phase 1 (tree traversal) synchronously and return a CrawlPlan.
 
@@ -532,7 +532,7 @@ def plan_crawl_sync(
 def execute_plan_sync(
     plan: CrawlPlan,
     plugin: CrawlPlugin,
-    client: HttpClient,
+    client: SyncHttpClientProtocol,
     config: RunConfig,
     on_leaf: Callable[[object, object], None] | None = None,
     on_progress: Callable[[int, int], None] | None = None,
@@ -542,7 +542,7 @@ def execute_plan_sync(
     Args:
         plan:        Plan produced by ``plan_crawl_sync()``.
         plugin:      Crawl plugin whose sink consumes each leaf.
-        client:      Configured HttpClient instance.
+        client:      Configured synchronous HTTP client protocol implementation.
         config:      Run-level configuration (leaf_limit; async_concurrency ignored).
                      If the plan was already narrowed with ``CrawlPlan.limited_to()``,
                      both caps apply independently — the tighter of the two wins.

--- a/tests/examples/test_cookbook_examples.py
+++ b/tests/examples/test_cookbook_examples.py
@@ -11,7 +11,7 @@ import pytest
 
 from ladon import (
     AsyncCrawlPlugin,
-    AsyncHttpClient,
+    AsyncHttpClientProtocol,
     HttpClient,
     HttpClientConfig,
     Ref,
@@ -113,7 +113,7 @@ def test_async_crawl_consumes_and_persists_every_local_record(
     async def capture_persisted(
         top_ref: object,
         plugin: AsyncCrawlPlugin,
-        client: AsyncHttpClient,
+        client: AsyncHttpClientProtocol,
         config: RunConfig,
         on_leaf: Callable[[object, object], Awaitable[None]] | None = None,
     ) -> RunResult:

--- a/tests/plugins/test_protocol.py
+++ b/tests/plugins/test_protocol.py
@@ -20,6 +20,7 @@ import pytest
 
 from ladon.networking.client import HttpClient
 from ladon.networking.config import HttpClientConfig
+from ladon.networking.protocols import SyncHttpClientProtocol
 from ladon.plugins.errors import (
     ChildListUnavailableError,
     ExpansionNotReadyError,
@@ -69,7 +70,7 @@ def _make_leaf(leaf_id: str, url: str) -> _DemoLeafRecord:
 class _MockSource:
     """Satisfies Source protocol by structure."""
 
-    def discover(self, client: HttpClient) -> Sequence[Ref]:
+    def discover(self, client: SyncHttpClientProtocol) -> Sequence[Ref]:
         return [Ref(url="https://demo.example.com/top/1")]
 
 
@@ -79,14 +80,16 @@ class _MockExpander:
     def __init__(self, child_refs: list[Ref]) -> None:
         self._child_refs = child_refs
 
-    def expand(self, ref: object, client: HttpClient) -> Expansion:
+    def expand(self, ref: object, client: SyncHttpClientProtocol) -> Expansion:
         return Expansion(record=_make_record(), child_refs=self._child_refs)
 
 
 class _MockSink:
     """Returns a leaf record for each ref without network calls."""
 
-    def consume(self, ref: object, client: HttpClient) -> _DemoLeafRecord:
+    def consume(
+        self, ref: object, client: SyncHttpClientProtocol
+    ) -> _DemoLeafRecord:
         r = ref if isinstance(ref, Ref) else Ref(url=str(ref))
         return _make_leaf(leaf_id=r.url.split("/")[-1], url=r.url)
 
@@ -96,12 +99,20 @@ class _MockPlugin:
 
     def __init__(self, child_refs: list[Ref]) -> None:
         self.source = _MockSource()
-        self.expanders: list[object] = [_MockExpander(child_refs)]
-        self.sink: object = _MockSink()
+        self.expanders: Sequence[Expander] = (_MockExpander(child_refs),)
+        self.sink: Sink = _MockSink()
 
     @property
     def name(self) -> str:
         return "mock_plugin"
+
+
+# Static counterparts to the runtime checks below. These assignments ensure
+# the test doubles satisfy the complete widened signatures under Pyright.
+_typed_source: Source = _MockSource()
+_typed_expander: Expander = _MockExpander([])
+_typed_sink: Sink = _MockSink()
+_typed_plugin: CrawlPlugin = _MockPlugin([])
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +297,9 @@ class TestRunnerErrors:
         child_refs: list[Ref],
     ) -> None:
         class _NotReadyExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 raise ExpansionNotReadyError("not ready yet")
 
         p = _MockPlugin(child_refs)
@@ -302,7 +315,9 @@ class TestRunnerErrors:
         child_refs: list[Ref],
     ) -> None:
         class _PartialExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 raise PartialExpansionError("partial")
 
         p = _MockPlugin(child_refs)
@@ -318,7 +333,9 @@ class TestRunnerErrors:
         child_refs: list[Ref],
     ) -> None:
         class _BrokenExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 raise ChildListUnavailableError("API down")
 
         p = _MockPlugin(child_refs)
@@ -339,7 +356,7 @@ class TestRunnerErrors:
 
         class _FailingSink:
             def consume(
-                self, ref: object, client: HttpClient
+                self, ref: object, client: SyncHttpClientProtocol
             ) -> _DemoLeafRecord:
                 r = ref if isinstance(ref, Ref) else Ref(url="")
                 if r.url.endswith("/1"):
@@ -366,7 +383,7 @@ class TestRunnerErrors:
     ) -> None:
         class _AlwaysFailSink:
             def consume(
-                self, ref: object, client: HttpClient
+                self, ref: object, client: SyncHttpClientProtocol
             ) -> _DemoLeafRecord:
                 raise LeafUnavailableError("always fails")
 
@@ -391,7 +408,7 @@ class TestRunnerErrors:
 
         class _MixedSink:
             def consume(
-                self, ref: object, client: HttpClient
+                self, ref: object, client: SyncHttpClientProtocol
             ) -> _DemoLeafRecord:
                 r = ref if isinstance(ref, Ref) else Ref(url="")
                 if r.url.endswith("/2"):
@@ -478,7 +495,7 @@ class TestRunnerErrors:
         # Scenario B: all consume() fail
         class _AlwaysFailSink:
             def consume(
-                self, ref: object, client: HttpClient
+                self, ref: object, client: SyncHttpClientProtocol
             ) -> _DemoLeafRecord:
                 raise LeafUnavailableError("always fails")
 
@@ -572,7 +589,9 @@ class TestRunnerLogging:
         refs = [Ref(url="https://demo.example.com/leaf/1")]
 
         class _FailSink:
-            def consume(self, ref: object, client: HttpClient) -> object:
+            def consume(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> object:
                 raise LeafUnavailableError("gone")
 
         p = _MockPlugin(refs)
@@ -608,12 +627,16 @@ class TestRunnerLogging:
                 return "X" * 200
 
         class _LargeParentExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 leaf = Ref(url="https://demo.example.com/leaf/1")
                 return Expansion(record=_LargeRecord(), child_refs=[leaf])
 
         class _FailSink:
-            def consume(self, ref: object, client: HttpClient) -> object:
+            def consume(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> object:
                 raise LeafUnavailableError("gone")
 
         p = _MockPlugin([])
@@ -643,11 +666,15 @@ class TestRunnerLogging:
         section_a = Ref(url="https://demo.example.com/section/a")
 
         class _FirstExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 return Expansion(record=_make_record(), child_refs=[section_a])
 
         class _FailingExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 raise ChildListUnavailableError("API down")
 
         p = _MockPlugin([])
@@ -725,14 +752,18 @@ class TestMultiExpander:
             name: str
 
         class _CatalogExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 return Expansion(
                     record=_CatalogRecord(),
                     child_refs=[section_a, section_b],
                 )
 
         class _SectionExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 r = ref if isinstance(ref, Ref) else Ref(url="")
                 if r.url.endswith("/a"):
                     return Expansion(
@@ -813,14 +844,18 @@ class TestMultiExpander:
         """
 
         class _FirstExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 return Expansion(
                     record=_make_record(),
                     child_refs=[Ref(url="https://demo.example.com/section/a")],
                 )
 
         class _NotReadySecondExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 raise ExpansionNotReadyError("section not live yet")
 
         p = _MockPlugin([])
@@ -844,14 +879,18 @@ class TestMultiExpander:
         item_1 = Ref(url="https://demo.example.com/item/1")
 
         class _FirstExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 return Expansion(
                     record=_make_record(),
                     child_refs=[section_a, section_b],
                 )
 
         class _SectionExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 r = ref if isinstance(ref, Ref) else Ref(url="")
                 if r.url.endswith("/a"):
                     raise PartialExpansionError("section_a unavailable")
@@ -882,14 +921,18 @@ class TestMultiExpander:
         item_1 = Ref(url="https://demo.example.com/item/1")
 
         class _FirstExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 return Expansion(
                     record=_make_record(),
                     child_refs=[section_a, section_b],
                 )
 
         class _SectionExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 r = ref if isinstance(ref, Ref) else Ref(url="")
                 if r.url.endswith("/b"):
                     raise ChildListUnavailableError("API down")
@@ -915,14 +958,18 @@ class TestMultiExpander:
         section_b = Ref(url="https://demo.example.com/section/b")
 
         class _FirstExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 return Expansion(
                     record=_make_record(),
                     child_refs=[section_a, section_b],
                 )
 
         class _AlwaysFailExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 raise ChildListUnavailableError("API down")
 
         p = _MockPlugin([])
@@ -940,7 +987,9 @@ class TestMultiExpander:
         config: RunConfig,
     ) -> None:
         class _EmptyExpander:
-            def expand(self, ref: object, client: HttpClient) -> Expansion:
+            def expand(
+                self, ref: object, client: SyncHttpClientProtocol
+            ) -> Expansion:
                 return Expansion(record=_make_record(), child_refs=[])
 
         p = _MockPlugin([])

--- a/tests/test_async_plugin_runner.py
+++ b/tests/test_async_plugin_runner.py
@@ -10,7 +10,7 @@ from typing import cast
 import pytest
 
 from ladon.async_runner import async_run_plugin
-from ladon.networking.async_client import AsyncHttpClient
+from ladon.networking.protocols import AsyncHttpClientProtocol
 from ladon.plugins.async_protocol import (
     AsyncCrawlPlugin,
     AsyncExpander,
@@ -36,7 +36,7 @@ class _AsyncSource:
         self._refs = refs
         self.calls = 0
 
-    async def discover(self, client: AsyncHttpClient) -> Sequence[Ref]:
+    async def discover(self, client: AsyncHttpClientProtocol) -> Sequence[Ref]:
         self.calls += 1
         return self._refs
 
@@ -50,7 +50,9 @@ class _AsyncExpander:
         self._error = error
         self._error_for = error_for
 
-    async def expand(self, ref: object, client: AsyncHttpClient) -> Expansion:
+    async def expand(
+        self, ref: object, client: AsyncHttpClientProtocol
+    ) -> Expansion:
         if self._error is not None:
             raise self._error
         assert isinstance(ref, Ref)
@@ -68,7 +70,9 @@ class _AsyncSink:
     def __init__(self, fail: Callable[[Ref], bool] | None = None) -> None:
         self._fail: Callable[[Ref], bool] = fail or _never_fail
 
-    async def consume(self, ref: object, client: AsyncHttpClient) -> _Record:
+    async def consume(
+        self, ref: object, client: AsyncHttpClientProtocol
+    ) -> _Record:
         assert isinstance(ref, Ref)
         if self._fail(ref):
             raise LeafUnavailableError("unavailable")
@@ -113,7 +117,9 @@ async def test_runs_every_discovered_root_and_aggregates_results() -> None:
     plugin = _AsyncPlugin(_refs())
 
     result = await async_run_plugin(
-        cast(AsyncCrawlPlugin, plugin), cast(AsyncHttpClient, None), RunConfig()
+        cast(AsyncCrawlPlugin, plugin),
+        cast(AsyncHttpClientProtocol, None),
+        RunConfig(),
     )
 
     assert isinstance(result, PluginRunResult)
@@ -131,7 +137,9 @@ async def test_empty_discovery_returns_zero_count_aggregate() -> None:
     plugin = _AsyncPlugin(())
 
     result = await async_run_plugin(
-        cast(AsyncCrawlPlugin, plugin), cast(AsyncHttpClient, None), RunConfig()
+        cast(AsyncCrawlPlugin, plugin),
+        cast(AsyncHttpClientProtocol, None),
+        RunConfig(),
     )
 
     assert isinstance(plugin.source, _AsyncSource)
@@ -155,7 +163,7 @@ async def test_forwards_on_leaf_to_each_single_root_run() -> None:
 
     result = await async_run_plugin(
         cast(AsyncCrawlPlugin, plugin),
-        cast(AsyncHttpClient, None),
+        cast(AsyncHttpClientProtocol, None),
         RunConfig(),
         on_leaf=on_leaf,
     )
@@ -167,7 +175,7 @@ async def test_forwards_on_leaf_to_each_single_root_run() -> None:
 async def test_applies_leaf_limit_to_each_discovered_root() -> None:
     result = await async_run_plugin(
         cast(AsyncCrawlPlugin, _AsyncPlugin(_refs())),
-        cast(AsyncHttpClient, None),
+        cast(AsyncHttpClientProtocol, None),
         RunConfig(leaf_limit=1),
     )
 
@@ -181,7 +189,9 @@ async def test_aggregates_leaf_errors_with_root_index() -> None:
     )
 
     result = await async_run_plugin(
-        cast(AsyncCrawlPlugin, plugin), cast(AsyncHttpClient, None), RunConfig()
+        cast(AsyncCrawlPlugin, plugin),
+        cast(AsyncHttpClientProtocol, None),
+        RunConfig(),
     )
 
     assert result.leaves_consumed == 3
@@ -193,7 +203,9 @@ async def test_aggregates_leaf_errors_with_root_index() -> None:
 
 async def test_discovery_errors_propagate() -> None:
     class _FailingSource(_AsyncSource):
-        async def discover(self, client: AsyncHttpClient) -> Sequence[Ref]:
+        async def discover(
+            self, client: AsyncHttpClientProtocol
+        ) -> Sequence[Ref]:
             raise RuntimeError("discovery failed")
 
     plugin = _AsyncPlugin(_refs())
@@ -202,7 +214,7 @@ async def test_discovery_errors_propagate() -> None:
     with pytest.raises(RuntimeError, match="discovery failed"):
         await async_run_plugin(
             cast(AsyncCrawlPlugin, plugin),
-            cast(AsyncHttpClient, None),
+            cast(AsyncHttpClientProtocol, None),
             RunConfig(),
         )
 
@@ -215,7 +227,7 @@ async def test_globally_fatal_root_errors_propagate() -> None:
     with pytest.raises(ExpansionNotReadyError, match="later"):
         await async_run_plugin(
             cast(AsyncCrawlPlugin, plugin),
-            cast(AsyncHttpClient, None),
+            cast(AsyncHttpClientProtocol, None),
             RunConfig(),
         )
 
@@ -223,7 +235,7 @@ async def test_globally_fatal_root_errors_propagate() -> None:
 async def test_asset_download_error_from_root_sink_propagates() -> None:
     class _FatalSink:
         async def consume(
-            self, ref: object, client: AsyncHttpClient
+            self, ref: object, client: AsyncHttpClientProtocol
         ) -> _Record:
             raise AssetDownloadError("asset host unavailable")
 
@@ -233,7 +245,7 @@ async def test_asset_download_error_from_root_sink_propagates() -> None:
     with pytest.raises(AssetDownloadError, match="asset host unavailable"):
         await async_run_plugin(
             cast(AsyncCrawlPlugin, plugin),
-            cast(AsyncHttpClient, None),
+            cast(AsyncHttpClientProtocol, None),
             RunConfig(),
         )
 
@@ -269,7 +281,7 @@ async def test_later_fatal_root_preserves_earlier_callback_side_effects() -> (
     with pytest.raises(ExpansionNotReadyError, match="later"):
         await async_run_plugin(
             cast(AsyncCrawlPlugin, plugin),
-            cast(AsyncHttpClient, None),
+            cast(AsyncHttpClientProtocol, None),
             RunConfig(),
             on_leaf=on_leaf,
         )

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -16,12 +16,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
 
 import pytest
 
 from ladon.async_runner import async_run_crawl, execute_plan, plan_crawl
+from ladon.networking.protocols import AsyncHttpClientProtocol
+from ladon.plugins.async_protocol import (
+    AsyncCrawlPlugin,
+    AsyncExpander,
+    AsyncSink,
+    AsyncSource,
+)
 from ladon.plugins.errors import (
     AssetDownloadError,
     ChildListUnavailableError,
@@ -83,18 +90,27 @@ class _TypedAsyncExpansionFailureSink:
         raise self._error
 
 
+class _MockAsyncSource:
+    async def discover(
+        self, client: AsyncHttpClientProtocol
+    ) -> Sequence[object]:
+        return ()
+
+
 class _MockAsyncPlugin:
     def __init__(self, child_refs: list[Ref]) -> None:
-        self.expanders: list[Any] = [_MockAsyncExpander(child_refs)]
-        self.sink: Any = _MockAsyncSink()
+        self.source: AsyncSource = _MockAsyncSource()
+        self.expanders: Sequence[AsyncExpander] = (
+            _MockAsyncExpander(child_refs),
+        )
+        self.sink: AsyncSink = _MockAsyncSink()
 
     @property
     def name(self) -> str:
         return "mock_async_plugin"
 
-    @property
-    def source(self) -> object:
-        return object()
+
+_typed_async_plugin: AsyncCrawlPlugin = _MockAsyncPlugin([])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_http_client_protocols.py
+++ b/tests/test_http_client_protocols.py
@@ -1,0 +1,249 @@
+# pyright: reportUnknownMemberType=false
+"""Static conformance fixtures and runtime smoke tests for HTTP protocols."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from ladon import (
+    AsyncCrawlPlugin,
+    AsyncCurlHttpClient,
+    AsyncExpander,
+    AsyncHttpClient,
+    AsyncHttpClientProtocol,
+    AsyncSink,
+    AsyncSource,
+    CrawlPlugin,
+    CurlHttpClient,
+    Expander,
+    Expansion,
+    HttpClient,
+    HttpClientConfig,
+    Sink,
+    Source,
+    SyncHttpClientProtocol,
+    async_run_crawl,
+    async_run_plugin,
+    execute_plan,
+    execute_plan_sync,
+    make_async_http_client,
+    make_http_client,
+    plan_crawl,
+    plan_crawl_sync,
+    run_crawl,
+    run_plugin,
+)
+from ladon.plugins import MultiSourceSink, Ref
+from ladon.runner import RunConfig
+
+
+class _Source:
+    def __init__(self, ref: object = "root") -> None:
+        self.ref = ref
+        self.seen_client: SyncHttpClientProtocol | None = None
+
+    def discover(self, client: SyncHttpClientProtocol) -> Sequence[object]:
+        self.seen_client = client
+        return (self.ref,)
+
+
+class _Expander:
+    def expand(self, ref: object, client: SyncHttpClientProtocol) -> Expansion:
+        return Expansion(record=ref, child_refs=("leaf",))
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.seen_client: SyncHttpClientProtocol | None = None
+
+    def consume(self, ref: object, client: SyncHttpClientProtocol) -> object:
+        self.seen_client = client
+        return ref
+
+
+class _Plugin:
+    name = "protocol-smoke"
+
+    def __init__(self) -> None:
+        self.source = _Source()
+        self.expanders = (_Expander(),)
+        self.sink = _Sink()
+
+
+class _AsyncSource:
+    def __init__(self, ref: object = "root") -> None:
+        self.ref = ref
+        self.seen_client: AsyncHttpClientProtocol | None = None
+
+    async def discover(
+        self, client: AsyncHttpClientProtocol
+    ) -> Sequence[object]:
+        self.seen_client = client
+        return (self.ref,)
+
+
+class _AsyncExpander:
+    async def expand(
+        self, ref: object, client: AsyncHttpClientProtocol
+    ) -> Expansion:
+        return Expansion(record=ref, child_refs=("leaf",))
+
+
+class _AsyncSink:
+    def __init__(self) -> None:
+        self.seen_client: AsyncHttpClientProtocol | None = None
+
+    async def consume(
+        self, ref: object, client: AsyncHttpClientProtocol
+    ) -> object:
+        self.seen_client = client
+        return ref
+
+
+class _AsyncPlugin:
+    name = "async-protocol-smoke"
+
+    def __init__(self) -> None:
+        self.source = _AsyncSource()
+        self.expanders = (_AsyncExpander(),)
+        self.sink = _AsyncSink()
+
+
+class _ResolutionSink(MultiSourceSink):
+    def __init__(self) -> None:
+        super().__init__([])
+
+    def _fetch_from_source(
+        self,
+        source: object,
+        ref: Ref,
+        client: SyncHttpClientProtocol,
+    ) -> bytes | None:
+        return None
+
+    def typecheck_fetch(self, client: SyncHttpClientProtocol) -> None:
+        self._fetch_from_source(object(), Ref("https://example.test"), client)
+
+
+def _accept_sync_adapters(
+    source: Source,
+    expander: Expander,
+    sink: Sink,
+    client: SyncHttpClientProtocol,
+) -> None:
+    source.discover(client)
+    expansion = expander.expand("root", client)
+    sink.consume(expansion.child_refs[0], client)
+
+
+async def _accept_async_adapters(
+    source: AsyncSource,
+    expander: AsyncExpander,
+    sink: AsyncSink,
+    client: AsyncHttpClientProtocol,
+) -> None:
+    await source.discover(client)
+    expansion = await expander.expand("root", client)
+    await sink.consume(expansion.child_refs[0], client)
+
+
+def _strict_pyright_sync_fixture(config: HttpClientConfig) -> None:
+    native: SyncHttpClientProtocol = HttpClient(config)
+    curl: SyncHttpClientProtocol = CurlHttpClient(
+        config, impersonate="chrome136"
+    )
+    factory_result: SyncHttpClientProtocol = make_http_client(config)
+    _accept_sync_adapters(_Source(), _Expander(), _Sink(), factory_result)
+    plugin: CrawlPlugin = _Plugin()
+    run_crawl("root", plugin, factory_result, RunConfig())
+    run_plugin(plugin, factory_result, RunConfig())
+    plan = plan_crawl_sync("root", plugin, factory_result)
+    execute_plan_sync(plan, plugin, factory_result, RunConfig())
+    resolution_sink = _ResolutionSink()
+    resolution_sink.resolve_multi(Ref("https://example.test"), factory_result)
+    resolution_sink.typecheck_fetch(factory_result)
+    native.close()
+    curl.close()
+    factory_result.close()
+
+
+async def _strict_pyright_async_fixture(config: HttpClientConfig) -> None:
+    native: AsyncHttpClientProtocol = AsyncHttpClient(config)
+    curl: AsyncHttpClientProtocol = AsyncCurlHttpClient(
+        config, impersonate="chrome136"
+    )
+    factory_result: AsyncHttpClientProtocol = make_async_http_client(config)
+    await _accept_async_adapters(
+        _AsyncSource(), _AsyncExpander(), _AsyncSink(), factory_result
+    )
+    plugin: AsyncCrawlPlugin = _AsyncPlugin()
+    await async_run_crawl("root", plugin, factory_result, RunConfig())
+    await async_run_plugin(plugin, factory_result, RunConfig())
+    plan = await plan_crawl("root", plugin, factory_result)
+    await execute_plan(plan, plugin, factory_result, RunConfig())
+    await native.aclose()
+    await curl.aclose()
+    await factory_result.aclose()
+
+
+def test_public_http_client_imports_remain_available() -> None:
+    assert SyncHttpClientProtocol is not None
+    assert AsyncHttpClientProtocol is not None
+    assert HttpClient is not None
+    assert CurlHttpClient is not None
+    assert AsyncHttpClient is not None
+    assert AsyncCurlHttpClient is not None
+    assert make_http_client is not None
+    assert make_async_http_client is not None
+
+
+def test_native_client_satisfies_sync_runtime_protocol() -> None:
+    with HttpClient(HttpClientConfig()) as client:
+        assert isinstance(client, SyncHttpClientProtocol)
+
+
+async def test_native_client_satisfies_async_runtime_protocol() -> None:
+    async with AsyncHttpClient(HttpClientConfig()) as client:
+        assert isinstance(client, AsyncHttpClientProtocol)
+
+
+def test_curl_client_runs_through_sync_plugin_path() -> None:
+    pytest.importorskip("curl_cffi", reason="curl-cffi not installed")
+    client = CurlHttpClient(HttpClientConfig(), impersonate="chrome136")
+    plugin = _Plugin()
+    try:
+        assert isinstance(client, SyncHttpClientProtocol)
+        result = run_plugin(plugin, client, RunConfig())
+    finally:
+        client.close()
+
+    assert result.leaves_consumed == 1
+    assert plugin.source.seen_client is client
+    assert plugin.sink.seen_client is client
+
+
+async def test_curl_client_runs_through_async_plugin_path() -> None:
+    pytest.importorskip("curl_cffi", reason="curl-cffi not installed")
+    client = AsyncCurlHttpClient(HttpClientConfig(), impersonate="chrome136")
+    plugin = _AsyncPlugin()
+    try:
+        assert isinstance(client, AsyncHttpClientProtocol)
+        result = await async_run_plugin(plugin, client, RunConfig())
+    finally:
+        await client.aclose()
+
+    assert result.leaves_consumed == 1
+    assert plugin.source.seen_client is client
+    assert plugin.sink.seen_client is client
+
+
+# These assignments also prove the complete plugin structures under strict
+# Pyright without requiring the optional curl-cffi dependency at runtime.
+_sync_plugin: CrawlPlugin = _Plugin()
+_async_plugin: AsyncCrawlPlugin = _AsyncPlugin()
+_static_fixtures = (
+    _strict_pyright_sync_fixture,
+    _strict_pyright_async_fixture,
+)

--- a/tests/test_plugin_runner.py
+++ b/tests/test_plugin_runner.py
@@ -9,7 +9,7 @@ from typing import cast
 
 import pytest
 
-from ladon.networking.client import HttpClient
+from ladon.networking.protocols import SyncHttpClientProtocol
 from ladon.plugins.errors import ExpansionNotReadyError, LeafUnavailableError
 from ladon.plugins.models import Expansion, Ref
 from ladon.plugins.protocol import CrawlPlugin, Expander, Sink, Source
@@ -26,7 +26,7 @@ class _Source:
         self._refs = refs
         self.calls = 0
 
-    def discover(self, client: HttpClient) -> Sequence[Ref]:
+    def discover(self, client: SyncHttpClientProtocol) -> Sequence[Ref]:
         self.calls += 1
         return self._refs
 
@@ -40,7 +40,7 @@ class _Expander:
         self._error = error
         self._error_for = error_for
 
-    def expand(self, ref: object, client: HttpClient) -> Expansion:
+    def expand(self, ref: object, client: SyncHttpClientProtocol) -> Expansion:
         if self._error is not None:
             raise self._error
         assert isinstance(ref, Ref)
@@ -58,7 +58,7 @@ class _Sink:
     def __init__(self, fail: Callable[[Ref], bool] | None = None) -> None:
         self._fail: Callable[[Ref], bool] = fail or _never_fail
 
-    def consume(self, ref: object, client: HttpClient) -> _Record:
+    def consume(self, ref: object, client: SyncHttpClientProtocol) -> _Record:
         assert isinstance(ref, Ref)
         if self._fail(ref):
             raise LeafUnavailableError("unavailable")
@@ -103,7 +103,9 @@ def test_runs_every_discovered_root_and_aggregates_results() -> None:
     plugin = _Plugin(_refs())
 
     result = run_plugin(
-        cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+        cast(CrawlPlugin, plugin),
+        cast(SyncHttpClientProtocol, None),
+        RunConfig(),
     )
 
     assert isinstance(result, PluginRunResult)
@@ -121,7 +123,9 @@ def test_empty_discovery_returns_zero_count_aggregate() -> None:
     plugin = _Plugin(())
 
     result = run_plugin(
-        cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+        cast(CrawlPlugin, plugin),
+        cast(SyncHttpClientProtocol, None),
+        RunConfig(),
     )
 
     assert isinstance(plugin.source, _Source)
@@ -145,7 +149,7 @@ def test_forwards_on_leaf_to_each_single_root_run() -> None:
 
     result = run_plugin(
         cast(CrawlPlugin, plugin),
-        cast(HttpClient, None),
+        cast(SyncHttpClientProtocol, None),
         RunConfig(),
         on_leaf=on_leaf,
     )
@@ -157,7 +161,7 @@ def test_forwards_on_leaf_to_each_single_root_run() -> None:
 def test_applies_leaf_limit_to_each_discovered_root() -> None:
     result = run_plugin(
         cast(CrawlPlugin, _Plugin(_refs())),
-        cast(HttpClient, None),
+        cast(SyncHttpClientProtocol, None),
         RunConfig(leaf_limit=1),
     )
 
@@ -171,7 +175,9 @@ def test_aggregates_leaf_errors_with_root_index() -> None:
     )
 
     result = run_plugin(
-        cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+        cast(CrawlPlugin, plugin),
+        cast(SyncHttpClientProtocol, None),
+        RunConfig(),
     )
 
     assert result.leaves_consumed == 3
@@ -183,7 +189,7 @@ def test_aggregates_leaf_errors_with_root_index() -> None:
 
 def test_discovery_errors_propagate() -> None:
     class _FailingSource(_Source):
-        def discover(self, client: HttpClient) -> Sequence[Ref]:
+        def discover(self, client: SyncHttpClientProtocol) -> Sequence[Ref]:
             raise RuntimeError("discovery failed")
 
     plugin = _Plugin(_refs())
@@ -191,7 +197,9 @@ def test_discovery_errors_propagate() -> None:
 
     with pytest.raises(RuntimeError, match="discovery failed"):
         run_plugin(
-            cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+            cast(CrawlPlugin, plugin),
+            cast(SyncHttpClientProtocol, None),
+            RunConfig(),
         )
 
 
@@ -202,7 +210,9 @@ def test_globally_fatal_root_errors_propagate() -> None:
 
     with pytest.raises(ExpansionNotReadyError, match="later"):
         run_plugin(
-            cast(CrawlPlugin, plugin), cast(HttpClient, None), RunConfig()
+            cast(CrawlPlugin, plugin),
+            cast(SyncHttpClientProtocol, None),
+            RunConfig(),
         )
 
 
@@ -226,7 +236,7 @@ def test_later_fatal_root_preserves_earlier_callback_side_effects() -> None:
     with pytest.raises(ExpansionNotReadyError, match="later"):
         run_plugin(
             cast(CrawlPlugin, plugin),
-            cast(HttpClient, None),
+            cast(SyncHttpClientProtocol, None),
             RunConfig(),
             on_leaf=on_leaf,
         )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,11 +10,12 @@ never use it; the runner passes it through without inspecting it.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
 
 import pytest
 
+from ladon.networking.protocols import SyncHttpClientProtocol
 from ladon.plugins.errors import (
     AssetDownloadError,
     ChildListUnavailableError,
@@ -23,6 +24,7 @@ from ladon.plugins.errors import (
     PartialExpansionError,
 )
 from ladon.plugins.models import Expansion, Ref
+from ladon.plugins.protocol import CrawlPlugin, Expander, Sink, Source
 from ladon.runner import (
     CrawlPlan,
     RunConfig,
@@ -68,18 +70,23 @@ class _MockSink:
         return _DemoLeafRecord(leaf_id=r.url.split("/")[-1], url=r.url)
 
 
+class _MockSource:
+    def discover(self, client: SyncHttpClientProtocol) -> Sequence[object]:
+        return ()
+
+
 class _MockPlugin:
     def __init__(self, child_refs: list[Ref]) -> None:
-        self.expanders: list[Any] = [_MockExpander(child_refs)]
-        self.sink: Any = _MockSink()
+        self.source: Source = _MockSource()
+        self.expanders: Sequence[Expander] = (_MockExpander(child_refs),)
+        self.sink: Sink = _MockSink()
 
     @property
     def name(self) -> str:
         return "mock_plugin"
 
-    @property
-    def source(self) -> object:
-        return object()
+
+_typed_plugin: CrawlPlugin = _MockPlugin([])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `make_http_client()` returns `HttpClient | CurlHttpClient`, and `make_async_http_client()` returns `AsyncHttpClient | AsyncCurlHttpClient` — the factory picks the backend from `config.backend`. But `Source.discover`, `Expander.expand`, `Sink.consume`, and every runner entry point (`run_crawl`, `run_plugin`, `plan_crawl_sync`, `execute_plan_sync` and their async equivalents, plus `MultiSourceSink.resolve_multi`/`_fetch_from_source`) typed their `client` parameter against a single concrete class, not the union and not the curl-cffi variants. A caller doing `client = make_http_client(config); my_source.discover(client)` got a strict-pyright error even though both backends implement the same request-policy surface via `SyncPolicyBase`/`AsyncPolicyBase` and the code runs correctly at runtime — the type system rejected the documented, intended usage of runtime backend substitution.
- `SyncHttpClientProtocol` and `AsyncHttpClientProtocol` are new structural (non-inheriting) contracts covering exactly the shared surface: `get`, `head`, `post`, `download`, `close`/`aclose`, and context-manager behavior. Deliberately excludes `circuit_state()`/`set_crawl_delay()` — those are policy-implementation capabilities, not part of what an adapter needs to make a request. `download()` returns `Result[Any, Exception]` in both protocols because there's no common response base type across `requests`/`httpx`/`curl-cffi`; `CurlHttpClient`/`AsyncCurlHttpClient` already return `Any` here today, so this isn't a narrowing regression.
- Named `*Protocol` explicitly (not bare `SyncHttpClient`/`AsyncHttpClient`) because `AsyncHttpClient` already names the concrete httpx-backed class in this same package — reusing it would collide.
- Retyping `Source`/`Expander`/`Sink`'s `client` parameter to the protocol forces every adapter implementation to widen its own `client` parameter too: Protocol structural conformance checks parameter contravariance, so an implementation still declaring `client: HttpClient` after the protocol widens is no longer a valid `Source`/`Expander`/`Sink`. This is why the fix touches the five cookbook examples, several test files' adapter doubles, and two authoring-plugins docs guides beyond the protocol definition itself — the contravariance requirement isn't optional cleanup, it's what makes the protocol widening sound.
- ADR-003 and ADR-004 predate this change and still show the old concrete-class snippets in their historical context; rather than rewriting decisions that were correct when made, they carry a one-line forward-pointer to the new ADR-014.
- Concrete classes (`HttpClient`, `CurlHttpClient`, `AsyncHttpClient`, `AsyncCurlHttpClient`) are unchanged and still required for construction and backend-specific configuration (e.g. `cli.py`'s direct `HttpClient(...)` instantiation) — only call sites that accept an already-constructed client, not sites that build one, move to the protocol types.

Fixes #161

## Test plan

- [x] `pytest tests/` — 781 passed
- [x] `pyright` — 0 errors, 0 warnings (this issue is explicitly about strict typing, so this gate matters more than usual here)
- [x] `pre-commit run --all-files` — all hooks passed
- [x] Strict-pyright fixtures assigning factory results to protocol-typed variables and passing them through every sync/async runner entry point and `MultiSourceSink`
- [x] Runtime `isinstance()` conformance checks for native and curl-cffi clients against both protocols
- [x] curl-cffi smoke tests running a full sync/async plugin crawl through `CurlHttpClient`/`AsyncCurlHttpClient` (skipped only when curl-cffi isn't installed)
- [x] Public import compatibility test for `SyncHttpClientProtocol`/`AsyncHttpClientProtocol` alongside all pre-existing networking exports

https://claude.ai/code/session_01FMqLunsgCtArSyVMioDDmf