### PR TITLE
feat(plugins): add generic SES protocol types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Generic SES protocol types** — `Ref[RawT]`,
+  `Expansion[RecordT, ChildRawT]`, `Source`, `Expander`, `Sink`,
+  `CrawlPlugin`, and `CrawlPlan` now preserve concrete adapter types under
+  strict type checking. New `OnLeafCallback` / `OnPlannedLeafCallback` type
+  aliases and async equivalents let adapter authors annotate callbacks
+  precisely.
 - **`SyncHttpClientProtocol` / `AsyncHttpClientProtocol`** — public structural
   HTTP client contracts implemented by both native and curl-cffi backends.
 - **`run_plugin()` / `async_run_plugin()`** — source-driven whole-plugin
@@ -43,6 +49,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rate-limit slots instead of waking in a batch, and HALF_OPEN circuit
   breakers admit exactly one probe. Both guards are cancellation-safe and
   remain independent across hosts.
+
+### Changed
+
+- **Breaking: planned-crawl callback keyword renamed** —
+  `execute_plan_sync(..., on_leaf=...)` and `execute_plan(..., on_leaf=...)`
+  must now use `on_planned_leaf=`, making their `(leaf_record, leaf_ref)`
+  contract distinct from the runners' `(leaf_record, parent_record)` callback.
 
 ---
 

--- a/docs/decisions/adr-015-generic-ses-protocols.md
+++ b/docs/decisions/adr-015-generic-ses-protocols.md
@@ -1,0 +1,162 @@
+---
+status: proposed
+date: 2026-08-13
+decision-makers: [Maintainers]
+informed: [Contributors]
+refs: [ADR-004, ADR-011, ADR-014, Issue #162]
+---
+
+# ADR-015 — Generic SES Protocol Types
+
+## Context and Problem Statement
+
+`Source`, `Expander`, `Sink`, `CrawlPlugin`, `Ref`, `Expansion`, and
+`CrawlPlan` are all typed against `object` (ADR-004). `Protocol` method
+parameters are contravariant, so a concrete adapter method narrower than
+`object` — e.g. `expand(self, ref: Ref, ...)` — does not structurally
+satisfy `Expander.expand(self, ref: object, ...)` under strict Pyright.
+Three shipped cookbook examples work around this today with
+`cast("CrawlPlugin", plugin)` / `cast(dict[str, object], leaf_record)` / a
+throwaway local `Protocol` built purely to regain attribute access on an
+`object`-typed callback parameter. The external `ladon-hackernews` adapter
+carries a live `# type: ignore[arg-type]` on `ref.raw` for the same root
+cause.
+
+Separately, `execute_plan_sync`'s `on_leaf` callback has always had a
+*different* parameter contract — `(leaf_record, leaf_ref)` — than
+`run_crawl`'s `on_leaf` — `(leaf_record, parent_record)` — a distinction
+ADR-011 established but that only a docstring sentence enforces today. A
+caller can pass either shape to either function and get a plausible-looking
+`object, object` signature match with no error until runtime.
+
+## Decision Drivers
+
+* Eliminate the three shipped `cast(...)` call sites without narrowing any
+  concrete backend or adapter capability (the same bar ADR-014 already met).
+* Make the `run_crawl` vs `execute_plan_sync` `on_leaf` contract mismatch a
+  compile-time error, not a docstring warning.
+* Preserve every existing bare (unsubscripted) `Ref`, `Expansion`,
+  `RunResult`, `CrawlPlan`, `PluginRunResult` usage — this repo's strict
+  Pyright config makes `reportMissingTypeArgument` a hard error for any
+  unbound generic, so this is not optional.
+* Preserve `expanders: Sequence[Expander]`'s existing homogeneous-list shape
+  — third-party adapters (e.g. `ladon-hackernews`) already implement it and
+  must not be forced to restructure.
+* Follow the structural-Protocol pattern this repo already uses for
+  `Source`/`Expander`/`Sink`, the same pattern ADR-014 cited as precedent
+  for its own client protocols.
+
+## Considered Options
+
+* **A — Generic Protocols with per-variance-role TypeVars, defaults via
+  `typing_extensions.TypeVar` (chosen)**
+* **B — Keep `object` everywhere; rely on `cast()` at every adapter
+  boundary (status quo)**
+* **C — Fully variadic per-expansion-level typing (`TypeVarTuple`-based)**
+* **D — Concrete unions at every boundary**
+
+## Decision Outcome
+
+**Chosen: Option A.**
+
+`Ref[RawT]` and `Expansion[RecordT, ChildRawT]` become `Generic`, covariant
+— the same variance already used for the one existing generic in this
+codebase, `Result[T, E]` (`networking/types.py`). Both use
+`typing_extensions.TypeVar(..., default=...)` (the PEP 696 backport; this
+repo supports Python `>=3.11`, and native `TypeVar` defaults require 3.13+)
+so that every existing bare usage keeps compiling unchanged: `RawT`
+defaults to `Mapping[str, object]`, matching `Ref.raw`'s current field
+type exactly.
+
+`Source[RefT]`, `Expander[RefT, RecordT, ChildRawT]`, and
+`Sink[RefT, RecordT]` each get one `TypeVar` per variance role — never a
+`TypeVar` reused across roles, which strict Pyright's
+`reportInvalidTypeVarUse` rejects for `Protocol` subclasses.
+
+`CrawlPlugin[TopRefT, LeafRefT, LeafRecordT]` takes exactly three type
+parameters — not one per pipeline stage. `expanders: Sequence[Expander]`
+is a single, homogeneous list covering an unbounded, heterogeneous chain:
+there is no way to express "expander *i* consumes what expander *i-1*
+produced" without variadic generics that would force a fixed maximum
+depth and break every existing adapter's `expanders` shape, including
+`ladon-hackernews`'s. `expanders` therefore stays
+`Sequence[Expander[Any, Any, Any]]` — one explicit, documented escape
+hatch for the chain interior. Only `source` and `sink` — single properties
+with single, fully knowable signatures — carry real type precision through
+`CrawlPlugin`.
+
+`CrawlPlan[LeafRefT]` becomes generic: leaf refs have one unambiguous
+source, `Sink`'s own ref parameter type. `RunResult` and
+`PluginRunResult` stay `object`-typed for `.record`/`.top_refs` — the
+*top* record has no equivalently clean single-boundary source, for the
+same chain-interior reason `expanders` does not.
+
+Two new callback type aliases replace the bare
+`Callable[[object, object], ...]` signatures and encode the ADR-011
+distinction in the type system:
+
+* `OnLeafCallback[RecordT, ParentT]` — used by `run_crawl`, `run_plugin`,
+  and their async equivalents. `ParentT` is pinned to `object`: `run_crawl`
+  threads `parent_record` across `plugin.expanders`, which is itself
+  `Any`-typed at the chain interior, so there is no type-safe source for a
+  precise `ParentT` here.
+* `OnPlannedLeafCallback[RecordT, LeafRefT]` — used by `execute_plan_sync`
+  and `execute_plan`, whose callback parameter is renamed from `on_leaf` to
+  `on_planned_leaf`. `LeafRefT` is fully precise, sourced from
+  `CrawlPlan[LeafRefT]`.
+
+Passing an `OnPlannedLeafCallback`-shaped function to `run_crawl`'s
+`on_leaf=` (or vice versa) is now a Pyright error instead of a silent
+runtime mismatch — this is the strongest concrete case for the change:
+today the only thing preventing that mistake is a sentence in a docstring.
+
+`persistence.protocol.Repository[T]` genericization is explicitly out of
+scope for this ADR. Its docstring already points at ADR-006, a distinct
+design context whose generic value depends on adapter-specific persistence
+wiring the runner does not control; conflating it with the SES boundary
+here would blur the review scope of both. A follow-up issue tracks it
+separately.
+
+### Consequences
+
+* **Good**: the three shipped example `cast(...)` call sites are
+  eliminated.
+* **Good**: the `run_crawl` vs `execute_plan_sync` callback-shape mismatch
+  becomes a compile-time error.
+* **Good**: zero runtime behavior change — `Protocol` `isinstance()` checks
+  and concrete method dispatch are unaffected by type parameters, the same
+  caveat ADR-014 already documents for its own protocols.
+* **Good**: existing untyped third-party adapters (e.g. `ladon-hackernews`)
+  need no code changes — `object`-typed methods trivially satisfy any
+  generic binding, and Pyright simply infers `object` at the call site,
+  matching today's behavior exactly.
+* **Neutral**: `expanders` and the runner's own Phase-1 loop body stay
+  `Any`/`object`-typed internally — only the plugin's `source`/`sink`
+  boundary and each adapter class's own method signatures gain precision.
+  This is a deliberate, bounded scope.
+* **Bad**: `execute_plan_sync`'s and `execute_plan`'s `on_leaf=` keyword
+  argument is renamed to `on_planned_leaf=` — a real, if narrow, breaking
+  change for any caller using the keyword form.
+* **Bad**: adds a new direct dependency, `typing_extensions>=4.6` (needed
+  for `TypeVar` defaults), already present transitively today.
+
+## Rejected Options
+
+**B — status quo:** leaves the three shipped example casts and the
+external `ladon-hackernews` `# type: ignore[arg-type]` uncorrected; the
+`on_leaf`/`on_planned_leaf` confusion stays a docstring-only convention
+with no compiler backing.
+
+**C — fully variadic per-level typing:** would require `TypeVarTuple`/
+`Unpack` threading one type per expansion depth, with no clean way to
+express "arbitrary but unknown length" short of a fixed maximum depth or a
+redesigned `expanders` property shape — breaking every existing adapter,
+including third-party ones. Rejected for the same reason ADR-014 rejected
+its own Option B (shared ABC): disproportionately invasive for the
+benefit.
+
+**D — concrete unions at every boundary:** the same rejection ADR-014
+already gave for its own Option C — duplicates adapter-shape knowledge
+into every public signature and requires every consumer annotation to
+change whenever a new adapter shape appears, defeating the purpose of the
+Source/Expander/Sink pipeline.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -20,6 +20,7 @@ chosen over the alternatives.
 | [ADR-011](adr-011-curl-cffi-cloudflare-bypass.md) | curl-cffi as the Cloudflare-Bypass HTTP Backend | Accepted |
 | [ADR-012](adr-012-session-contract-boundary.md) | Session Contract Boundary in `SyncPolicyBase` | Accepted |
 | [ADR-014](adr-014-http-client-protocols.md) | Structural HTTP Client Protocols | Accepted |
+| [ADR-015](adr-015-generic-ses-protocols.md) | Generic SES Protocol Types | Proposed |
 
 ## Format
 

--- a/examples/cookbook/async_crawl.py
+++ b/examples/cookbook/async_crawl.py
@@ -10,7 +10,6 @@ from threading import Thread
 from typing import cast
 
 from ladon import (
-    AsyncCrawlPlugin,
     AsyncHttpClient,
     AsyncHttpClientProtocol,
     Expansion,
@@ -95,15 +94,17 @@ class AsyncCatalogPlugin:
 async def crawl_one(base_url: str) -> RunResult:
     persisted: list[dict[str, object]] = []
 
-    async def persist(leaf_record: object, parent_record: object) -> None:
+    async def persist(
+        leaf_record: dict[str, object], parent_record: object
+    ) -> None:
         del parent_record
-        persisted.append(cast(dict[str, object], leaf_record))
+        persisted.append(leaf_record)
 
     config = HttpClientConfig(user_agent="my-async-crawler/1.0", retries=0)
     async with AsyncHttpClient(config) as client:
         result = await async_run_crawl(
             top_ref=Ref(f"{base_url}/listing"),
-            plugin=cast("AsyncCrawlPlugin", AsyncCatalogPlugin()),
+            plugin=AsyncCatalogPlugin(),
             client=client,
             config=RunConfig(leaf_limit=500, async_concurrency=20),
             on_leaf=persist,

--- a/examples/cookbook/flat_crawl.py
+++ b/examples/cookbook/flat_crawl.py
@@ -4,11 +4,9 @@
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import cast
 
 from ladon import (
     ChildListUnavailableError,
-    CrawlPlugin,
     Expansion,
     HttpClient,
     HttpClientConfig,
@@ -68,7 +66,7 @@ def run_example() -> PluginRunResult:
     with HttpClient(
         HttpClientConfig(user_agent="example-crawler/1.0")
     ) as client:
-        result = run_plugin(cast("CrawlPlugin", plugin), client, RunConfig())
+        result = run_plugin(plugin, client, RunConfig())
         print(result.leaves_consumed, result.errors)
         return result
 

--- a/examples/cookbook/tree_crawl_hackernews.py
+++ b/examples/cookbook/tree_crawl_hackernews.py
@@ -1,7 +1,7 @@
 """Crawl Hacker News comments using the external ladon-hackernews adapter."""
 
 # --8<-- [start:example]
-from typing import Protocol, cast
+from operator import attrgetter
 
 from ladon_hackernews import HNPlugin
 
@@ -15,12 +15,10 @@ from ladon import (
 )
 
 
-class HasId(Protocol):
-    id: object
-
-
 def print_comment(comment: object, story: object) -> None:
-    print(cast(HasId, story).id, cast(HasId, comment).id)
+    # Full precision requires ladon-hackernews to narrow its object signatures.
+    get_id = attrgetter("id")
+    print(get_id(story), get_id(comment))
 
 
 def run_example() -> list[RunResult]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "httpx>=0.27",
     "requests>=2.28",
+    "typing_extensions>=4.6",
 ]
 
 [project.scripts]

--- a/src/ladon/__init__.py
+++ b/src/ladon/__init__.py
@@ -3,6 +3,8 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .async_runner import (
+    AsyncOnLeafCallback,
+    AsyncOnPlannedLeafCallback,
     async_run_crawl,
     async_run_plugin,
     execute_plan,
@@ -52,6 +54,8 @@ from .plugins import (
 )
 from .runner import (
     CrawlPlan,
+    OnLeafCallback,
+    OnPlannedLeafCallback,
     PluginRunResult,
     RunConfig,
     RunResult,
@@ -87,11 +91,15 @@ __all__ = [
     "RunResult",
     "PluginRunResult",
     "CrawlPlan",
+    "OnLeafCallback",
+    "OnPlannedLeafCallback",
     # Runner — async
     "async_run_crawl",
     "async_run_plugin",
     "plan_crawl",
     "execute_plan",
+    "AsyncOnLeafCallback",
+    "AsyncOnPlannedLeafCallback",
     # Sync plugin protocols
     "CrawlPlugin",
     "Source",

--- a/src/ladon/async_runner.py
+++ b/src/ladon/async_runner.py
@@ -12,8 +12,9 @@ The plan/execute split (v0.3):
   ``execute_plan`` runs Phase 3 against an existing plan.
   ``async_run_crawl`` remains a self-contained Phase 1+3 entry point with the
   original ``on_leaf(leaf_record, parent_record)`` contract.
-  ``execute_plan``'s ``on_leaf`` receives ``(leaf_record, leaf_ref)``
-  per ADR-011 — different from ``async_run_crawl``'s contract.
+  ``execute_plan``'s ``on_planned_leaf`` receives
+  ``(leaf_record, leaf_ref)`` per ADR-011 and ADR-015 — different from
+  ``async_run_crawl``'s contract.
 
 ``ExpansionNotReadyError`` retains the same globally-fatal semantics as in
 the sync runner: when any expander raises it, the coroutine raises immediately
@@ -34,7 +35,9 @@ import asyncio
 import inspect
 import logging
 from collections.abc import Awaitable, Callable
-from typing import cast
+from typing import Any, cast
+
+from typing_extensions import TypeVar
 
 from ladon.networking.protocols import AsyncHttpClientProtocol
 from ladon.plugins.async_protocol import AsyncCrawlPlugin
@@ -52,6 +55,18 @@ from ladon.runner import (
     RunResult,
     log_leaf_exception,
 )
+
+AsyncLeafRecordT = TypeVar("AsyncLeafRecordT", default=object)
+AsyncParentT = TypeVar("AsyncParentT", default=object)
+AsyncPlannedLeafRefT = TypeVar("AsyncPlannedLeafRefT", default=object)
+AsyncPlanLeafRefT = TypeVar("AsyncPlanLeafRefT", default=object)
+
+AsyncOnLeafCallback = Callable[
+    [AsyncLeafRecordT, AsyncParentT], Awaitable[None]
+]
+AsyncOnPlannedLeafCallback = Callable[
+    [AsyncLeafRecordT, AsyncPlannedLeafRefT], Awaitable[None]
+]
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +99,10 @@ def _raise_first_fatal_outcome(
 
 async def async_run_crawl(
     top_ref: object,
-    plugin: AsyncCrawlPlugin,
+    plugin: AsyncCrawlPlugin[Any, Any, AsyncLeafRecordT],
     client: AsyncHttpClientProtocol,
     config: RunConfig,
-    on_leaf: Callable[[object, object], Awaitable[None]] | None = None,
+    on_leaf: AsyncOnLeafCallback[AsyncLeafRecordT, object] | None = None,
 ) -> RunResult:
     """Run a single top-level ref through an async plugin adapter stack.
 
@@ -282,10 +297,10 @@ async def async_run_crawl(
 
 
 async def async_run_plugin(
-    plugin: AsyncCrawlPlugin,
+    plugin: AsyncCrawlPlugin[Any, Any, AsyncLeafRecordT],
     client: AsyncHttpClientProtocol,
     config: RunConfig,
-    on_leaf: Callable[[object, object], Awaitable[None]] | None = None,
+    on_leaf: AsyncOnLeafCallback[AsyncLeafRecordT, object] | None = None,
 ) -> PluginRunResult:
     """Discover and run every top-level ref exposed by an async plugin.
 
@@ -327,9 +342,9 @@ async def async_run_plugin(
 
 async def plan_crawl(
     top_ref: object,
-    plugin: AsyncCrawlPlugin,
+    plugin: AsyncCrawlPlugin[Any, AsyncPlanLeafRefT, Any],
     client: AsyncHttpClientProtocol,
-) -> CrawlPlan:
+) -> CrawlPlan[AsyncPlanLeafRefT]:
     """Run Phase 1 (tree traversal) asynchronously and return a CrawlPlan.
 
     Traverses all expanders in order and collects every leaf ref.  Does not
@@ -388,19 +403,26 @@ async def plan_crawl(
         "plan_crawl finished",
         extra={"plugin": plugin.name, "leaf_count": len(current_refs)},
     )
-    return CrawlPlan(
-        record=top_record,
-        leaves=tuple(current_refs),
-        errors=tuple(errors),
+    # This cast is where the deliberately erased chain interior meets the sink.
+    return cast(
+        "CrawlPlan[AsyncPlanLeafRefT]",
+        CrawlPlan(
+            record=top_record,
+            leaves=tuple(current_refs),
+            errors=tuple(errors),
+        ),
     )
 
 
 async def execute_plan(
-    plan: CrawlPlan,
-    plugin: AsyncCrawlPlugin,
+    plan: CrawlPlan[AsyncPlannedLeafRefT],
+    plugin: AsyncCrawlPlugin[Any, AsyncPlannedLeafRefT, AsyncLeafRecordT],
     client: AsyncHttpClientProtocol,
     config: RunConfig,
-    on_leaf: Callable[[object, object], Awaitable[None]] | None = None,
+    on_planned_leaf: (
+        AsyncOnPlannedLeafCallback[AsyncLeafRecordT, AsyncPlannedLeafRefT]
+        | None
+    ) = None,
     on_progress: Callable[[int, int], None] | None = None,
 ) -> RunResult:
     """Run Phase 3 (leaf fetching) asynchronously against an existing CrawlPlan.
@@ -413,9 +435,10 @@ async def execute_plan(
                      If the plan was already narrowed with ``CrawlPlan.limited_to()``,
                      both that cap and ``config.leaf_limit`` apply independently —
                      the tighter of the two wins.
-        on_leaf:     Optional async callback receiving ``(leaf_record, leaf_ref)``
-                     after each successful consume.  Note: second argument is the
-                     **leaf ref**, not a parent record (see ADR-011).
+        on_planned_leaf: Optional async callback receiving
+                     ``(leaf_record, leaf_ref)`` after each successful consume.
+                     The second argument is the **leaf ref**, not a parent
+                     record; ADR-015 enforces ADR-011's distinction in types.
         on_progress: Optional **synchronous** callback receiving
                      ``(leaves_done, total_leaves)`` after each leaf attempt
                      (success or failure).  Called from inside concurrent leaf
@@ -440,8 +463,8 @@ async def execute_plan(
                                 plugin error propagates.
         TypeError:               ``on_progress`` is an async callable; only
                                 synchronous callables are supported.
-        asyncio.CancelledError: A leaf consume or ``on_leaf`` callback, or an
-                                ``on_progress`` callback, was cancelled.
+        asyncio.CancelledError: A leaf consume or ``on_planned_leaf`` callback,
+                                or an ``on_progress`` callback, was cancelled.
         BaseException:          Other fatal BaseException subclasses raised
                                 by a leaf task propagate unchanged.
     """
@@ -469,12 +492,12 @@ async def execute_plan(
     done_count = 0
 
     async def _process_leaf(
-        i: int, leaf_ref: object
+        i: int, leaf_ref: AsyncPlannedLeafRefT
     ) -> tuple[bool, bool, list[str]] | BaseException:
         """Returns (consumed, persisted, leaf_errors).
 
         consumed=True  when sink.consume() succeeded.
-        persisted=True when consumed AND on_leaf succeeded (or no callback).
+        persisted=True when consumed AND on_planned_leaf succeeded (or no callback).
         leaf_errors    holds at most one error string.
         """
         nonlocal done_count
@@ -536,16 +559,16 @@ async def execute_plan(
                 # original exception unchanged.
                 return exc
 
-            if on_leaf is not None:
+            if on_planned_leaf is not None:
                 try:
-                    await on_leaf(leaf_record, leaf_ref)
+                    await on_planned_leaf(leaf_record, leaf_ref)
                     done_count += 1
                     if (progress_error := _fire_progress()) is not None:
                         return progress_error
                     return (True, True, [])
                 except Exception as exc:
                     logger.warning(
-                        "on_leaf callback failed — ref[%d] error=%s",
+                        "on_planned_leaf callback failed — ref[%d] error=%s",
                         i,
                         exc,
                         extra={

--- a/src/ladon/plugins/async_protocol.py
+++ b/src/ladon/plugins/async_protocol.py
@@ -12,38 +12,78 @@ The three-layer pipeline is:
 
     AsyncSource  →  [AsyncExpander, ...]  →  AsyncSink
 
-``AsyncSource`` discovers top-level refs. Each ``AsyncExpander`` awaits
-a ref and returns an ``Expansion``. ``AsyncSink`` awaits a leaf ref and
-returns a final record. ``AsyncCrawlPlugin`` bundles all three.
+``AsyncSource[RefT]`` discovers top-level refs. Each
+``AsyncExpander[RefT, RecordT, ChildRawT]`` awaits a ref and returns an
+``Expansion``. ``AsyncSink[RefT, RecordT]`` awaits a leaf ref and returns a
+final record. ``AsyncCrawlPlugin[TopRefT, LeafRefT, LeafRecordT]`` bundles
+all three.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Protocol, runtime_checkable
+from typing import runtime_checkable
+
+from typing_extensions import Any, Protocol, TypeVar
 
 from ..networking.protocols import AsyncHttpClientProtocol
 from .models import Expansion
 
+AsyncSourceRefT_co = TypeVar(
+    "AsyncSourceRefT_co", covariant=True, default=object
+)
+AsyncExpanderRefT_contra = TypeVar(
+    "AsyncExpanderRefT_contra", contravariant=True, default=object
+)
+AsyncExpanderRecordT_co = TypeVar(
+    "AsyncExpanderRecordT_co", covariant=True, default=object
+)
+AsyncExpanderChildRawT_co = TypeVar(
+    "AsyncExpanderChildRawT_co", covariant=True, default=object
+)
+AsyncSinkRefT_contra = TypeVar(
+    "AsyncSinkRefT_contra", contravariant=True, default=object
+)
+AsyncSinkRecordT_co = TypeVar(
+    "AsyncSinkRecordT_co", covariant=True, default=object
+)
+AsyncPluginTopRefT_co = TypeVar(
+    "AsyncPluginTopRefT_co", covariant=True, default=object
+)
+AsyncPluginLeafRefT_contra = TypeVar(
+    "AsyncPluginLeafRefT_contra", contravariant=True, default=object
+)
+AsyncPluginLeafRecordT_co = TypeVar(
+    "AsyncPluginLeafRecordT_co", covariant=True, default=object
+)
+
 
 @runtime_checkable
-class AsyncSource(Protocol):
+class AsyncSource(Protocol[AsyncSourceRefT_co]):
     """Discover top-level refs from an external source, asynchronously."""
 
     async def discover(
         self, client: AsyncHttpClientProtocol
-    ) -> Sequence[object]:
+    ) -> Sequence[AsyncSourceRefT_co]:
         """Return all discoverable top-level references."""
         ...
 
 
 @runtime_checkable
-class AsyncExpander(Protocol):
+class AsyncExpander(
+    Protocol[
+        AsyncExpanderRefT_contra,
+        AsyncExpanderRecordT_co,
+        AsyncExpanderChildRawT_co,
+    ]
+):
     """Expand one ref into a record plus child refs, asynchronously."""
 
     async def expand(
-        self, ref: object, client: AsyncHttpClientProtocol
-    ) -> Expansion:
+        self,
+        ref: AsyncExpanderRefT_contra,
+        client: AsyncHttpClientProtocol,
+    ) -> Expansion[AsyncExpanderRecordT_co, AsyncExpanderChildRawT_co]:
         """Fetch ref, return its record and the child refs to process next.
 
         Raises:
@@ -55,12 +95,12 @@ class AsyncExpander(Protocol):
 
 
 @runtime_checkable
-class AsyncSink(Protocol):
+class AsyncSink(Protocol[AsyncSinkRefT_contra, AsyncSinkRecordT_co]):
     """Consume a leaf ref and return its final record, asynchronously."""
 
     async def consume(
-        self, ref: object, client: AsyncHttpClientProtocol
-    ) -> object:
+        self, ref: AsyncSinkRefT_contra, client: AsyncHttpClientProtocol
+    ) -> AsyncSinkRecordT_co:
         """Fetch and parse one leaf ref, returning a complete record.
 
         Context for the leaf flows through ``ref.raw`` — no parent-record
@@ -73,23 +113,34 @@ class AsyncSink(Protocol):
 
 
 @runtime_checkable
-class AsyncCrawlPlugin(Protocol):
+class AsyncCrawlPlugin(
+    Protocol[
+        AsyncPluginTopRefT_co,
+        AsyncPluginLeafRefT_contra,
+        AsyncPluginLeafRecordT_co,
+    ]
+):
     """Bundle of all async adapters for one crawl domain.
 
     ``name`` is a short identifier used in log lines and error messages.
     ``source`` discovers top-level refs. ``expanders`` is an ordered list
     of async expansion steps. ``sink`` consumes the leaf refs produced by
     the last expander.
+
+    The heterogeneous chain interior deliberately uses ``Any`` because a
+    single homogeneous sequence cannot express per-stage types; see ADR-015.
     """
 
     @property
     def name(self) -> str: ...
 
     @property
-    def source(self) -> AsyncSource: ...
+    def source(self) -> AsyncSource[AsyncPluginTopRefT_co]: ...
 
     @property
-    def expanders(self) -> Sequence[AsyncExpander]: ...
+    def expanders(self) -> Sequence[AsyncExpander[Any, Any, Any]]: ...
 
     @property
-    def sink(self) -> AsyncSink: ...
+    def sink(
+        self,
+    ) -> AsyncSink[AsyncPluginLeafRefT_contra, AsyncPluginLeafRecordT_co]: ...

--- a/src/ladon/plugins/models.py
+++ b/src/ladon/plugins/models.py
@@ -4,14 +4,23 @@ All models are frozen dataclasses. Adapters produce them; the runner
 consumes them. The ``raw`` field on ``Ref`` carries house-specific data
 that does not fit the shared schema.
 
-``Expansion`` is returned by an ``Expander`` and carries the record for
-the current node plus the child refs to be expanded or consumed next.
+``Ref[RawT]`` preserves adapter-specific raw context. ``Expansion[RecordT,
+ChildRawT]`` carries the current record and typed child refs to the next stage.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from typing import Generic, overload
+
+from typing_extensions import TypeVar
+
+RawT = TypeVar("RawT", covariant=True, default=Mapping[str, object])
+RecordT_co = TypeVar("RecordT_co", covariant=True, default=object)
+ChildRawT_co = TypeVar("ChildRawT_co", covariant=True, default=object)
+
+_MISSING_RAW = object()
 
 
 def _empty_raw() -> dict[str, object]:
@@ -19,26 +28,41 @@ def _empty_raw() -> dict[str, object]:
     return {}
 
 
-@dataclass(frozen=True)
-class Ref:
+@dataclass(frozen=True, init=False)
+class Ref(Generic[RawT]):
     """Generic reference to any crawlable resource.
 
     ``url`` is the canonical URL of the resource. ``raw`` carries any
-    house-specific data discovered alongside the URL (e.g. an ID or
-    code needed by the expander).
+    house-specific data discovered alongside the URL (e.g. an ID or code
+    needed by the expander). Omitting ``raw`` selects the default
+    ``Mapping[str, object]`` specialization and supplies an empty dict.
     """
 
     url: str
-    raw: Mapping[str, object] = field(default_factory=_empty_raw)
+    # The constructor overloads constrain omission to the default specialization.
+    raw: RawT = field(default_factory=_empty_raw)  # type: ignore[assignment]
+
+    @overload
+    def __init__(self: Ref[Mapping[str, object]], url: str) -> None: ...
+
+    @overload
+    def __init__(self, url: str, raw: RawT) -> None: ...
+
+    def __init__(self, url: str, raw: object = _MISSING_RAW) -> None:
+        """Initialize a reference while preserving frozen-dataclass semantics."""
+        object.__setattr__(self, "url", url)
+        object.__setattr__(
+            self, "raw", _empty_raw() if raw is _MISSING_RAW else raw
+        )
 
 
 @dataclass(frozen=True)
-class Expansion:
+class Expansion(Generic[RecordT_co, ChildRawT_co]):
     """Result of an Expander.expand() call.
 
     Carries the record for the expanded node plus the child refs to be
     processed next (either expanded further or consumed by a Sink).
     """
 
-    record: object
-    child_refs: Sequence[object]
+    record: RecordT_co
+    child_refs: Sequence[Ref[ChildRawT_co]]

--- a/src/ladon/plugins/protocol.py
+++ b/src/ladon/plugins/protocol.py
@@ -12,34 +12,68 @@ The three-layer pipeline is:
 
     Source  →  [Expander, ...]  →  Sink
 
-``Source`` produces top-level refs. Each ``Expander`` takes a ref and
-returns an ``Expansion`` (record + child refs). ``Sink`` takes a leaf
-ref and returns a final record. ``CrawlPlugin`` bundles all three.
+``Source[RefT]`` produces top-level refs. Each
+``Expander[RefT, RecordT, ChildRawT]`` takes a ref and returns an
+``Expansion`` (record + child refs). ``Sink[RefT, RecordT]`` takes a leaf
+ref and returns a final record. ``CrawlPlugin[TopRefT, LeafRefT,
+LeafRecordT]`` bundles all three.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Protocol, runtime_checkable
+from typing import runtime_checkable
+
+from typing_extensions import Any, Protocol, TypeVar
 
 from ..networking.protocols import SyncHttpClientProtocol
 from .models import Expansion
 
+SourceRefT_co = TypeVar("SourceRefT_co", covariant=True, default=object)
+ExpanderRefT_contra = TypeVar(
+    "ExpanderRefT_contra", contravariant=True, default=object
+)
+ExpanderRecordT_co = TypeVar(
+    "ExpanderRecordT_co", covariant=True, default=object
+)
+ExpanderChildRawT_co = TypeVar(
+    "ExpanderChildRawT_co", covariant=True, default=object
+)
+SinkRefT_contra = TypeVar("SinkRefT_contra", contravariant=True, default=object)
+SinkRecordT_co = TypeVar("SinkRecordT_co", covariant=True, default=object)
+PluginTopRefT_co = TypeVar("PluginTopRefT_co", covariant=True, default=object)
+PluginLeafRefT_contra = TypeVar(
+    "PluginLeafRefT_contra", contravariant=True, default=object
+)
+PluginLeafRecordT_co = TypeVar(
+    "PluginLeafRecordT_co", covariant=True, default=object
+)
+
 
 @runtime_checkable
-class Source(Protocol):
+class Source(Protocol[SourceRefT_co]):
     """Discover top-level refs from an external source."""
 
-    def discover(self, client: SyncHttpClientProtocol) -> Sequence[object]:
+    def discover(
+        self, client: SyncHttpClientProtocol
+    ) -> Sequence[SourceRefT_co]:
         """Return all discoverable top-level references."""
         ...
 
 
 @runtime_checkable
-class Expander(Protocol):
+class Expander(
+    Protocol[
+        ExpanderRefT_contra,
+        ExpanderRecordT_co,
+        ExpanderChildRawT_co,
+    ]
+):
     """Expand one ref into a record plus child refs."""
 
-    def expand(self, ref: object, client: SyncHttpClientProtocol) -> Expansion:
+    def expand(
+        self, ref: ExpanderRefT_contra, client: SyncHttpClientProtocol
+    ) -> Expansion[ExpanderRecordT_co, ExpanderChildRawT_co]:
         """Fetch ref, return its record and the child refs to process next.
 
         Raises:
@@ -51,10 +85,12 @@ class Expander(Protocol):
 
 
 @runtime_checkable
-class Sink(Protocol):
+class Sink(Protocol[SinkRefT_contra, SinkRecordT_co]):
     """Consume a leaf ref and return its final record."""
 
-    def consume(self, ref: object, client: SyncHttpClientProtocol) -> object:
+    def consume(
+        self, ref: SinkRefT_contra, client: SyncHttpClientProtocol
+    ) -> SinkRecordT_co:
         """Fetch and parse one leaf ref, returning a complete record.
 
         Context for the leaf (e.g. parent data) flows through
@@ -67,7 +103,13 @@ class Sink(Protocol):
 
 
 @runtime_checkable
-class CrawlPlugin(Protocol):
+class CrawlPlugin(
+    Protocol[
+        PluginTopRefT_co,
+        PluginLeafRefT_contra,
+        PluginLeafRecordT_co,
+    ]
+):
     """Bundle of all adapters for one crawl domain.
 
     ``name`` is a short identifier used in log lines and error messages
@@ -75,6 +117,9 @@ class CrawlPlugin(Protocol):
     top-level refs. ``expanders`` is an ordered list of expansion steps
     (one per tree level above the leaves). ``sink`` consumes the leaf
     refs produced by the last expander.
+
+    The heterogeneous chain interior deliberately uses ``Any`` because a
+    single homogeneous sequence cannot express per-stage types; see ADR-015.
 
     CLI convention
     --------------
@@ -89,10 +134,10 @@ class CrawlPlugin(Protocol):
     def name(self) -> str: ...
 
     @property
-    def source(self) -> Source: ...
+    def source(self) -> Source[PluginTopRefT_co]: ...
 
     @property
-    def expanders(self) -> Sequence[Expander]: ...
+    def expanders(self) -> Sequence[Expander[Any, Any, Any]]: ...
 
     @property
-    def sink(self) -> Sink: ...
+    def sink(self) -> Sink[PluginLeafRefT_contra, PluginLeafRecordT_co]: ...

--- a/src/ladon/runner.py
+++ b/src/ladon/runner.py
@@ -22,15 +22,18 @@ The plan/execute split (v0.3):
   ``execute_plan_sync`` runs Phase 3 against an existing plan.
   ``run_crawl`` remains a self-contained Phase 1+3 entry point with the
   original ``on_leaf(leaf_record, parent_record)`` contract.
-  ``execute_plan_sync``'s ``on_leaf`` receives ``(leaf_record, leaf_ref)``
-  per ADR-011 — different from ``run_crawl``'s contract.
+  ``execute_plan_sync``'s ``on_planned_leaf`` receives
+  ``(leaf_record, leaf_ref)`` per ADR-011 and ADR-015 — different from
+  ``run_crawl``'s contract.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable, Generic, cast
+
+from typing_extensions import TypeVar
 
 from ladon.networking.protocols import SyncHttpClientProtocol
 from ladon.plugins.errors import (
@@ -41,6 +44,14 @@ from ladon.plugins.errors import (
     PartialExpansionError,
 )
 from ladon.plugins.protocol import CrawlPlugin
+
+LeafRefT = TypeVar("LeafRefT", default=object)
+LeafRecordT = TypeVar("LeafRecordT", default=object)
+ParentT = TypeVar("ParentT", default=object)
+PlannedLeafRefT = TypeVar("PlannedLeafRefT", default=object)
+
+OnLeafCallback = Callable[[LeafRecordT, ParentT], None]
+OnPlannedLeafCallback = Callable[[LeafRecordT, PlannedLeafRefT], None]
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +86,7 @@ def log_leaf_exception(
 
 
 @dataclass(frozen=True)
-class CrawlPlan:
+class CrawlPlan(Generic[LeafRefT]):
     """Immutable output of ``plan_crawl_sync()`` / ``plan_crawl()``.
 
     Carries the top-level record, all leaf refs collected during Phase 1
@@ -85,10 +96,12 @@ class CrawlPlan:
     """
 
     record: object
-    leaves: tuple[object, ...]
+    leaves: tuple[LeafRefT, ...]
     errors: tuple[str, ...]
 
-    def excluding(self, predicate: Callable[[object], bool]) -> CrawlPlan:
+    def excluding(
+        self, predicate: Callable[[LeafRefT], bool]
+    ) -> CrawlPlan[LeafRefT]:
         """Return a new plan with leaves for which predicate is True removed."""
         return CrawlPlan(
             record=self.record,
@@ -96,7 +109,7 @@ class CrawlPlan:
             errors=self.errors,
         )
 
-    def limited_to(self, n: int) -> CrawlPlan:
+    def limited_to(self, n: int) -> CrawlPlan[LeafRefT]:
         """Return a new plan capped at the first n leaves.
 
         ``n`` must be a positive integer; ``0`` and negative values raise
@@ -127,9 +140,10 @@ class RunConfig:
     no limit. ``run_plugin()`` applies the same cap independently to every
     root discovered by its source.
     ``async_concurrency`` bounds the number of concurrent leaf-processing
-    slots in ``async_run_crawl`` — each slot covers the full
-    ``sink.consume()`` + ``on_leaf`` pair, so slow callbacks reduce effective
-    fetch concurrency.  Ignored by the sync ``run_crawl()``.
+    slots in ``async_run_crawl()`` and ``execute_plan()`` — each slot covers
+    the full ``sink.consume()`` + callback pair, so slow ``on_leaf`` or
+    ``on_planned_leaf`` callbacks reduce effective fetch concurrency. Ignored
+    by the synchronous runners.
     """
 
     leaf_limit: int = 0
@@ -147,12 +161,13 @@ class RunResult:
     """Outcome of a crawl run — returned by run_crawl(), execute_plan_sync(), and execute_plan().
 
     ``leaves_consumed`` counts leaves for which ``sink.consume()`` succeeded,
-    regardless of whether the ``on_leaf`` callback also succeeded.
+    regardless of whether the applicable ``on_leaf`` or ``on_planned_leaf``
+    callback also succeeded.
 
     ``leaves_persisted`` counts leaves for which the full pipeline succeeded:
-    ``sink.consume()`` completed *and* the ``on_leaf`` callback completed
-    without raising.  When no callback is supplied, ``leaves_persisted``
-    equals ``leaves_consumed`` (the pipeline trivially succeeds after consume).
+    ``sink.consume()`` completed *and* the applicable callback completed
+    without raising. When no callback is supplied, ``leaves_persisted`` equals
+    ``leaves_consumed`` (the pipeline trivially succeeds after consume).
 
     ``leaves_failed`` counts leaves for which ``sink.consume()`` raised a
     non-fatal exception. Callback failures are NOT included here — derive them
@@ -226,10 +241,10 @@ class PluginRunResult:
 
 def run_crawl(
     top_ref: object,
-    plugin: CrawlPlugin,
+    plugin: CrawlPlugin[Any, Any, LeafRecordT],
     client: SyncHttpClientProtocol,
     config: RunConfig,
-    on_leaf: Callable[[object, object], None] | None = None,
+    on_leaf: OnLeafCallback[LeafRecordT, object] | None = None,
 ) -> RunResult:
     """Run a single top-level ref through the plugin adapter stack.
 
@@ -408,10 +423,10 @@ def run_crawl(
 
 
 def run_plugin(
-    plugin: CrawlPlugin,
+    plugin: CrawlPlugin[Any, Any, LeafRecordT],
     client: SyncHttpClientProtocol,
     config: RunConfig,
-    on_leaf: Callable[[object, object], None] | None = None,
+    on_leaf: OnLeafCallback[LeafRecordT, object] | None = None,
 ) -> PluginRunResult:
     """Discover and run every top-level ref exposed by a sync plugin.
 
@@ -462,9 +477,9 @@ def run_plugin(
 
 def plan_crawl_sync(
     top_ref: object,
-    plugin: CrawlPlugin,
+    plugin: CrawlPlugin[Any, LeafRefT, Any],
     client: SyncHttpClientProtocol,
-) -> CrawlPlan:
+) -> CrawlPlan[LeafRefT]:
     """Run Phase 1 (tree traversal) synchronously and return a CrawlPlan.
 
     Traverses all expanders in order and collects every leaf ref.  Does not
@@ -522,19 +537,25 @@ def plan_crawl_sync(
         "plan_crawl_sync finished",
         extra={"plugin": plugin.name, "leaf_count": len(current_refs)},
     )
-    return CrawlPlan(
-        record=top_record,
-        leaves=tuple(current_refs),
-        errors=tuple(errors),
+    # This cast is where the deliberately erased chain interior meets the sink.
+    return cast(
+        "CrawlPlan[LeafRefT]",
+        CrawlPlan(
+            record=top_record,
+            leaves=tuple(current_refs),
+            errors=tuple(errors),
+        ),
     )
 
 
 def execute_plan_sync(
-    plan: CrawlPlan,
-    plugin: CrawlPlugin,
+    plan: CrawlPlan[PlannedLeafRefT],
+    plugin: CrawlPlugin[Any, PlannedLeafRefT, LeafRecordT],
     client: SyncHttpClientProtocol,
     config: RunConfig,
-    on_leaf: Callable[[object, object], None] | None = None,
+    on_planned_leaf: (
+        OnPlannedLeafCallback[LeafRecordT, PlannedLeafRefT] | None
+    ) = None,
     on_progress: Callable[[int, int], None] | None = None,
 ) -> RunResult:
     """Run Phase 3 (leaf fetching) against an existing CrawlPlan.
@@ -546,9 +567,10 @@ def execute_plan_sync(
         config:      Run-level configuration (leaf_limit; async_concurrency ignored).
                      If the plan was already narrowed with ``CrawlPlan.limited_to()``,
                      both caps apply independently — the tighter of the two wins.
-        on_leaf:     Optional callback receiving ``(leaf_record, leaf_ref)``
-                     after each successful consume.  Note: second argument is the
-                     **leaf ref**, not a parent record (see ADR-011).
+        on_planned_leaf: Optional callback receiving
+                     ``(leaf_record, leaf_ref)`` after each successful consume.
+                     The second argument is the **leaf ref**, not a parent
+                     record; ADR-015 enforces ADR-011's distinction in types.
         on_progress: Optional callback receiving ``(leaves_done, total_leaves)``
                      after each leaf attempt (success or failure).  Ordinary
                      ``Exception`` subclasses raised by this callback are logged
@@ -568,7 +590,7 @@ def execute_plan_sync(
         AssetDownloadError: Raised from the Sink. This explicitly fatal
                             plugin error propagates.
         BaseException:      KeyboardInterrupt and other fatal errors raised by
-                            the Sink or ``on_leaf`` propagate unchanged.
+                            the Sink or ``on_planned_leaf`` propagate unchanged.
     """
     leaves = plan.leaves
     if config.leaf_limit > 0:
@@ -638,14 +660,14 @@ def execute_plan_sync(
 
         leaves_consumed += 1
 
-        if on_leaf is not None:
+        if on_planned_leaf is not None:
             try:
-                on_leaf(leaf_record, leaf_ref)
+                on_planned_leaf(leaf_record, leaf_ref)
                 leaves_persisted += 1
             except Exception as exc:
                 errors.append(f"ref[{i}] callback failed: {exc}")
                 logger.warning(
-                    "on_leaf callback failed — ref[%d] error=%s",
+                    "on_planned_leaf callback failed — ref[%d] error=%s",
                     i,
                     exc,
                     extra={

--- a/tests/plugins/test_async_protocol.py
+++ b/tests/plugins/test_async_protocol.py
@@ -7,7 +7,9 @@ All isinstance checks are synchronous — pytest-asyncio is not required.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
+from ladon.networking.protocols import AsyncHttpClientProtocol
 from ladon.plugins.async_protocol import (
     AsyncCrawlPlugin,
     AsyncExpander,
@@ -52,6 +54,60 @@ class _MockAsyncPlugin:
     @property
     def sink(self) -> _MockAsyncSink:
         return _MockAsyncSink()
+
+
+@dataclass(frozen=True)
+class _TypedAsyncRecord:
+    value: int
+
+
+class _TypedAsyncSource:
+    async def discover(
+        self, client: AsyncHttpClientProtocol
+    ) -> Sequence[Ref[dict[str, str]]]:
+        return (Ref("https://typed.example/top", {"kind": "top"}),)
+
+
+class _TypedAsyncExpander:
+    async def expand(
+        self,
+        ref: Ref[dict[str, str]],
+        client: AsyncHttpClientProtocol,
+    ) -> Expansion[_TypedAsyncRecord, dict[str, int]]:
+        return Expansion(
+            _TypedAsyncRecord(0),
+            (Ref(f"{ref.url}/leaf", {"leaf_id": 1}),),
+        )
+
+
+class _TypedAsyncSink:
+    async def consume(
+        self,
+        ref: Ref[dict[str, int]],
+        client: AsyncHttpClientProtocol,
+    ) -> _TypedAsyncRecord:
+        return _TypedAsyncRecord(ref.raw["leaf_id"])
+
+
+@dataclass(frozen=True)
+class _TypedAsyncPlugin:
+    name: str = "typed_async_plugin"
+    source: _TypedAsyncSource = _TypedAsyncSource()
+    expanders: Sequence[_TypedAsyncExpander] = (_TypedAsyncExpander(),)
+    sink: _TypedAsyncSink = _TypedAsyncSink()
+
+
+# These assignments are static conformance checks with no boundary casts.
+_concrete_async_source: AsyncSource[Ref[dict[str, str]]] = _TypedAsyncSource()
+_concrete_async_expander: AsyncExpander[
+    Ref[dict[str, str]], _TypedAsyncRecord, dict[str, int]
+] = _TypedAsyncExpander()
+_concrete_async_sink: AsyncSink[Ref[dict[str, int]], _TypedAsyncRecord] = (
+    _TypedAsyncSink()
+)
+_concrete_async_plugin: AsyncCrawlPlugin[
+    Ref[dict[str, str]], Ref[dict[str, int]], _TypedAsyncRecord
+] = _TypedAsyncPlugin()
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +217,9 @@ class TestAsyncCrawlPluginProtocol:
     def test_sink_property_type(self) -> None:
         plugin = _MockAsyncPlugin()
         assert isinstance(plugin.sink, AsyncSink)
+
+    def test_concretely_typed_plugin_satisfied(self) -> None:
+        assert isinstance(_TypedAsyncPlugin(), AsyncCrawlPlugin)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_models.py
+++ b/tests/plugins/test_models.py
@@ -4,7 +4,13 @@
 
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError
+import json
+import subprocess
+import sys
+from collections.abc import Mapping
+from dataclasses import MISSING, FrozenInstanceError, fields
+from pathlib import Path
+from typing import assert_type
 
 import pytest
 
@@ -20,6 +26,53 @@ class TestRef:
     def test_raw_preserved(self) -> None:
         ref = Ref(url="https://example.com/resource/1", raw={"code": "X001"})
         assert ref.raw["code"] == "X001"
+
+    def test_omitted_raw_uses_default_specialization(self) -> None:
+        ref = assert_type(
+            Ref("https://example.com/resource/1"),
+            Ref[Mapping[str, object]],
+        )
+        assert ref.raw == {}
+
+    def test_raw_retains_dataclass_default_factory(self) -> None:
+        raw_field = next(field for field in fields(Ref) if field.name == "raw")
+        default_factory = raw_field.default_factory
+        assert default_factory is not MISSING
+        first = default_factory()
+        second = default_factory()
+        assert first == second == {}
+        assert first is not second
+
+    def test_explicit_specialization_requires_raw(self, tmp_path: Path) -> None:
+        source = tmp_path / "invalid_ref.py"
+        source.write_text(
+            "from dataclasses import dataclass\n"
+            "from ladon import Ref\n\n"
+            "@dataclass(frozen=True)\n"
+            "class RawContext:\n"
+            "    value: int\n\n"
+            'invalid = Ref[RawContext]("https://example.com")\n'
+        )
+        config = tmp_path / "pyrightconfig.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "typeCheckingMode": "strict",
+                    "include": [str(source)],
+                    "extraPaths": [str(Path(__file__).parents[2] / "src")],
+                }
+            )
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-m", "pyright", "--project", str(config)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 1
+        assert 'Argument missing for parameter "raw"' in result.stdout
 
     def test_immutable(self) -> None:
         ref = Ref(url="https://example.com/resource/1")

--- a/tests/plugins/test_protocol.py
+++ b/tests/plugins/test_protocol.py
@@ -115,6 +115,58 @@ _typed_sink: Sink = _MockSink()
 _typed_plugin: CrawlPlugin = _MockPlugin([])
 
 
+@dataclass(frozen=True)
+class _TypedRecord:
+    value: int
+
+
+class _TypedSource:
+    def discover(
+        self, client: SyncHttpClientProtocol
+    ) -> Sequence[Ref[dict[str, str]]]:
+        return (Ref("https://typed.example/top", {"kind": "top"}),)
+
+
+class _TypedExpander:
+    def expand(
+        self,
+        ref: Ref[dict[str, str]],
+        client: SyncHttpClientProtocol,
+    ) -> Expansion[_DemoRecord, dict[str, int]]:
+        return Expansion(
+            _make_record(),
+            (Ref(f"{ref.url}/leaf", {"leaf_id": 1}),),
+        )
+
+
+class _TypedSink:
+    def consume(
+        self,
+        ref: Ref[dict[str, int]],
+        client: SyncHttpClientProtocol,
+    ) -> _TypedRecord:
+        return _TypedRecord(ref.raw["leaf_id"])
+
+
+@dataclass(frozen=True)
+class _TypedPlugin:
+    name: str = "typed_plugin"
+    source: _TypedSource = _TypedSource()
+    expanders: Sequence[_TypedExpander] = (_TypedExpander(),)
+    sink: _TypedSink = _TypedSink()
+
+
+# These assignments are static conformance checks with no boundary casts.
+_concrete_source: Source[Ref[dict[str, str]]] = _TypedSource()
+_concrete_expander: Expander[
+    Ref[dict[str, str]], _DemoRecord, dict[str, int]
+] = _TypedExpander()
+_concrete_sink: Sink[Ref[dict[str, int]], _TypedRecord] = _TypedSink()
+_concrete_plugin: CrawlPlugin[
+    Ref[dict[str, str]], Ref[dict[str, int]], _TypedRecord
+] = _TypedPlugin()
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -169,6 +221,9 @@ class TestProtocolStructure:
 
     def test_crawl_plugin_name(self, plugin: _MockPlugin) -> None:
         assert plugin.name == "mock_plugin"
+
+    def test_concretely_typed_plugin_satisfied(self) -> None:
+        assert isinstance(_TypedPlugin(), CrawlPlugin)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_async_plugin_runner.py
+++ b/tests/test_async_plugin_runner.py
@@ -56,8 +56,9 @@ class _AsyncExpander:
         if self._error is not None:
             raise self._error
         assert isinstance(ref, Ref)
+        typed_ref = Ref(ref.url)
         if self._error_for is not None:
-            error = self._error_for(ref)
+            error = self._error_for(typed_ref)
             if error is not None:
                 raise error
         return Expansion(
@@ -74,7 +75,8 @@ class _AsyncSink:
         self, ref: object, client: AsyncHttpClientProtocol
     ) -> _Record:
         assert isinstance(ref, Ref)
-        if self._fail(ref):
+        typed_ref = Ref(ref.url)
+        if self._fail(typed_ref):
             raise LeafUnavailableError("unavailable")
         return _Record(ref.url)
 

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -113,6 +113,42 @@ class _MockAsyncPlugin:
 _typed_async_plugin: AsyncCrawlPlugin = _MockAsyncPlugin([])
 
 
+class _PreciseAsyncSource:
+    async def discover(
+        self, client: AsyncHttpClientProtocol
+    ) -> Sequence[Ref[dict[str, str]]]:
+        return (Ref("https://typed.example/top", {"kind": "top"}),)
+
+
+class _PreciseAsyncExpander:
+    async def expand(
+        self,
+        ref: Ref[dict[str, str]],
+        client: AsyncHttpClientProtocol,
+    ) -> Expansion[_DemoRecord, dict[str, int]]:
+        return Expansion(
+            _DemoRecord(),
+            (Ref(f"{ref.url}/leaf", {"leaf_id": 7}),),
+        )
+
+
+class _PreciseAsyncSink:
+    async def consume(
+        self,
+        ref: Ref[dict[str, int]],
+        client: AsyncHttpClientProtocol,
+    ) -> _DemoLeafRecord:
+        return _DemoLeafRecord(str(ref.raw["leaf_id"]), ref.url)
+
+
+@dataclass(frozen=True)
+class _PreciseAsyncPlugin:
+    name: str = "precise_async_plugin"
+    source: _PreciseAsyncSource = _PreciseAsyncSource()
+    expanders: Sequence[_PreciseAsyncExpander] = (_PreciseAsyncExpander(),)
+    sink: _PreciseAsyncSink = _PreciseAsyncSink()
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -140,6 +176,24 @@ def config() -> RunConfig:
 @pytest.fixture()
 def top_ref() -> Ref:
     return Ref(url="https://demo.example.com/top/1")
+
+
+@pytest.fixture()
+def two_level_async_plugin() -> _MockAsyncPlugin:
+    section = Ref(url="https://demo.example.com/section/1")
+    leaf = Ref(url="https://demo.example.com/leaf/1")
+
+    class _RootExpander:
+        async def expand(self, ref: object, client: object) -> Expansion:
+            return Expansion(_DemoRecord("root"), (section,))
+
+    class _SectionExpander:
+        async def expand(self, ref: object, client: object) -> Expansion:
+            return Expansion(_DemoRecord("direct-parent"), (leaf,))
+
+    plugin = _MockAsyncPlugin([])
+    plugin.expanders = (_RootExpander(), _SectionExpander())
+    return plugin
 
 
 @pytest.mark.parametrize("entry_point", ["async_run_crawl", "execute_plan"])
@@ -802,6 +856,28 @@ class TestPhase3Concurrency:
 
 
 class TestMultiExpander:
+    async def test_parent_context_comes_from_second_expander(
+        self,
+        top_ref: Ref,
+        config: RunConfig,
+        two_level_async_plugin: _MockAsyncPlugin,
+    ) -> None:
+        parents: list[object] = []
+
+        # ParentT is deliberately object because ADR-015 erases chain interiors.
+        async def on_leaf(record: _DemoLeafRecord, parent: object) -> None:
+            parents.append(parent)
+
+        result = await async_run_crawl(
+            top_ref,
+            two_level_async_plugin,
+            None,  # type: ignore[arg-type]
+            config,
+            on_leaf=on_leaf,
+        )
+        assert result.leaves_consumed == 1
+        assert parents == [_DemoRecord("direct-parent")]
+
     async def test_all_leaves_reached(
         self,
         top_ref: Ref,
@@ -1113,6 +1189,31 @@ class TestPlanCrawl:
 
 
 class TestExecutePlan:
+    async def test_precise_plan_leaf_type_flows_to_callback(self) -> None:
+        plugin = _PreciseAsyncPlugin()
+        plan = await plan_crawl(
+            Ref("https://typed.example/top", {"kind": "top"}),
+            plugin,
+            None,  # type: ignore[arg-type]
+        )
+        leaf_ref: Ref[dict[str, int]] = plan.leaves[0]
+        seen: list[tuple[_DemoLeafRecord, Ref[dict[str, int]]]] = []
+
+        async def on_planned_leaf(
+            record: _DemoLeafRecord, ref: Ref[dict[str, int]]
+        ) -> None:
+            seen.append((record, ref))
+
+        await execute_plan(
+            plan,
+            plugin,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_planned_leaf=on_planned_leaf,
+        )
+        assert leaf_ref.raw["leaf_id"] == 7
+        assert seen == [(_DemoLeafRecord("7", leaf_ref.url), leaf_ref)]
+
     async def test_returns_run_result(
         self, top_ref: Ref, plugin: _MockAsyncPlugin
     ) -> None:
@@ -1145,7 +1246,13 @@ class TestExecutePlan:
         async def on_leaf(record: object, ref: object) -> None:
             calls.append((record, ref))
 
-        await execute_plan(plan, plugin, None, RunConfig(), on_leaf=on_leaf)  # type: ignore[arg-type]
+        await execute_plan(
+            plan,
+            plugin,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_planned_leaf=on_leaf,
+        )
         assert len(calls) == 3
         for _, ref in calls:
             assert isinstance(ref, Ref)
@@ -1410,7 +1517,7 @@ class TestExecutePlan:
                 plugin,
                 None,  # type: ignore[arg-type]
                 RunConfig(),
-                on_leaf=interrupting_callback,
+                on_planned_leaf=interrupting_callback,
             )
 
         assert exc_info.value is interruption
@@ -1449,7 +1556,11 @@ class TestExecutePlan:
             raise RuntimeError("db exploded")
 
         result = await execute_plan(
-            plan, plugin, None, RunConfig(), on_leaf=bad_callback  # type: ignore[arg-type]
+            plan,
+            plugin,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_planned_leaf=bad_callback,
         )
         assert result.leaves_consumed == 3
         assert result.leaves_persisted == 0
@@ -1613,7 +1724,7 @@ class TestExecutePlan:
             p,
             None,  # type: ignore[arg-type]
             RunConfig(),
-            on_leaf=failing_callback,
+            on_planned_leaf=failing_callback,
             on_progress=lambda d, t: progress_calls.append((d, t)),
         )
         assert progress_calls == [(1, 1)]
@@ -1638,7 +1749,7 @@ class TestExecutePlan:
                 plugin,
                 None,  # type: ignore[arg-type]
                 RunConfig(),
-                on_leaf=cancelled_callback,
+                on_planned_leaf=cancelled_callback,
                 on_progress=lambda done, total: progress_calls.append(
                     (done, total)
                 ),
@@ -1647,7 +1758,7 @@ class TestExecutePlan:
         assert exc_info.value is cancellation
         assert progress_calls == [(1, 1)]
         assert execute_plan.__doc__ is not None
-        assert "consume or ``on_leaf``" in execute_plan.__doc__
+        assert "consume or ``on_planned_leaf``" in execute_plan.__doc__
 
     async def test_plan_crawl_then_execute_plan_roundtrip(
         self, top_ref: Ref, plugin: _MockAsyncPlugin

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -310,11 +310,11 @@ class TestMainDispatch:
     def test_run_exits_2_on_real_sink_consume_exception(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        from ladon.plugins.models import Expansion
+        from ladon.plugins.models import Expansion, Ref
 
         class _Expander:
             def expand(self, ref: object, client: object) -> Expansion:
-                return Expansion(record=object(), child_refs=("leaf-1",))
+                return Expansion(record=object(), child_refs=(Ref("leaf-1"),))
 
         class _Sink:
             def consume(self, ref: object, client: object) -> object:
@@ -352,11 +352,11 @@ class TestMainDispatch:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         from ladon.plugins.errors import AssetDownloadError
-        from ladon.plugins.models import Expansion
+        from ladon.plugins.models import Expansion, Ref
 
         class _Expander:
             def expand(self, ref: object, client: object) -> Expansion:
-                return Expansion(record=object(), child_refs=("leaf-1",))
+                return Expansion(record=object(), child_refs=(Ref("leaf-1"),))
 
         class _Sink:
             def consume(self, ref: object, client: object) -> object:

--- a/tests/test_http_client_protocols.py
+++ b/tests/test_http_client_protocols.py
@@ -51,7 +51,7 @@ class _Source:
 
 class _Expander:
     def expand(self, ref: object, client: SyncHttpClientProtocol) -> Expansion:
-        return Expansion(record=ref, child_refs=("leaf",))
+        return Expansion(record=ref, child_refs=(Ref("leaf"),))
 
 
 class _Sink:
@@ -88,7 +88,7 @@ class _AsyncExpander:
     async def expand(
         self, ref: object, client: AsyncHttpClientProtocol
     ) -> Expansion:
-        return Expansion(record=ref, child_refs=("leaf",))
+        return Expansion(record=ref, child_refs=(Ref("leaf"),))
 
 
 class _AsyncSink:

--- a/tests/test_plugin_runner.py
+++ b/tests/test_plugin_runner.py
@@ -44,8 +44,9 @@ class _Expander:
         if self._error is not None:
             raise self._error
         assert isinstance(ref, Ref)
+        typed_ref = Ref(ref.url)
         if self._error_for is not None:
-            error = self._error_for(ref)
+            error = self._error_for(typed_ref)
             if error is not None:
                 raise error
         return Expansion(
@@ -60,7 +61,8 @@ class _Sink:
 
     def consume(self, ref: object, client: SyncHttpClientProtocol) -> _Record:
         assert isinstance(ref, Ref)
-        if self._fail(ref):
+        typed_ref = Ref(ref.url)
+        if self._fail(typed_ref):
             raise LeafUnavailableError("unavailable")
         return _Record(ref.url)
 

--- a/tests/test_public_api_typing.py
+++ b/tests/test_public_api_typing.py
@@ -1,0 +1,28 @@
+"""Runtime and strict-type-checking smoke tests for public generic defaults."""
+
+from ladon import (
+    AsyncOnLeafCallback,
+    AsyncOnPlannedLeafCallback,
+    CrawlPlan,
+    Expansion,
+    OnLeafCallback,
+    OnPlannedLeafCallback,
+    PluginRunResult,
+    Ref,
+    RunResult,
+)
+
+
+def test_bare_public_generic_symbols_remain_importable() -> None:
+    symbols: tuple[object, ...] = (
+        Ref,
+        Expansion,
+        RunResult,
+        CrawlPlan,
+        PluginRunResult,
+        OnLeafCallback,
+        OnPlannedLeafCallback,
+        AsyncOnLeafCallback,
+        AsyncOnPlannedLeafCallback,
+    )
+    assert all(symbol is not None for symbol in symbols)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -89,6 +89,42 @@ class _MockPlugin:
 _typed_plugin: CrawlPlugin = _MockPlugin([])
 
 
+class _PreciseSource:
+    def discover(
+        self, client: SyncHttpClientProtocol
+    ) -> Sequence[Ref[dict[str, str]]]:
+        return (Ref("https://typed.example/top", {"kind": "top"}),)
+
+
+class _PreciseExpander:
+    def expand(
+        self,
+        ref: Ref[dict[str, str]],
+        client: SyncHttpClientProtocol,
+    ) -> Expansion[_DemoRecord, dict[str, int]]:
+        return Expansion(
+            _DemoRecord(),
+            (Ref(f"{ref.url}/leaf", {"leaf_id": 7}),),
+        )
+
+
+class _PreciseSink:
+    def consume(
+        self,
+        ref: Ref[dict[str, int]],
+        client: SyncHttpClientProtocol,
+    ) -> _DemoLeafRecord:
+        return _DemoLeafRecord(str(ref.raw["leaf_id"]), ref.url)
+
+
+@dataclass(frozen=True)
+class _PrecisePlugin:
+    name: str = "precise_plugin"
+    source: _PreciseSource = _PreciseSource()
+    expanders: Sequence[_PreciseExpander] = (_PreciseExpander(),)
+    sink: _PreciseSink = _PreciseSink()
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -111,6 +147,24 @@ def plugin(child_refs: list[Ref]) -> _MockPlugin:
 @pytest.fixture()
 def top_ref() -> Ref:
     return Ref(url="https://demo.example.com/top/1")
+
+
+@pytest.fixture()
+def two_level_plugin() -> _MockPlugin:
+    section = Ref(url="https://demo.example.com/section/1")
+    leaf = Ref(url="https://demo.example.com/leaf/1")
+
+    class _RootExpander:
+        def expand(self, ref: object, client: object) -> Expansion:
+            return Expansion(_DemoRecord("root"), (section,))
+
+    class _SectionExpander:
+        def expand(self, ref: object, client: object) -> Expansion:
+            return Expansion(_DemoRecord("direct-parent"), (leaf,))
+
+    plugin = _MockPlugin([])
+    plugin.expanders = (_RootExpander(), _SectionExpander())
+    return plugin
 
 
 class _UnexpectedFailureSink:
@@ -149,6 +203,15 @@ class TestRunCrawlExceptionSemantics:
         assert RunResult.__doc__ is not None
         assert '"ref[N] consume failed: ..."' in RunResult.__doc__
         assert '"ref[N] callback failed: ..."' in RunResult.__doc__
+
+    def test_shared_result_and_config_docs_name_both_callback_contracts(
+        self,
+    ) -> None:
+        assert RunConfig.__doc__ is not None
+        assert RunResult.__doc__ is not None
+        for callback_name in ("``on_leaf``", "``on_planned_leaf``"):
+            assert callback_name in RunConfig.__doc__
+            assert callback_name in RunResult.__doc__
 
     def test_run_crawl_documents_fatal_exceptions(self) -> None:
         assert run_crawl.__doc__ is not None
@@ -482,6 +545,31 @@ class TestPlanCrawlSync:
 
 
 class TestExecutePlanSync:
+    def test_precise_plan_leaf_type_flows_to_callback(self) -> None:
+        plugin = _PrecisePlugin()
+        plan = plan_crawl_sync(
+            Ref("https://typed.example/top", {"kind": "top"}),
+            plugin,
+            None,  # type: ignore[arg-type]
+        )
+        leaf_ref: Ref[dict[str, int]] = plan.leaves[0]
+        seen: list[tuple[_DemoLeafRecord, Ref[dict[str, int]]]] = []
+
+        def on_planned_leaf(
+            record: _DemoLeafRecord, ref: Ref[dict[str, int]]
+        ) -> None:
+            seen.append((record, ref))
+
+        execute_plan_sync(
+            plan,
+            plugin,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_planned_leaf=on_planned_leaf,
+        )
+        assert leaf_ref.raw["leaf_id"] == 7
+        assert seen == [(_DemoLeafRecord("7", leaf_ref.url), leaf_ref)]
+
     def test_returns_run_result(
         self, top_ref: Ref, plugin: _MockPlugin
     ) -> None:
@@ -497,6 +585,25 @@ class TestExecutePlanSync:
         assert result.leaves_consumed == 3
         assert result.leaves_persisted == 3
         assert result.leaves_failed == 0
+
+    def test_run_crawl_uses_direct_parent_from_second_expander(
+        self, top_ref: Ref, two_level_plugin: _MockPlugin
+    ) -> None:
+        parents: list[object] = []
+
+        # ParentT is deliberately object because ADR-015 erases chain interiors.
+        def on_leaf(record: _DemoLeafRecord, parent: object) -> None:
+            parents.append(parent)
+
+        result = run_crawl(
+            top_ref,
+            two_level_plugin,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_leaf=on_leaf,
+        )
+        assert result.leaves_consumed == 1
+        assert parents == [_DemoRecord("direct-parent")]
 
     def test_record_carried_from_plan(
         self, top_ref: Ref, plugin: _MockPlugin
@@ -514,7 +621,13 @@ class TestExecutePlanSync:
         def on_leaf(record: object, ref: object) -> None:
             calls.append((record, ref))
 
-        execute_plan_sync(plan, plugin, None, RunConfig(), on_leaf=on_leaf)  # type: ignore[arg-type]
+        execute_plan_sync(
+            plan,
+            plugin,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_planned_leaf=on_leaf,
+        )
         assert len(calls) == 3
         # Second arg must be the leaf ref (a Ref), not a parent record
         for _, ref in calls:
@@ -532,7 +645,13 @@ class TestExecutePlanSync:
         p.sink = _FailingSink()
         plan = plan_crawl_sync(top_ref, p, None)  # type: ignore[arg-type]
         calls: list[object] = []
-        execute_plan_sync(plan, p, None, RunConfig(), on_leaf=lambda r, ref: calls.append(r))  # type: ignore[arg-type]
+        execute_plan_sync(
+            plan,
+            p,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_planned_leaf=lambda r, ref: calls.append(r),
+        )
         assert len(calls) == 0
 
     def test_leaf_unavailable_counted_as_failed(self, top_ref: Ref) -> None:
@@ -691,7 +810,13 @@ class TestExecutePlanSync:
         def bad_callback(record: object, ref: object) -> None:
             raise RuntimeError("db exploded")
 
-        result = execute_plan_sync(plan, plugin, None, RunConfig(), on_leaf=bad_callback)  # type: ignore[arg-type]
+        result = execute_plan_sync(
+            plan,
+            plugin,
+            None,  # type: ignore[arg-type]
+            RunConfig(),
+            on_planned_leaf=bad_callback,
+        )
         assert result.leaves_consumed == 3
         assert result.leaves_persisted == 0
         assert result.leaves_failed == 0
@@ -807,7 +932,7 @@ class TestExecutePlanSync:
             p,
             None,  # type: ignore[arg-type]
             RunConfig(),
-            on_leaf=failing_callback,
+            on_planned_leaf=failing_callback,
             on_progress=lambda d, t: progress_calls.append((d, t)),
         )
         assert progress_calls == [(1, 1)]
@@ -832,7 +957,7 @@ class TestExecutePlanSync:
                 plugin,
                 None,  # type: ignore[arg-type]
                 RunConfig(),
-                on_leaf=cancelled_callback,
+                on_planned_leaf=cancelled_callback,
                 on_progress=lambda done, total: progress_calls.append(
                     (done, total)
                 ),
@@ -843,7 +968,7 @@ class TestExecutePlanSync:
         assert caplog.records[0].error_type == "KeyboardInterrupt"  # type: ignore[attr-defined]
         assert "failed" not in caplog.records[0].getMessage()
         assert execute_plan_sync.__doc__ is not None
-        assert "Sink or ``on_leaf``" in execute_plan_sync.__doc__
+        assert "Sink or ``on_planned_leaf``" in execute_plan_sync.__doc__
 
     def test_on_progress_exception_is_swallowed(
         self, top_ref: Ref, plugin: _MockPlugin


### PR DESCRIPTION
## Summary

Closes #162.

- `Ref[RawT]`, `Expansion[RecordT, ChildRawT]`, `Source`, `Expander`, `Sink`, and `CrawlPlugin` become generic (`CrawlPlugin[TopRefT, LeafRefT, LeafRecordT]` — three parameters, not one per pipeline stage; see ADR-015 for why `expanders` stays `Sequence[Expander[Any, Any, Any]]`). `CrawlPlan` becomes generic over its leaf-ref type.
- New `OnLeafCallback`/`OnPlannedLeafCallback` type aliases (+ async equivalents) make the previously docstring-only `run_crawl` vs `execute_plan_sync` callback-shape distinction (ADR-011) a compile-time error. **Breaking change**: `execute_plan_sync`/`execute_plan`'s `on_leaf=` keyword is renamed to `on_planned_leaf=`.
- Fixes a real gap found during review: `Ref[CustomRaw]("url")` (omitting `raw`) type-checked under strict Pyright while silently producing `{}` at runtime. Fixed with self-type constructor overloads that reject that call shape for non-default specializations.
- Removes the `cast(...)` workarounds in the three cookbook examples that this typing gap forced.
- Full design rationale and rejected alternatives: `docs/decisions/adr-015-generic-ses-protocols.md`.

## Test plan

- [x] `pyright --project pyproject.toml` — 0 errors
- [x] `pytest` — 792 passed
- [x] `ruff check .` / `black --check .` — clean
- [x] `grep -rn 'cast(' examples/cookbook/*.py` — only the unrelated socket-address casts in `async_crawl.py` remain
- [x] New regression test spawns Pyright against a scratch fixture to prove `Ref[CustomRaw]("url")` is now rejected statically, not just asserted

https://claude.ai/code/session_01L6XEPrkmybAuesVvB4PEpJ