### PR TITLE
feat(plugins): add composable FetchPredicate combinators

### DIFF
--- a/src/ladon/plugins/__init__.py
+++ b/src/ladon/plugins/__init__.py
@@ -12,6 +12,7 @@ from .async_protocol import (
     AsyncSink,
     AsyncSource,
 )
+from .combinators import AllOf, AnyOf, Not
 from .errors import (
     AssetDownloadError,
     ChildListUnavailableError,
@@ -44,6 +45,9 @@ __all__ = [
     # Resolution
     "FetchPredicate",
     "MultiSourceSink",
+    "AllOf",
+    "AnyOf",
+    "Not",
     # Errors
     "PluginError",
     "ExpansionNotReadyError",

--- a/src/ladon/plugins/combinators.py
+++ b/src/ladon/plugins/combinators.py
@@ -1,0 +1,140 @@
+"""Composable boolean predicates for multi-source fetch resolution.
+
+The combinators in this module turn existing
+:class:`~ladon.plugins.resolution.FetchPredicate` implementations into new
+predicates.  They can be nested to describe an adapter's acceptance policy
+without changing :class:`~ladon.plugins.resolution.MultiSourceSink` or the
+individual predicates that supply its domain-specific checks.
+
+Each combinator preserves Python's boolean short-circuit behaviour.  Later
+predicates are therefore not evaluated once the result is known, which is
+important when a predicate is expensive or records diagnostic state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import Ref
+from .resolution import FetchPredicate
+
+
+def _validated_predicates(
+    predicates: tuple[object, ...],
+) -> tuple[FetchPredicate, ...]:
+    """Return *predicates* after validating their structural contract."""
+    validated: list[FetchPredicate] = []
+    for predicate in predicates:
+        try:
+            accepts = getattr(predicate, "accepts", None)
+        except Exception as exc:
+            raise TypeError(
+                "predicate must implement callable accepts(data, ref); "
+                f"got {type(predicate).__name__}"
+            ) from exc
+        if not callable(accepts) or not isinstance(predicate, FetchPredicate):
+            raise TypeError(
+                "predicate must implement callable accepts(data, ref); "
+                f"got {type(predicate).__name__}"
+            )
+        validated.append(predicate)
+    return tuple(validated)
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class AllOf:
+    """Accept only when every component predicate accepts.
+
+    Predicates are evaluated from left to right and evaluation stops at the
+    first rejection.  ``AllOf()`` accepts by vacuous truth, matching
+    ``all(())``.  Components may themselves be :class:`AllOf`,
+    :class:`AnyOf`, or :class:`Not` instances, allowing policies to be nested.
+
+    .. note::
+        Components are retained as an immutable tuple.  The predicate objects
+        themselves are not copied; any state they intentionally maintain is
+        shared with the combinator.
+    """
+
+    _predicates: tuple[FetchPredicate, ...]
+
+    def __init__(
+        self,
+        *predicates: FetchPredicate,
+        _predicates: tuple[FetchPredicate, ...] | None = None,
+    ) -> None:
+        if predicates and _predicates is not None:
+            raise TypeError(
+                "predicates cannot be supplied both positionally and by field"
+            )
+        components = predicates if _predicates is None else _predicates
+        object.__setattr__(
+            self, "_predicates", _validated_predicates(components)
+        )
+
+    def accepts(self, data: bytes, ref: Ref) -> bool:
+        """Return True if every component accepts *data* for *ref*."""
+        return all(
+            predicate.accepts(data, ref) for predicate in self._predicates
+        )
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class AnyOf:
+    """Accept when at least one component predicate accepts.
+
+    Predicates are evaluated from left to right and evaluation stops at the
+    first acceptance.  ``AnyOf()`` rejects, matching ``any(())``.  Components
+    may themselves be :class:`AllOf`, :class:`AnyOf`, or :class:`Not`
+    instances, allowing policies to be nested.
+
+    .. note::
+        Components are retained as an immutable tuple.  The predicate objects
+        themselves are not copied; any state they intentionally maintain is
+        shared with the combinator.
+    """
+
+    _predicates: tuple[FetchPredicate, ...]
+
+    def __init__(
+        self,
+        *predicates: FetchPredicate,
+        _predicates: tuple[FetchPredicate, ...] | None = None,
+    ) -> None:
+        if predicates and _predicates is not None:
+            raise TypeError(
+                "predicates cannot be supplied both positionally and by field"
+            )
+        components = predicates if _predicates is None else _predicates
+        object.__setattr__(
+            self, "_predicates", _validated_predicates(components)
+        )
+
+    def accepts(self, data: bytes, ref: Ref) -> bool:
+        """Return True if any component accepts *data* for *ref*."""
+        return any(
+            predicate.accepts(data, ref) for predicate in self._predicates
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Not:
+    """Accept when one component predicate rejects, and vice versa.
+
+    The component may be an :class:`AllOf`, :class:`AnyOf`, or another
+    :class:`Not`, so negation composes with arbitrarily nested policies.  Only
+    the wrapped predicate is evaluated.
+
+    .. note::
+        The predicate object is retained rather than copied, so any state it
+        intentionally maintains is shared with the combinator.
+    """
+
+    _predicate: FetchPredicate
+
+    def __post_init__(self) -> None:
+        _validated_predicates((self._predicate,))
+
+    def accepts(self, data: bytes, ref: Ref) -> bool:
+        """Return the boolean negation of the component's result."""
+        return not self._predicate.accepts(data, ref)

--- a/tests/plugins/test_combinators.py
+++ b/tests/plugins/test_combinators.py
@@ -1,0 +1,229 @@
+# pyright: reportUnknownMemberType=false
+"""Tests for composable fetch-predicate combinators."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import cast
+
+import pytest
+
+from ladon.networking.protocols import SyncHttpClientProtocol
+from ladon.plugins import AllOf, AnyOf, FetchPredicate, MultiSourceSink, Not
+from ladon.plugins.models import Ref
+
+
+def _ref(url: str = "https://example.com/item") -> Ref:
+    return Ref(url)
+
+
+class _StaticPredicate:
+    """Adapter-shaped predicate returning one configured result."""
+
+    def __init__(self, result: bool) -> None:
+        self._result = result
+
+    def accepts(self, data: bytes, ref: Ref) -> bool:
+        return self._result
+
+
+class _PayloadIs:
+    def __init__(self, expected: bytes) -> None:
+        self._expected = expected
+
+    def accepts(self, data: bytes, ref: Ref) -> bool:
+        return data == self._expected
+
+
+class _RaisesIfCalled:
+    def accepts(self, data: bytes, ref: Ref) -> bool:
+        raise AssertionError("should not have been called")
+
+
+class _NonCallableAccepts:
+    accepts = True
+
+
+class _BrokenAcceptsDescriptor:
+    @property
+    def accepts(self) -> object:
+        raise RuntimeError("broken descriptor")
+
+
+# Static conformance check: a concrete adapter-shaped predicate can be passed
+# through each combinator under strict Pyright checking.
+_typed_predicate: FetchPredicate = _StaticPredicate(True)
+_typed_all: FetchPredicate = AllOf(_typed_predicate)
+_typed_any: FetchPredicate = AnyOf(_typed_predicate)
+_typed_not: FetchPredicate = Not(_typed_predicate)
+
+
+@pytest.mark.parametrize(
+    ("results", "expected"),
+    [
+        ((), True),
+        ((True,), True),
+        ((False,), False),
+        ((True, True), True),
+        ((True, False), False),
+        ((False, True), False),
+        ((False, False), False),
+    ],
+)
+def test_all_of_truth_table(results: tuple[bool, ...], expected: bool) -> None:
+    predicate = AllOf(*(_StaticPredicate(result) for result in results))
+    assert predicate.accepts(b"data", _ref()) is expected
+
+
+@pytest.mark.parametrize(
+    ("results", "expected"),
+    [
+        ((), False),
+        ((True,), True),
+        ((False,), False),
+        ((True, True), True),
+        ((True, False), True),
+        ((False, True), True),
+        ((False, False), False),
+    ],
+)
+def test_any_of_truth_table(results: tuple[bool, ...], expected: bool) -> None:
+    predicate = AnyOf(*(_StaticPredicate(result) for result in results))
+    assert predicate.accepts(b"data", _ref()) is expected
+
+
+def test_all_of_empty_input_accepts() -> None:
+    assert AllOf().accepts(b"data", _ref()) is True
+
+
+def test_any_of_empty_input_rejects() -> None:
+    assert AnyOf().accepts(b"data", _ref()) is False
+
+
+@pytest.mark.parametrize(
+    ("component_result", "expected"), [(True, False), (False, True)]
+)
+def test_not_truth_table(component_result: bool, expected: bool) -> None:
+    assert (
+        Not(_StaticPredicate(component_result)).accepts(b"data", _ref())
+        is expected
+    )
+
+
+def test_combinators_nest() -> None:
+    predicate = AllOf(
+        AnyOf(_PayloadIs(b"preferred"), _PayloadIs(b"acceptable")),
+        Not(_PayloadIs(b"blocked")),
+    )
+
+    assert predicate.accepts(b"acceptable", _ref("https://example.com/7"))
+
+
+def test_all_of_short_circuits_after_rejection() -> None:
+    predicate = AllOf(_StaticPredicate(False), _RaisesIfCalled())
+
+    assert predicate.accepts(b"data", _ref()) is False
+
+
+def test_any_of_short_circuits_after_acceptance() -> None:
+    predicate = AnyOf(_StaticPredicate(True), _RaisesIfCalled())
+
+    assert predicate.accepts(b"data", _ref()) is True
+
+
+def test_combinators_satisfy_fetch_predicate_at_runtime() -> None:
+    assert isinstance(AllOf(), FetchPredicate)
+    assert isinstance(AnyOf(), FetchPredicate)
+    assert isinstance(Not(_StaticPredicate(True)), FetchPredicate)
+
+
+def test_non_predicates_are_rejected_at_construction() -> None:
+    for value in ("not a predicate", _NonCallableAccepts()):
+        invalid = cast(FetchPredicate, value)
+
+        with pytest.raises(TypeError, match="must implement callable accepts"):
+            AllOf(invalid)
+        with pytest.raises(TypeError, match="must implement callable accepts"):
+            AnyOf(invalid)
+        with pytest.raises(TypeError, match="must implement callable accepts"):
+            Not(invalid)
+
+
+def test_broken_accepts_descriptor_is_rejected_with_type_error() -> None:
+    invalid = cast(FetchPredicate, _BrokenAcceptsDescriptor())
+
+    with pytest.raises(TypeError, match="must implement callable accepts"):
+        AllOf(invalid)
+    with pytest.raises(TypeError, match="must implement callable accepts"):
+        AnyOf(invalid)
+    with pytest.raises(TypeError, match="must implement callable accepts"):
+        Not(invalid)
+
+
+def test_dataclasses_replace_preserves_variadic_combinators() -> None:
+    predicate = _StaticPredicate(True)
+    all_of = AllOf(predicate)
+    any_of = AnyOf(predicate)
+
+    assert replace(all_of) == all_of
+    assert replace(any_of) == any_of
+
+
+class _Source:
+    def __init__(self, name: str, data: bytes) -> None:
+        self.name = name
+        self._data = data
+        self.calls = 0
+
+    def fetch(self) -> bytes:
+        self.calls += 1
+        return self._data
+
+
+class _Sink(MultiSourceSink):
+    def _fetch_from_source(
+        self,
+        source: object,
+        ref: Ref,
+        client: SyncHttpClientProtocol,
+    ) -> bytes | None:
+        if not isinstance(source, _Source):
+            raise TypeError("test sink requires _Source instances")
+        return source.fetch()
+
+
+def _unused_client() -> SyncHttpClientProtocol:
+    """Return a typed stand-in; the test sink never calls the client."""
+    return cast(SyncHttpClientProtocol, object())
+
+
+def test_multi_source_sink_falls_through_until_combinator_accepts() -> None:
+    first = _Source("first", b"blocked")
+    second = _Source("second", b"accepted")
+    predicate = AllOf(
+        AnyOf(_PayloadIs(b"blocked"), _PayloadIs(b"accepted")),
+        Not(_PayloadIs(b"blocked")),
+    )
+    sink = _Sink(sources=[first, second], predicates=[predicate])
+
+    data, source = sink.resolve_multi(_ref(), _unused_client())
+
+    assert data == b"accepted"
+    assert source is second
+    assert first.calls == 1
+    assert second.calls == 1
+
+
+def test_multi_source_sink_returns_fallback_after_combinator_rejects() -> None:
+    source = _Source("only", b"fallback")
+    sink = _Sink(
+        sources=[source],
+        predicates=[
+            AllOf(_PayloadIs(b"accepted"), Not(_PayloadIs(b"blocked")))
+        ],
+    )
+
+    data, resolved_source = sink.resolve_multi(_ref(), _unused_client())
+
+    assert data == b"fallback"
+    assert resolved_source is source


### PR DESCRIPTION
## Summary

Closes #122.

- Adds `AllOf`, `AnyOf`, `Not` — boolean combinators over `FetchPredicate` — as first-class, nestable predicate values (`AllOf(AnyOf(p1, p2), Not(p3))`).
- `MultiSourceSink.resolve_multi()` already evaluates registered predicates as an implicit AND internally; this makes that composition explicit and available to adapters without touching the loop mechanics.
- Deliberately non-generic/fetch-specific (no `AllOf[T]`) per the scope decision in the vault design note — a generic rules framework has no second consumer yet.
- Construction-time validation rejects non-predicates with a clear `TypeError`, including normalizing an unexpected exception from a broken `accepts` descriptor into the same error shape.
- `AllOf`/`AnyOf` support `dataclasses.replace()`.

## Test plan

- [x] `pyright --project pyproject.toml` — 0 errors
- [x] `pytest` — 819 passed (27 new combinator tests: truth tables, empty-input semantics, nesting, short-circuiting with a predicate that raises if evaluated, runtime `isinstance` protocol compatibility, construction-time rejection, real `MultiSourceSink` end-to-end use)
- [x] `black` / `ruff` — clean

https://claude.ai/code/session_01L6XEPrkmybAuesVvB4PEpJ